### PR TITLE
feat: apply metadata per-photo during bulk analyze when validation is off

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -1460,6 +1460,11 @@ end
 -- @param selectedPhotos table Array of LrPhoto objects to process.
 -- @param progressScope LrProgressScope Progress scope for UI updates.
 -- @param options table Processing options (tasks, provider, language, temperature, etc.).
+--                Optional options.onPhotoAnalyzed(photo, photoId, progressScope): if provided,
+--                invoked inside the worker loop immediately after each photo is successfully
+--                analyzed. Lets callers write metadata per-photo as the batch progresses
+--                instead of waiting for all photos to finish. Errors in the callback are
+--                caught with LrTasks.pcall and logged; the batch continues.
 -- @param closeProgressScope boolean|nil When false, does not call :done() on the scope (caller must close).
 -- @return string status Status: "success", "canceled", "somefailed", or "allfailed".
 -- @return number processed Number of photos processed.
@@ -1608,6 +1613,14 @@ function SearchIndexAPI.analyzeAndIndexSelectedPhotos(selectedPhotos, progressSc
                         if indexResponse and indexResponse.warnings and #indexResponse.warnings > 0 then
                             for _, w in ipairs(indexResponse.warnings) do
                                 table.insert(warningsList, w)
+                            end
+                        end
+                        if options.onPhotoAnalyzed then
+                            local okCb, cbErr = LrTasks.pcall(function()
+                                options.onPhotoAnalyzed(photo, photoId, progressScope)
+                            end)
+                            if not okCb then
+                                log:error("onPhotoAnalyzed callback failed for " .. filename .. ": " .. tostring(cbErr))
                             end
                         end
                     else

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -734,10 +734,33 @@ LrTasks.startAsyncTask(function()
 
         log:trace("Starting AnalyzeAndIndexTask with " .. #photosToProcess .. " photos")
 
+        -- When validation is disabled, apply metadata inline as each photo's analysis returns
+        -- so keywords/title/caption land on photos progressively instead of all at the end.
+        -- Validation-on keeps the two-phase flow because modal dialogs must serialize on the main task.
+        local usedInlineApply = false
+        if props.enableMetadata and props.saveDataToCatalog and not props.enableValidation then
+            usedInlineApply = true
+            options.onPhotoAnalyzed = function(photo, photoId, scope)
+                local response = SearchIndexAPI.getPhotoData(photoId)
+                if response and response.metadata then
+                    MetadataManager.applyMetadata(photo, response, nil, {
+                        applyKeywords = props.generateKeywords,
+                        applyTitle = props.generateTitle,
+                        applyCaption = props.generateCaption,
+                        applyAltText = props.generateAltText,
+                        useTopLevelKeyword = props.useTopLevelKeyword,
+                        topLevelKeyword = props.topLevelKeyword,
+                        appendMetadata = props.appendMetadata,
+                    })
+                    SearchIndexAPI.importMetadataFromCatalog({ photo }, scope, false)
+                end
+            end
+        end
+
         local status, processed, failed, processedPhotos, combinedError, combinedWarnings
         status, processed, failed, processedPhotos, combinedError, combinedWarnings = SearchIndexAPI.analyzeAndIndexSelectedPhotos(photosToProcess, progressScope, options, false)
 
-        if status ~= "allfailed" and props.enableMetadata and props.saveDataToCatalog then
+        if status ~= "allfailed" and props.enableMetadata and props.saveDataToCatalog and not usedInlineApply then
             log:trace("Saving metadata for processed photos...")
             local savedCount = 0
             local skippedCount = 0


### PR DESCRIPTION

Previously, keywords/title/caption didn't land on any photo until every photo in the bulk selection finished AI analysis. `analyzeAndIndexSelectedPhotos` now accepts `options.onPhotoAnalyzed`, a callback invoked inside the worker loop right after each successful `/index_base64`. TaskAnalyzeAndIndex installs that callback (getPhotoData + applyMetadata + importMetadataFromCatalog) when `enableValidation` is off and skips the Phase 2 apply-loop via a `usedInlineApply` guard to prevent double-writes. The validation-on flow is unchanged — modal dialogs still serialize on the main task. Callback errors are caught with LrTasks.pcall and logged; the batch continues.

Fixes #116