### PR TITLE
Python formatting/linting cleanup + new workflow

### DIFF
--- a/.agents/rules/general-rules.md
+++ b/.agents/rules/general-rules.md
@@ -24,6 +24,7 @@ These rules ensure consistency across the Lightroom plugin and the Python backen
 - **API Response Format**: Return structured JSON. Standard fields include `results`, `error`, and `warning` (actionable short message for the GUI).
 - **Environment**: Configuration should be driven by environment variables (e.g., `GENIUSAI_PORT`, `GENIUSAI_BACKUP_ENABLED`).
 - **Lifecycle**: Respect `server_lifecycle.py` for PID management and "OK" file signaling.
+- **Code Style**: Code should be formatted with `uv run ruff format` and should have no errors from `server/src/scripts/lint_format.sh`:w
 
 ## Infrastructure & Testing
 - **Docker**: Always update `Dockerfile`, `docker-compose-dev.yml`, and `docker-compose-prod.yml` when changing dependencies or environment requirements.

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -2,7 +2,7 @@ name: "Python lint/format check"
 on: [push, pull_request]
 jobs:
   format-lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Linting

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,0 +1,17 @@
+name: "Python lint/format check"
+on: [push, pull_request]
+jobs:
+  format-lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Linting
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --ignore E741"
+          src: "./server"
+      - name: Formatting
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check --diff"
+          src: "./server"

--- a/server/scripts/lint_format.sh
+++ b/server/scripts/lint_format.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# ensure no linting errors
+echo "Checking for linting errors..."
+uv run ruff check --respect-gitignore --ignore E741
+
+echo "Checking for format issues..."
+uv run ruff format --respect-gitignore --check

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -6,17 +6,23 @@ import os
 import torch
 
 # In windowless environments (like pythonw.exe on Windows), sys.stdout and sys.stderr are None.
-# We redirect them to devnull to prevent crashes in libraries (logging, traceback, etc.) 
+# We redirect them to devnull to prevent crashes in libraries (logging, traceback, etc.)
 # that attempt to write to them.
 if sys.stdout is None:
-    sys.stdout = open(os.devnull, 'w')
+    sys.stdout = open(os.devnull, "w")
 if sys.stderr is None:
-    sys.stderr = open(os.devnull, 'w')
+    sys.stderr = open(os.devnull, "w")
 
 # --- Argument Parsing ---
-parser = argparse.ArgumentParser(description='LrGenius Server')
-parser.add_argument('--db-path', type=str, help='Path to the ChromaDB database folder', required=False)
-parser.add_argument('--debug', action='store_true', help='Enable debug mode with auto-reloading and debug log level')
+parser = argparse.ArgumentParser(description="LrGenius Server")
+parser.add_argument(
+    "--db-path", type=str, help="Path to the ChromaDB database folder", required=False
+)
+parser.add_argument(
+    "--debug",
+    action="store_true",
+    help="Enable debug mode with auto-reloading and debug log level",
+)
 args = parser.parse_args()
 
 # --- Constants ---
@@ -36,8 +42,7 @@ else:
     TORCH_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
-
-CLIP_MODEL_NAME="ViT-SO400M-16-SigLIP2-384"
+CLIP_MODEL_NAME = "ViT-SO400M-16-SigLIP2-384"
 IMAGE_MODEL_ID = "timm/" + CLIP_MODEL_NAME
 
 
@@ -64,8 +69,15 @@ DEFAULT_METADATA_PROVIDER = "ollama"
 # Metadata Generation Settings
 DEFAULT_METADATA_LANGUAGE = "English"
 DEFAULT_KEYWORD_CATEGORIES = [
-    "People", "Activities", "Objects", "Locations", "Events", 
-    "Colors", "Mood", "Technical", "Composition"
+    "People",
+    "Activities",
+    "Objects",
+    "Locations",
+    "Events",
+    "Colors",
+    "Mood",
+    "Technical",
+    "Composition",
 ]
 
 LMSTUDIO_HOST = "localhost:1234"
@@ -240,38 +252,47 @@ def get_available_culling_presets() -> list[str]:
 
 CULLING_CONFIG = get_culling_config("default")
 
+
 # --- Logger Setup ---
 def get_current_log_path() -> str:
     """Returns the log path based on the current DB_PATH, or the default if not set."""
     if DB_PATH:
         # Use dynamic DB_PATH context if available
         return os.path.join(os.path.dirname(DB_PATH) or ".", "lrgenius-server.log")
-        
+
     # Default paths determined at startup
     if sys.platform == "darwin":  # macOS
         return os.path.expanduser("~/Library/Logs/LrGeniusAI/lrgenius-server.log")
     elif sys.platform == "win32":  # Windows
-        return os.path.join(os.environ.get("LOCALAPPDATA", ""), "LrGeniusAI", "logs", "lrgenius-server.log")
+        return os.path.join(
+            os.environ.get("LOCALAPPDATA", ""),
+            "LrGeniusAI",
+            "logs",
+            "lrgenius-server.log",
+        )
     else:
         return os.path.join(os.getcwd(), "lrgenius-server.log")
 
+
 LOG_PATH = get_current_log_path()
+
 
 def update_log_path(new_db_path: str):
     """Updates the global LOG_PATH and potentially reconfigures logging handlers."""
     global DB_PATH, LOG_PATH
     DB_PATH = new_db_path
     LOG_PATH = get_current_log_path()
-    
+
     # Ensure directory exists
     try:
         os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
     except Exception:
         pass
-    
-    # Optional: We could reconfigure logging here, but for now we'll 
+
+    # Optional: We could reconfigure logging here, but for now we'll
     # at least ensure endpoints find the right file.
     logger.info(f"Log path context updated to: {LOG_PATH}")
+
 
 try:
     os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
@@ -280,10 +301,12 @@ except Exception:
 
 log_level = logging.DEBUG if args.debug else logging.INFO
 
+
 # When running locally (not in Docker), on every start create a new log file and keep N backups.
 # In Docker we keep a single file so container logs stay simple.
 def _is_running_in_docker() -> bool:
     return os.path.exists("/.dockerenv") or os.environ.get("container") == "docker"
+
 
 def _rotate_log_on_startup(log_path: str, backup_count: int) -> None:
     """Shift existing log files: .log -> .log.1, .log.1 -> .log.2, ...; remove .log.backup_count."""
@@ -312,6 +335,7 @@ def _rotate_log_on_startup(log_path: str, backup_count: int) -> None:
     except OSError:
         pass
 
+
 def _file_log_handler():
     if _is_running_in_docker():
         return logging.FileHandler(LOG_PATH, encoding="utf-8")
@@ -323,6 +347,7 @@ def _file_log_handler():
     backup_count = max(1, min(backup_count, 20))
     _rotate_log_on_startup(LOG_PATH, backup_count)
     return logging.FileHandler(LOG_PATH, encoding="utf-8")
+
 
 # Configure logging with UTF-8 encoding to handle Unicode characters
 handlers = [_file_log_handler()]

--- a/server/src/edit_recipe.py
+++ b/server/src/edit_recipe.py
@@ -5,6 +5,7 @@ This module defines the canonical edit contract used between the LLM backend
 and the Lightroom plugin. The schema stays provider-agnostic while the plugin
 maps canonical fields onto Lightroom-specific develop keys.
 """
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -382,7 +383,9 @@ def _normalize_warning_list(value: Any) -> List[str]:
     return warnings
 
 
-def _normalize_crop_settings(crop: Any, warnings: List[str] | None = None) -> Dict[str, float]:
+def _normalize_crop_settings(
+    crop: Any, warnings: List[str] | None = None
+) -> Dict[str, float]:
     if not isinstance(crop, dict):
         return {}
 
@@ -423,12 +426,16 @@ def _normalize_crop_settings(crop: Any, warnings: List[str] | None = None) -> Di
     bottom = normalized_crop.get("bottom")
     if left is not None and right is not None and left >= right:
         if warnings is not None:
-            warnings.append("Ignored crop: left edge was not smaller than right edge after normalization.")
+            warnings.append(
+                "Ignored crop: left edge was not smaller than right edge after normalization."
+            )
         normalized_crop.pop("left", None)
         normalized_crop.pop("right", None)
     if top is not None and bottom is not None and top >= bottom:
         if warnings is not None:
-            warnings.append("Ignored crop: top edge was not smaller than bottom edge after normalization.")
+            warnings.append(
+                "Ignored crop: top edge was not smaller than bottom edge after normalization."
+            )
         normalized_crop.pop("top", None)
         normalized_crop.pop("bottom", None)
 
@@ -443,7 +450,9 @@ def _normalize_crop_settings(crop: Any, warnings: List[str] | None = None) -> Di
     return normalized_crop
 
 
-def _normalize_global_settings(global_settings: Any, warnings: List[str] | None = None) -> Dict[str, Any]:
+def _normalize_global_settings(
+    global_settings: Any, warnings: List[str] | None = None
+) -> Dict[str, Any]:
     if not isinstance(global_settings, dict):
         return {}
 
@@ -451,14 +460,18 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
     for field_name, bounds in GLOBAL_FIELD_RANGES.items():
         if field_name not in global_settings:
             continue
-        clamped = _clamp_number(global_settings.get(field_name), bounds["min"], bounds["max"])
+        clamped = _clamp_number(
+            global_settings.get(field_name), bounds["min"], bounds["max"]
+        )
         if clamped is not None:
             normalized[field_name] = clamped
 
     white_balance = global_settings.get("white_balance")
     if isinstance(white_balance, dict):
         if "temperature" not in normalized:
-            clamped_temp = _clamp_number(white_balance.get("temperature"), 2000.0, 50000.0)
+            clamped_temp = _clamp_number(
+                white_balance.get("temperature"), 2000.0, 50000.0
+            )
             if clamped_temp is not None:
                 normalized["temperature"] = clamped_temp
         if "tint" not in normalized:
@@ -472,7 +485,9 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
         if normalized_crop:
             normalized["crop"] = normalized_crop
         elif warnings is not None:
-            warnings.append("Ignored crop: no supported crop fields were returned by the model.")
+            warnings.append(
+                "Ignored crop: no supported crop fields were returned by the model."
+            )
 
     tone_curve = global_settings.get("tone_curve")
     if isinstance(tone_curve, dict):
@@ -490,7 +505,9 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
         if isinstance(point_curve, dict):
             normalized_point_curve: Dict[str, List[int]] = {}
             for channel in ("master", "red", "green", "blue"):
-                normalized_points = _normalize_point_curve_points(point_curve.get(channel), 0.0, 255.0)
+                normalized_points = _normalize_point_curve_points(
+                    point_curve.get(channel), 0.0, 255.0
+                )
                 if normalized_points:
                     normalized_point_curve[channel] = normalized_points
             if normalized_point_curve:
@@ -500,7 +517,9 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
         if isinstance(extended_point_curve, dict):
             normalized_extended_curve: Dict[str, List[int]] = {}
             for channel in ("master", "red", "green", "blue"):
-                normalized_points = _normalize_point_curve_points(extended_point_curve.get(channel), 0.0, 4096.0)
+                normalized_points = _normalize_point_curve_points(
+                    extended_point_curve.get(channel), 0.0, 4096.0
+                )
                 if normalized_points:
                     normalized_extended_curve[channel] = normalized_points
             if normalized_extended_curve:
@@ -534,7 +553,9 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
                 continue
             normalized_region: Dict[str, float] = {}
             for key, bounds in COLOR_GRADING_RANGES.items():
-                clamped = _clamp_number(region_data.get(key), bounds["min"], bounds["max"])
+                clamped = _clamp_number(
+                    region_data.get(key), bounds["min"], bounds["max"]
+                )
                 if clamped is not None:
                     normalized_region[key] = clamped
             if normalized_region:
@@ -543,8 +564,13 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
         global_region = color_grading.get("global")
         if isinstance(global_region, dict):
             normalized_global_region: Dict[str, float] = {}
-            for key, bounds in {"hue": {"min": 0.0, "max": 360.0}, "saturation": {"min": 0.0, "max": 100.0}}.items():
-                clamped = _clamp_number(global_region.get(key), bounds["min"], bounds["max"])
+            for key, bounds in {
+                "hue": {"min": 0.0, "max": 360.0},
+                "saturation": {"min": 0.0, "max": 100.0},
+            }.items():
+                clamped = _clamp_number(
+                    global_region.get(key), bounds["min"], bounds["max"]
+                )
                 if clamped is not None:
                     normalized_global_region[key] = clamped
             if normalized_global_region:
@@ -562,7 +588,9 @@ def _normalize_global_settings(global_settings: Any, warnings: List[str] | None 
     return normalized
 
 
-def _normalize_point_curve_points(value: Any, minimum: float, maximum: float) -> List[int]:
+def _normalize_point_curve_points(
+    value: Any, minimum: float, maximum: float
+) -> List[int]:
     if not isinstance(value, list) or len(value) < 2:
         return []
 
@@ -611,7 +639,9 @@ def _normalize_masks(masks: Any, warnings: List[str]) -> List[Dict[str, Any]]:
 
         kind = _normalize_text(mask.get("kind")).lower()
         if kind not in MASK_KINDS:
-            warnings.append(f"Ignored mask #{index + 1}: unsupported kind '{kind or 'unknown'}'.")
+            warnings.append(
+                f"Ignored mask #{index + 1}: unsupported kind '{kind or 'unknown'}'."
+            )
             continue
 
         raw_adjustments = mask.get("adjustments")
@@ -623,12 +653,16 @@ def _normalize_masks(masks: Any, warnings: List[str]) -> List[Dict[str, Any]]:
         for field_name, bounds in MASK_ADJUSTMENT_RANGES.items():
             if field_name not in raw_adjustments:
                 continue
-            clamped = _clamp_number(raw_adjustments.get(field_name), bounds["min"], bounds["max"])
+            clamped = _clamp_number(
+                raw_adjustments.get(field_name), bounds["min"], bounds["max"]
+            )
             if clamped is not None:
                 normalized_adjustments[field_name] = clamped
 
         if not normalized_adjustments:
-            warnings.append(f"Ignored mask '{kind}': no supported adjustments were returned.")
+            warnings.append(
+                f"Ignored mask '{kind}': no supported adjustments were returned."
+            )
             continue
 
         normalized_mask = {
@@ -668,7 +702,9 @@ def normalize_edit_recipe(parsed_data: Any) -> Dict[str, Any]:
     return normalized
 
 
-def filter_edit_recipe_by_controls(recipe: Dict[str, Any], controls: Dict[str, bool]) -> Dict[str, Any]:
+def filter_edit_recipe_by_controls(
+    recipe: Dict[str, Any], controls: Dict[str, bool]
+) -> Dict[str, Any]:
     if not isinstance(recipe, dict):
         return recipe
 
@@ -744,7 +780,14 @@ def filter_edit_recipe_by_controls(recipe: Dict[str, Any], controls: Dict[str, b
         if not controls.get("adjust_white_balance", True):
             allowed_mask_adjustments -= {"temperature", "tint"}
         if not controls.get("adjust_basic_tone", True):
-            allowed_mask_adjustments -= {"exposure", "contrast", "highlights", "shadows", "whites", "blacks"}
+            allowed_mask_adjustments -= {
+                "exposure",
+                "contrast",
+                "highlights",
+                "shadows",
+                "whites",
+                "blacks",
+            }
         if not controls.get("adjust_presence", True):
             allowed_mask_adjustments -= {"texture", "clarity", "dehaze"}
         if not controls.get("adjust_color_mix", True):
@@ -759,7 +802,9 @@ def filter_edit_recipe_by_controls(recipe: Dict[str, Any], controls: Dict[str, b
             adjustments = mask.get("adjustments")
             if not isinstance(adjustments, dict):
                 continue
-            kept_adjustments = {k: v for k, v in adjustments.items() if k in allowed_mask_adjustments}
+            kept_adjustments = {
+                k: v for k, v in adjustments.items() if k in allowed_mask_adjustments
+            }
             if not kept_adjustments:
                 continue
             next_mask = deepcopy(mask)

--- a/server/src/geniusai_server.py
+++ b/server/src/geniusai_server.py
@@ -9,11 +9,9 @@ import json
 # Import modularized components
 from config import logger, args, DB_PATH
 from service_version import get_backend_version_info
-logger.info("Imported config")
 
 # Lazy import server_lifecycle to speed up startup
 import server_lifecycle
-logger.info("Imported server_lifecycle")
 
 # Import blueprints only (services are imported by routes when needed)
 from routes_index import index_bp

--- a/server/src/geniusai_server.py
+++ b/server/src/geniusai_server.py
@@ -63,7 +63,9 @@ def _start_faces_cluster_scheduler() -> None:
       GENIUSAI_FACES_CLUSTER_LINKAGE    ("complete" | "average"; default: "complete")
     """
     if not _bool_env("GENIUSAI_FACES_CLUSTER_ENABLED", default=False):
-        logger.info("Faces cluster scheduler disabled (GENIUSAI_FACES_CLUSTER_ENABLED not set).")
+        logger.info(
+            "Faces cluster scheduler disabled (GENIUSAI_FACES_CLUSTER_ENABLED not set)."
+        )
         return
 
     try:
@@ -84,7 +86,11 @@ def _start_faces_cluster_scheduler() -> None:
         except ValueError:
             min_faces = None
 
-    linkage = (os.environ.get("GENIUSAI_FACES_CLUSTER_LINKAGE", "complete") or "complete").strip().lower()
+    linkage = (
+        (os.environ.get("GENIUSAI_FACES_CLUSTER_LINKAGE", "complete") or "complete")
+        .strip()
+        .lower()
+    )
     if linkage not in ("complete", "average"):
         linkage = "complete"
 
@@ -147,12 +153,16 @@ def _start_housekeeping_scheduler() -> None:
         while True:
             try:
                 zip_path, backup_name = service_db.build_backup_zip()
-                logger.info("Periodic DB backup created: %s (%s)", backup_name, zip_path)
+                logger.info(
+                    "Periodic DB backup created: %s (%s)", backup_name, zip_path
+                )
                 service_db.prune_old_backups(max_keep=max_keep)
                 try:
                     os.remove(zip_path)
                 except OSError as e:
-                    logger.warning("Could not remove temporary backup zip %s: %s", zip_path, e)
+                    logger.warning(
+                        "Could not remove temporary backup zip %s: %s", zip_path, e
+                    )
             except Exception as e:
                 logger.error("Periodic DB backup failed: %s", e, exc_info=True)
             time.sleep(interval)
@@ -160,25 +170,35 @@ def _start_housekeeping_scheduler() -> None:
     t = threading.Thread(target=_loop, name="db-backup-scheduler", daemon=True)
     t.start()
 
+
 @app.errorhandler(500)
 def handle_internal_server_error(e):
     logger.error(f"Internal Server Error: {e}")
     return jsonify({"error": "Internal Server Error"}), 500
 
+
 if __name__ == "__main__":
     version_info = get_backend_version_info()
     logger.info("=" * 60)
-    logger.info("LrGenius Server version %s (build %s)", version_info.get("backend_version", "?"), version_info.get("backend_build", "?"))
+    logger.info(
+        "LrGenius Server version %s (build %s)",
+        version_info.get("backend_version", "?"),
+        version_info.get("backend_build", "?"),
+    )
     logger.info("LrGenius Server starting...")
     logger.info(f"Python: {sys.version.split()[0]}")
     logger.info(f"Database Path: {DB_PATH or 'Idle (waiting for plugin initialize)'}")
     logger.info("=" * 60)
-    
+
     # Optional one-shot ID migration for deployed databases.
     # Set GENIUSAI_MIGRATION_FILE to a JSON list/object with mappings.
     migration_file = os.environ.get("GENIUSAI_MIGRATION_FILE", "").strip()
     if migration_file and DB_PATH:
-        migration_path = migration_file if os.path.isabs(migration_file) else os.path.join(DB_PATH, migration_file)
+        migration_path = (
+            migration_file
+            if os.path.isabs(migration_file)
+            else os.path.join(DB_PATH, migration_file)
+        )
         try:
             with open(migration_path, "r", encoding="utf-8") as f:
                 payload = json.load(f)
@@ -190,19 +210,21 @@ if __name__ == "__main__":
 
     # Mark server as ready for startup scripts
     server_lifecycle.write_ok_file()
-    
+
     # Write PID for lifecycle management
     server_lifecycle.write_pid_file()
 
     # Start optional background schedulers (housekeeping, clustering)
     _start_housekeeping_scheduler()
     _start_faces_cluster_scheduler()
-    
+
     host = os.environ.get("GENIUSAI_HOST", "127.0.0.1")
     port = int(os.environ.get("GENIUSAI_PORT", "19819"))
     try:
         if args.debug:
-            logger.info(f"Starting Flask development server in debug mode on http://{host}:{port}")
+            logger.info(
+                f"Starting Flask development server in debug mode on http://{host}:{port}"
+            )
             app.run(debug=True, host=host, port=port)
         else:
             logger.info(f"Starting production server on http://{host}:{port}")

--- a/server/src/llm_provider_base.py
+++ b/server/src/llm_provider_base.py
@@ -10,46 +10,48 @@ import io
 from config import METADATA_GENERATION_SYSTEM_PROMPT
 from edit_recipe import OPENAI_EDIT_RECIPE_SCHEMA, normalize_edit_recipe
 
+
 @dataclass
 class MetadataGenerationRequest:
     """Request structure for metadata generation"""
+
     image_data: bytes
     uuid: str
-    
+
     # Provider selection and model configuration
     provider: str
     model: str
     api_key: Optional[str]
-    
+
     # Generation options (what to generate)
     generate_keywords: bool
     generate_caption: bool
     generate_title: bool
     generate_alt_text: bool
-    
+
     # Output language for all generated metadata
     language: str
-    
+
     # LLM parameters
     temperature: float
     max_tokens: Optional[int]
-    
+
     # System and user prompts (can override defaults)
     system_prompt: Optional[str]
     user_prompt: Optional[str]
-    
+
     # Context flags (whether to include additional context)
     submit_gps: bool
     submit_keywords: bool
     submit_folder_names: bool
-    
+
     # Optional context data
     existing_keywords: Optional[List[str]]
     gps_coordinates: Optional[Dict[str, float]]
     folder_names: Optional[str]
     user_context: Optional[str]
     date_time: Optional[str]
-    
+
     # Keyword hierarchy for structured output
     # Can be either a flat list of strings: ["People", "Activities"]
     # Or a nested dict: {"People": {"Family": {}, "Friends": {}}, "Activities": {}}
@@ -65,19 +67,20 @@ class MetadataGenerationRequest:
 @dataclass
 class MetadataGenerationResponse:
     """Response structure for metadata generation"""
+
     uuid: str
     success: bool
-    
+
     # Generated metadata
     keywords: Optional[dict[str, str]] = None
     caption: Optional[str] = None
     title: Optional[str] = None
     alt_text: Optional[str] = None
-    
+
     # Token usage for tracking
     input_tokens: int = 0
     output_tokens: int = 0
-    
+
     # Error information
     error: Optional[str] = None
     warning: Optional[str] = None
@@ -86,6 +89,7 @@ class MetadataGenerationResponse:
 @dataclass
 class EditGenerationRequest:
     """Request structure for Lightroom edit recipe generation."""
+
     image_data: bytes
     uuid: str
 
@@ -132,6 +136,7 @@ class EditGenerationRequest:
 @dataclass
 class EditGenerationResponse:
     """Structured Lightroom edit recipe response."""
+
     uuid: str
     success: bool
     recipe: Optional[Dict[str, Any]] = None
@@ -146,60 +151,64 @@ class LLMProviderBase(ABC):
     Abstract base class for all LLM providers.
     Each provider (Qwen, Ollama, LM Studio, ChatGPT, Gemini) implements this interface.
     """
-    
+
     def __init__(self, config: Dict[str, Any]):
         """
         Initialize provider with configuration.
-        
+
         Args:
             config: Provider-specific configuration dictionary
         """
         self.config = config
         self.provider_name = self.__class__.__name__
-    
+
     @abstractmethod
-    def generate_metadata(self, request: MetadataGenerationRequest) -> MetadataGenerationResponse:
+    def generate_metadata(
+        self, request: MetadataGenerationRequest
+    ) -> MetadataGenerationResponse:
         """
         Generate metadata for a single image.
-        
+
         Args:
             request: MetadataGenerationRequest containing image and generation options
-            
+
         Returns:
             MetadataGenerationResponse with generated metadata or error
         """
         pass
-    
+
     @abstractmethod
     def is_available(self) -> bool:
         """
         Check if the provider is available and properly configured.
-        
+
         Returns:
             True if provider can be used, False otherwise
         """
         pass
 
     @abstractmethod
-    def generate_edit_recipe(self, request: EditGenerationRequest) -> EditGenerationResponse:
+    def generate_edit_recipe(
+        self, request: EditGenerationRequest
+    ) -> EditGenerationResponse:
         """
         Generate a Lightroom edit recipe for a single image.
         """
         pass
-    
+
     @abstractmethod
     def list_available_models(self) -> list:
         """
         List all available models for this provider.
-        
+
         Args:
             only_multimodal: If True, return only vision-capable models
-            
+
         Returns:
             List of model names/identifiers
         """
         pass
-    
+
     def _prepare_system_prompt(self, request: MetadataGenerationRequest) -> str:
         """
         Prepare system instruction based on request options.
@@ -208,10 +217,10 @@ class LLMProviderBase(ABC):
         # Use custom system prompt if provided
         if request.system_prompt:
             return request.system_prompt
-        
+
         # Use default system prompt from config
         return METADATA_GENERATION_SYSTEM_PROMPT
-    
+
     def _prepare_user_prompt(self, request: MetadataGenerationRequest) -> str:
         """
         Prepare user task/prompt based on what metadata to generate.
@@ -222,67 +231,81 @@ class LLMProviderBase(ABC):
             base_prompt = request.user_prompt
         else:
             # Default task prompt
-            base_prompt = "Analyze the uploaded photo and generate the following data:\n"
-            
+            base_prompt = (
+                "Analyze the uploaded photo and generate the following data:\n"
+            )
+
             if request.generate_alt_text:
                 base_prompt += "* Alt text (with context for screen readers)\n"
-            
+
             if request.generate_caption:
                 base_prompt += "* Image caption\n"
-            
+
             if request.generate_title:
                 base_prompt += "* Image title\n"
-            
+
             if request.generate_keywords:
                 base_prompt += "* Keywords\n"
-        
+
         # Add language instruction
         base_prompt += f"\n\nAll results should be generated in {request.language}."
-        
+
         # Add contextual information if provided and enabled
         context_additions = []
-        
+
         if request.submit_gps and isinstance(request.gps_coordinates, dict):
-            lat = request.gps_coordinates.get('latitude')
-            lon = request.gps_coordinates.get('longitude')
+            lat = request.gps_coordinates.get("latitude")
+            lon = request.gps_coordinates.get("longitude")
             if lat is not None and lon is not None:
-                context_additions.append(f"This photo was taken at the following coordinates: {lat}, {lon}")
-        
+                context_additions.append(
+                    f"This photo was taken at the following coordinates: {lat}, {lon}"
+                )
+
         if request.submit_keywords and request.existing_keywords:
             # Must be a list; if still a string, split so join() doesn't iterate over characters (issue #45).
             kw_list = request.existing_keywords
             if isinstance(kw_list, str):
-                kw_list = [k.strip() for k in kw_list.split(',') if k.strip()]
+                kw_list = [k.strip() for k in kw_list.split(",") if k.strip()]
             if isinstance(kw_list, list):
-                keywords_str = ", ".join(str(k).strip() for k in kw_list if str(k).strip())
+                keywords_str = ", ".join(
+                    str(k).strip() for k in kw_list if str(k).strip()
+                )
                 if keywords_str:
                     context_additions.append(f"Some keywords are: {keywords_str}")
-        
+
         if request.user_context and str(request.user_context).strip() != "":
             context_additions.append(f"Context: {request.user_context}")
-        
+
         if request.submit_folder_names and request.folder_names:
             # Check if folder names contain alphabetic characters (ignore pure numbers or special chars)
             if any(c.isalpha() for c in request.folder_names):
                 context_additions.append(f"Folders: {request.folder_names}")
-        
+
         if request.date_time and str(request.date_time).strip() != "":
             context_additions.append(f"Capture Time: {request.date_time}")
-        
+
         # Add keyword hierarchy information if provided
         if request.generate_keywords and request.keyword_categories:
             if isinstance(request.keyword_categories, dict):
                 # Nested structure - provide instructions on how to use it
-                categories_list = self._flatten_keyword_categories(request.keyword_categories)
+                categories_list = self._flatten_keyword_categories(
+                    request.keyword_categories
+                )
                 categories_str = ", ".join(categories_list)
-                context_additions.append(f"Please organize keywords into these categories: {categories_str}. Use the hierarchical structure to organize keywords logically.")
+                context_additions.append(
+                    f"Please organize keywords into these categories: {categories_str}. Use the hierarchical structure to organize keywords logically."
+                )
             else:
                 # Flat list
                 categories_str = ", ".join(request.keyword_categories)
-                context_additions.append(f"Please organize keywords into these categories: {categories_str}")
+                context_additions.append(
+                    f"Please organize keywords into these categories: {categories_str}"
+                )
 
         if request.generate_keywords and request.bilingual_keywords:
-            secondary_language = (request.keyword_secondary_language or "English").strip() or "English"
+            secondary_language = (
+                request.keyword_secondary_language or "English"
+            ).strip() or "English"
             if secondary_language.lower() != request.language.lower():
                 context_additions.append(
                     "For keywords only, return each keyword as an object with fields "
@@ -297,11 +320,11 @@ class LLMProviderBase(ABC):
                     "For keywords, return each keyword as an object with fields `name` and `synonyms`. "
                     "Use `synonyms` only for meaningful alternate terms and avoid duplicates."
                 )
-        
+
         # Append context if any
         if context_additions:
             base_prompt += "\n\n" + "\n".join(context_additions)
-        
+
         return base_prompt
 
     def _prepare_edit_system_prompt(self, request: EditGenerationRequest) -> str:
@@ -325,14 +348,33 @@ class LLMProviderBase(ABC):
 
         # Keep only numeric develop values to avoid cluttering the prompt.
         CANONICAL_KEYS = {
-            "Exposure2012", "Contrast2012", "Highlights2012", "Shadows2012",
-            "Whites2012", "Blacks2012", "Temp", "Tint", "Texture", "Clarity2012",
-            "Dehaze", "Vibrance", "Saturation", "Sharpness", "LuminanceSmoothing",
-            "ColorNoiseReduction", "PostCropVignetteAmount", "GrainAmount",
-            "SplitToningShadowHue", "SplitToningShadowSaturation",
-            "SplitToningHighlightHue", "SplitToningHighlightSaturation",
-            "SplitToningBalance", "ParametricHighlights", "ParametricLights",
-            "ParametricDarks", "ParametricShadows",
+            "Exposure2012",
+            "Contrast2012",
+            "Highlights2012",
+            "Shadows2012",
+            "Whites2012",
+            "Blacks2012",
+            "Temp",
+            "Tint",
+            "Texture",
+            "Clarity2012",
+            "Dehaze",
+            "Vibrance",
+            "Saturation",
+            "Sharpness",
+            "LuminanceSmoothing",
+            "ColorNoiseReduction",
+            "PostCropVignetteAmount",
+            "GrainAmount",
+            "SplitToningShadowHue",
+            "SplitToningShadowSaturation",
+            "SplitToningHighlightHue",
+            "SplitToningHighlightSaturation",
+            "SplitToningBalance",
+            "ParametricHighlights",
+            "ParametricLights",
+            "ParametricDarks",
+            "ParametricShadows",
         }
         compact = {
             k: round(v, 2) if isinstance(v, float) else v
@@ -385,17 +427,25 @@ class LLMProviderBase(ABC):
         if not request.adjust_basic_tone:
             base_prompt += "* Do not adjust global basic tone controls (`exposure`, `contrast`, `highlights`, `shadows`, `whites`, `blacks`)\n"
         if not request.adjust_presence:
-            base_prompt += "* Do not adjust presence controls (`texture`, `clarity`, `dehaze`)\n"
+            base_prompt += (
+                "* Do not adjust presence controls (`texture`, `clarity`, `dehaze`)\n"
+            )
         if not request.adjust_color_mix:
-            base_prompt += "* Do not adjust color mix controls (`vibrance`, `saturation`, `hsl`)\n"
+            base_prompt += (
+                "* Do not adjust color mix controls (`vibrance`, `saturation`, `hsl`)\n"
+            )
         if not request.do_color_grading:
             base_prompt += "* Do not use `color_grading`\n"
         if not request.use_tone_curve:
-            base_prompt += "* Do not use `tone_curve` (neither parametric nor point curve)\n"
+            base_prompt += (
+                "* Do not use `tone_curve` (neither parametric nor point curve)\n"
+            )
         elif not request.use_point_curve:
             base_prompt += "* Do not use `tone_curve.point_curve` or `tone_curve.extended_point_curve`; use only parametric tone curve sliders if needed\n"
         if not request.adjust_detail:
-            base_prompt += "* Do not adjust detail controls (sharpening/noise reduction)\n"
+            base_prompt += (
+                "* Do not adjust detail controls (sharpening/noise reduction)\n"
+            )
         if not request.adjust_effects:
             base_prompt += "* Do not adjust effects controls (vignette/grain)\n"
         if not request.adjust_lens_corrections:
@@ -426,17 +476,27 @@ class LLMProviderBase(ABC):
         if strength > 1.0:
             strength = 1.0
         if strength <= 0.25:
-            context_additions.append("Style strength: very subtle (minimal slider movement, preserve original character).")
+            context_additions.append(
+                "Style strength: very subtle (minimal slider movement, preserve original character)."
+            )
         elif strength <= 0.5:
-            context_additions.append("Style strength: subtle to moderate (clean refinement, avoid strong stylization).")
+            context_additions.append(
+                "Style strength: subtle to moderate (clean refinement, avoid strong stylization)."
+            )
         elif strength <= 0.75:
-            context_additions.append("Style strength: moderate to strong (noticeable look while staying plausible).")
+            context_additions.append(
+                "Style strength: moderate to strong (noticeable look while staying plausible)."
+            )
         else:
-            context_additions.append("Style strength: strong (bold look allowed, but avoid clipping and artifacts).")
+            context_additions.append(
+                "Style strength: strong (bold look allowed, but avoid clipping and artifacts)."
+            )
         if request.user_context:
             context_additions.append(f"Per-photo instructions: {request.user_context}")
         if request.submit_keywords and request.existing_keywords:
-            keywords_str = ", ".join(str(k).strip() for k in request.existing_keywords if str(k).strip())
+            keywords_str = ", ".join(
+                str(k).strip() for k in request.existing_keywords if str(k).strip()
+            )
             if keywords_str:
                 context_additions.append(f"Existing keywords: {keywords_str}")
         if request.submit_folder_names and request.folder_names:
@@ -469,14 +529,16 @@ class LLMProviderBase(ABC):
             base_prompt += "--- END OF STYLE EXAMPLES ---\n"
 
         return base_prompt
-    
-    def _build_nested_keyword_schema(self, categories: Dict[str, Any], bilingual: bool = False) -> Dict[str, Any]:
+
+    def _build_nested_keyword_schema(
+        self, categories: Dict[str, Any], bilingual: bool = False
+    ) -> Dict[str, Any]:
         """
         Recursively build JSON schema for nested keyword categories.
-        
+
         Args:
             categories: Dict where keys are category names and values are sub-dicts
-            
+
         Returns:
             JSON schema for nested structure
         """
@@ -484,22 +546,26 @@ class LLMProviderBase(ABC):
             "type": "object",
             "properties": {},
             "additionalProperties": False,
-            "required": []
+            "required": [],
         }
-        
+
         for category_name, subcategories in categories.items():
             if isinstance(subcategories, dict) and len(subcategories) > 0:
                 # Nested structure - recursively build
-                schema["properties"][category_name] = self._build_nested_keyword_schema(subcategories, bilingual)
+                schema["properties"][category_name] = self._build_nested_keyword_schema(
+                    subcategories, bilingual
+                )
             else:
                 # Leaf node - array of keywords
                 schema["properties"][category_name] = {
                     "type": "array",
-                    "items": self._keyword_leaf_item_schema(request_bilingual=bilingual)
+                    "items": self._keyword_leaf_item_schema(
+                        request_bilingual=bilingual
+                    ),
                 }
             if category_name not in schema["required"]:
                 schema["required"].append(category_name)
-        
+
         return schema
 
     def _keyword_leaf_item_schema(self, request_bilingual: bool) -> Dict[str, Any]:
@@ -510,81 +576,83 @@ class LLMProviderBase(ABC):
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
-                "synonyms": {
-                    "type": "array",
-                    "items": {"type": "string"}
-                }
+                "synonyms": {"type": "array", "items": {"type": "string"}},
             },
             "required": ["name", "synonyms"],
-            "additionalProperties": False
+            "additionalProperties": False,
         }
-    
-    def _flatten_keyword_categories(self, categories: Union[List[str], Dict[str, Any]]) -> List[str]:
+
+    def _flatten_keyword_categories(
+        self, categories: Union[List[str], Dict[str, Any]]
+    ) -> List[str]:
         """
         Flatten nested keyword categories to a simple list.
         Used for context in the prompt if needed.
-        
+
         Args:
             categories: Either a flat list or nested dict of categories
-            
+
         Returns:
             Flat list of all category names
         """
         if isinstance(categories, list):
             return categories
-        
+
         result = []
+
         def traverse(d):
             for key, value in d.items():
                 result.append(key)
                 if isinstance(value, dict) and len(value) > 0:
                     traverse(value)
-        
+
         traverse(categories)
         return result
-    
-    def _prepare_response_structure(self, request: MetadataGenerationRequest) -> Dict[str, Any]:
+
+    def _prepare_response_structure(
+        self, request: MetadataGenerationRequest
+    ) -> Dict[str, Any]:
         """
         Prepare JSON schema for structured output.
         Different providers have different formats (OpenAI vs Gemini).
         Must be overridden by specific providers.
         """
-        schema = {
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-        
+        schema = {"type": "object", "properties": {}, "required": []}
+
         if request.generate_title:
             schema["properties"]["title"] = {"type": "string"}
             schema["required"].append("title")
-        
+
         if request.generate_caption:
             schema["properties"]["caption"] = {"type": "string"}
             schema["required"].append("caption")
-        
+
         if request.generate_alt_text:
             schema["properties"]["alt_text"] = {"type": "string"}
             schema["required"].append("alt_text")
-        
+
         if request.generate_keywords:
             if request.keyword_categories:
                 # Structured keywords by category (handles both flat and nested)
                 if isinstance(request.keyword_categories, dict):
                     # Nested structure
-                    keywords_schema = self._build_nested_keyword_schema(request.keyword_categories, request.bilingual_keywords)
+                    keywords_schema = self._build_nested_keyword_schema(
+                        request.keyword_categories, request.bilingual_keywords
+                    )
                 else:
                     # Flat list
                     keywords_schema = {
                         "type": "object",
                         "properties": {},
                         "additionalProperties": False,
-                        "required": []
+                        "required": [],
                     }
                     for category in request.keyword_categories:
                         keywords_schema["properties"][category] = {
                             "type": "array",
-                            "items": self._keyword_leaf_item_schema(request.bilingual_keywords)
+                            "items": self._keyword_leaf_item_schema(
+                                request.bilingual_keywords
+                            ),
                         }
                         if category not in keywords_schema["required"]:
                             keywords_schema["required"].append(category)
@@ -593,13 +661,15 @@ class LLMProviderBase(ABC):
                 # Simple keyword array
                 schema["properties"]["keywords"] = {
                     "type": "array",
-                    "items": self._keyword_leaf_item_schema(request.bilingual_keywords)
+                    "items": self._keyword_leaf_item_schema(request.bilingual_keywords),
                 }
             schema["required"].append("keywords")
-        
+
         return schema
 
-    def _normalize_keyword_leaf(self, value: Any) -> Optional[Union[str, Dict[str, Any]]]:
+    def _normalize_keyword_leaf(
+        self, value: Any
+    ) -> Optional[Union[str, Dict[str, Any]]]:
         if isinstance(value, str):
             keyword = value.strip()
             return keyword or None
@@ -664,7 +734,7 @@ class LLMProviderBase(ABC):
 
     def _normalize_edit_recipe(self, value: Any) -> Dict[str, Any]:
         return normalize_edit_recipe(value)
-    
+
     def _image_to_base64(self, image_data: bytes) -> str:
         """
         Convert image bytes to base64 string.
@@ -673,17 +743,17 @@ class LLMProviderBase(ABC):
         try:
             # Optimization: Check for JPEG magic numbers (FF D8 FF)
             # If it's already JPEG, skip the expensive PIL load/save cycle
-            if image_data.startswith(b'\xff\xd8\xff'):
+            if image_data.startswith(b"\xff\xd8\xff"):
                 return base64.b64encode(image_data).decode("utf-8")
 
             # For non-JPEGs (PNG, WEBP, etc.), convert to JPEG
             image = Image.open(io.BytesIO(image_data)).convert("RGB")
-            
+
             buffer = io.BytesIO()
             # Keep high quality for conversion
-            image.save(buffer, format="JPEG", quality=95) 
+            image.save(buffer, format="JPEG", quality=95)
             image_bytes = buffer.getvalue()
-            
+
             return base64.b64encode(image_bytes).decode("utf-8")
         except Exception as e:
             raise ValueError(f"Failed to process image: {str(e)}")

--- a/server/src/llm_provider_chatgpt.py
+++ b/server/src/llm_provider_chatgpt.py
@@ -1,6 +1,7 @@
 """
 ChatGPT/OpenAI Provider for metadata generation using OpenAI API
 """
+
 import json
 from typing import Dict, Any
 from llm_provider_base import (
@@ -18,40 +19,40 @@ class ChatGPTProvider(LLMProviderBase):
     Provider for OpenAI ChatGPT API.
     Supports GPT-4o, GPT-4-turbo, and other vision-capable models.
     """
-    
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
-        self.api_key = config.get('api_key')
-        self.timeout = config.get('timeout', 120)
+        self.api_key = config.get("api_key")
+        self.timeout = config.get("timeout", 120)
         self.client = None
-        
+
         if self.api_key:
             self._initialize_client()
-    
+
     def _initialize_client(self):
         """Initialize OpenAI client"""
         try:
             from openai import OpenAI
-            self.client = OpenAI(
-                api_key=self.api_key,
-                timeout=self.timeout
-            )
+
+            self.client = OpenAI(api_key=self.api_key, timeout=self.timeout)
             logger.info("OpenAI client initialized")
         except Exception as e:
             logger.error(f"Failed to initialize OpenAI client: {e}")
             self.client = None
-    
+
     def is_available(self) -> bool:
         """Check if OpenAI API is configured"""
         return self.client is not None and bool(self.api_key)
-    
-    def generate_metadata(self, request: MetadataGenerationRequest) -> MetadataGenerationResponse:
+
+    def generate_metadata(
+        self, request: MetadataGenerationRequest
+    ) -> MetadataGenerationResponse:
         """
         Generate metadata using OpenAI API.
-        
+
         Args:
             request: MetadataGenerationRequest with image and options
-            
+
         Returns:
             MetadataGenerationResponse with generated metadata
         """
@@ -64,71 +65,60 @@ class ChatGPTProvider(LLMProviderBase):
                     return MetadataGenerationResponse(
                         uuid=request.uuid,
                         success=False,
-                        error="OpenAI API initialization failed with provided API key"
+                        error="OpenAI API initialization failed with provided API key",
                     )
                 else:
-                    logger.info("OpenAI client initialized with provided API key for metadata generation")
+                    logger.info(
+                        "OpenAI client initialized with provided API key for metadata generation"
+                    )
             else:
                 return MetadataGenerationResponse(
-                    uuid=request.uuid,
-                    success=False,
-                    error="OpenAI API not configured"
+                    uuid=request.uuid, success=False, error="OpenAI API not configured"
                 )
-        
+
         try:
             # Convert image to base64 data URI
             image_b64 = self._image_to_base64(request.image_data)
             data_uri = f"data:image/jpeg;base64,{image_b64}"
-            
+
             # Prepare prompts
             system_prompt = self._prepare_system_prompt(request)
             user_prompt = self._prepare_user_prompt(request)
-            
+
             # Prepare response format
             response_format = self._prepare_openai_response_format(request)
-            
+
             # Handle GPT-5 models (they don't support temperature)
-            temperature = 1.0 if request.model.startswith("gpt-5") else request.temperature
-            
+            temperature = (
+                1.0 if request.model.startswith("gpt-5") else request.temperature
+            )
+
             # Prepare messages
             messages = [
-                {
-                    "role": "system",
-                    "content": system_prompt
-                },
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
                 {
                     "role": "user",
-                    "content": user_prompt
+                    "content": [{"type": "image_url", "image_url": {"url": data_uri}}],
                 },
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": data_uri
-                            }
-                        }
-                    ]
-                }
             ]
-            
+
             # Make API call
             logger.debug(f"Sending request to OpenAI: {request.model}")
-            
+
             completion_params = {
                 "model": request.model,
                 "messages": messages,
                 "response_format": response_format,
                 "temperature": temperature,
             }
-            
+
             # GPT-5 models require reasoning_effort
             if request.model.startswith("gpt-5"):
                 completion_params["reasoning_effort"] = "low"
-            
+
             response = self.client.chat.completions.create(**completion_params)
-            
+
             # Check finish reason
             choice = response.choices[0]
             if choice.finish_reason != "stop":
@@ -139,27 +129,33 @@ class ChatGPTProvider(LLMProviderBase):
                     success=False,
                     error=error_msg,
                     input_tokens=response.usage.prompt_tokens if response.usage else 0,
-                    output_tokens=response.usage.completion_tokens if response.usage else 0
+                    output_tokens=response.usage.completion_tokens
+                    if response.usage
+                    else 0,
                 )
-            
+
             # Extract message content
             content = choice.message.content
             logger.debug(f"OpenAI raw response: {content}")
-            
+
             # Parse JSON
             parsed_data = json.loads(content)
-            
+
             # Extract metadata
-            keywords = self._normalize_keywords_structure(parsed_data.get("keywords", []))
-            
+            keywords = self._normalize_keywords_structure(
+                parsed_data.get("keywords", [])
+            )
+
             caption = parsed_data.get("caption") if request.generate_caption else None
             title = parsed_data.get("title") if request.generate_title else None
-            alt_text = parsed_data.get("alt_text") if request.generate_alt_text else None
-            
+            alt_text = (
+                parsed_data.get("alt_text") if request.generate_alt_text else None
+            )
+
             # Token usage
             input_tokens = response.usage.prompt_tokens if response.usage else 0
             output_tokens = response.usage.completion_tokens if response.usage else 0
-            
+
             return MetadataGenerationResponse(
                 uuid=request.uuid,
                 success=True,
@@ -168,25 +164,23 @@ class ChatGPTProvider(LLMProviderBase):
                 title=title,
                 alt_text=alt_text,
                 input_tokens=input_tokens,
-                output_tokens=output_tokens
+                output_tokens=output_tokens,
             )
-            
+
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON from OpenAI response: {e}")
             return MetadataGenerationResponse(
-                uuid=request.uuid,
-                success=False,
-                error=f"JSON parsing error: {str(e)}"
+                uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}"
             )
         except Exception as e:
             logger.error(f"Error generating metadata with OpenAI: {e}", exc_info=True)
             return MetadataGenerationResponse(
-                uuid=request.uuid,
-                success=False,
-                error=str(e)
+                uuid=request.uuid, success=False, error=str(e)
             )
 
-    def generate_edit_recipe(self, request: EditGenerationRequest) -> EditGenerationResponse:
+    def generate_edit_recipe(
+        self, request: EditGenerationRequest
+    ) -> EditGenerationResponse:
         if not self.is_available():
             if request.api_key:
                 self.api_key = request.api_key
@@ -198,7 +192,9 @@ class ChatGPTProvider(LLMProviderBase):
                         error="OpenAI API initialization failed with provided API key",
                     )
             else:
-                return EditGenerationResponse(uuid=request.uuid, success=False, error="OpenAI API not configured")
+                return EditGenerationResponse(
+                    uuid=request.uuid, success=False, error="OpenAI API not configured"
+                )
 
         try:
             image_b64 = self._image_to_base64(request.image_data)
@@ -206,7 +202,9 @@ class ChatGPTProvider(LLMProviderBase):
             system_prompt = self._prepare_edit_system_prompt(request)
             user_prompt = self._prepare_edit_user_prompt(request)
             response_format = self._prepare_openai_edit_response_format()
-            temperature = 1.0 if request.model.startswith("gpt-5") else request.temperature
+            temperature = (
+                1.0 if request.model.startswith("gpt-5") else request.temperature
+            )
 
             messages = [
                 {"role": "system", "content": system_prompt},
@@ -238,7 +236,9 @@ class ChatGPTProvider(LLMProviderBase):
                     success=False,
                     error=f"OpenAI generation failed: {choice.finish_reason}",
                     input_tokens=response.usage.prompt_tokens if response.usage else 0,
-                    output_tokens=response.usage.completion_tokens if response.usage else 0,
+                    output_tokens=response.usage.completion_tokens
+                    if response.usage
+                    else 0,
                 )
 
             parsed_data = json.loads(choice.message.content)
@@ -252,38 +252,46 @@ class ChatGPTProvider(LLMProviderBase):
             )
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse edit JSON from OpenAI response: {e}")
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}")
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}"
+            )
         except Exception as e:
-            logger.error(f"Error generating edit recipe with OpenAI: {e}", exc_info=True)
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=str(e))
-    
-    def _prepare_openai_response_format(self, request: MetadataGenerationRequest) -> Dict[str, Any]:
+            logger.error(
+                f"Error generating edit recipe with OpenAI: {e}", exc_info=True
+            )
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=str(e)
+            )
+
+    def _prepare_openai_response_format(
+        self, request: MetadataGenerationRequest
+    ) -> Dict[str, Any]:
         """Prepare OpenAI-style response format with JSON schema"""
         schema = self._prepare_response_structure(request)
         # Ensure the schema is strictly compliant with OpenAI requirements
         schema = self._make_schema_strict(schema)
-        
+
         return {
             "type": "json_schema",
             "json_schema": {
                 "name": "metadata_response",
                 "schema": schema,
-                "strict": True
-            }
+                "strict": True,
+            },
         }
 
     def _prepare_openai_edit_response_format(self) -> Dict[str, Any]:
         schema = self._prepare_edit_response_structure()
         # Ensure the schema is strictly compliant with OpenAI requirements
         schema = self._make_schema_strict(schema)
-        
+
         return {
             "type": "json_schema",
             "json_schema": {
                 "name": "lightroom_edit_recipe",
                 "schema": schema,
-                "strict": True
-            }
+                "strict": True,
+            },
         }
 
     def _make_schema_strict(self, schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -302,22 +310,24 @@ class ChatGPTProvider(LLMProviderBase):
         if schema_type == "object" or "properties" in schema:
             schema["type"] = "object"  # Ensure type is set
             schema["additionalProperties"] = False
-            
+
             properties = schema.get("properties", {})
             if properties:
                 # Initialize required list if missing
                 if "required" not in schema:
                     schema["required"] = []
-                
+
                 # All properties must be in required
                 for prop_name in properties.keys():
                     if prop_name not in schema["required"]:
                         schema["required"].append(prop_name)
-                
+
                 # Recursively process each property
                 for prop_name, prop_schema in properties.items():
-                    schema["properties"][prop_name] = self._make_schema_strict(prop_schema)
-        
+                    schema["properties"][prop_name] = self._make_schema_strict(
+                        prop_schema
+                    )
+
         # Handle arrays
         elif schema_type == "array" or "items" in schema:
             schema["type"] = "array"  # Ensure type is set
@@ -325,32 +335,32 @@ class ChatGPTProvider(LLMProviderBase):
                 schema["items"] = self._make_schema_strict(schema["items"])
 
         return schema
-    
+
     def list_available_models(self) -> list:
         """
         List available OpenAI models.
-        
+
         Args:
             only_multimodal: If True, return only vision-capable models
-            
+
         Returns:
             List of model identifiers
         """
         # Return hardcoded list even if API key is not configured
         # This allows users to see which models are available
         # The actual API key will be provided when making requests
-        
+
         # Hardcoded list of vision-capable ChatGPT models
         # SDK-based filtering commented out as it returns too many irrelevant models
         vision_models = [
-            'gpt-4.1',
-            'gpt-4.1-mini',
-            'gpt-5',
-            'gpt-5-mini',
-            'gpt-5-nano',
-            'gpt-5.4',
-            'gpt-5.4-pro',
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano",
+            "gpt-5.4",
+            "gpt-5.4-pro",
         ]
-        
+
         logger.info(f"Returning {len(vision_models)} hardcoded ChatGPT models")
         return vision_models

--- a/server/src/llm_provider_gemini.py
+++ b/server/src/llm_provider_gemini.py
@@ -1,6 +1,7 @@
 """
 Gemini Provider for metadata generation using Google Generative AI API
 """
+
 import json
 import time
 from typing import Dict, Any
@@ -14,23 +15,24 @@ from llm_provider_base import (
 from config import logger
 from edit_recipe import GEMINI_EDIT_RECIPE_SCHEMA
 
+
 class GeminiProvider(LLMProviderBase):
     """
     Provider for Google Gemini API.
     Supports Gemini 2.0, Gemini 1.5 Pro, and other vision-capable models.
     """
-    
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
-        self.api_key = config.get('api_key')
-        self.timeout = config.get('timeout', 300)
+        self.api_key = config.get("api_key")
+        self.timeout = config.get("timeout", 300)
         # client will be a google.genai.Client instance when initialized
         self.client = None
         self.rate_limit_hit = 0
-        
+
         if self.api_key:
             self._initialize_client()
-    
+
     def _initialize_client(self):
         """Initialize Google Generative AI client"""
         try:
@@ -39,24 +41,27 @@ class GeminiProvider(LLMProviderBase):
             # The new google-genai SDK exposes a Client API.
             # Create a genai Client instance and store it on the provider.
             import google.genai as genai
+
             self.client = genai.Client(api_key=self.api_key)
 
             logger.info("Google GenAI client initialized")
         except Exception as e:
             logger.error(f"Failed to initialize Gemini client: {e}")
             self.client = None
-    
+
     def is_available(self) -> bool:
         """Check if Gemini API is configured"""
         return self.client is not None and bool(self.api_key)
-    
-    def generate_metadata(self, request: MetadataGenerationRequest) -> MetadataGenerationResponse:
+
+    def generate_metadata(
+        self, request: MetadataGenerationRequest
+    ) -> MetadataGenerationResponse:
         """
         Generate metadata using Gemini API.
-        
+
         Args:
             request: MetadataGenerationRequest with image and options
-            
+
         Returns:
             MetadataGenerationResponse with generated metadata
         """
@@ -68,26 +73,23 @@ class GeminiProvider(LLMProviderBase):
                 return MetadataGenerationResponse(
                     uuid=request.uuid,
                     success=False,
-                    error="Gemini API not configured with provided API key"
+                    error="Gemini API not configured with provided API key",
                 )
             else:
                 logger.info("Gemini client initialized with request API key")
         else:
             return MetadataGenerationResponse(
-                uuid=request.uuid,
-                success=False,
-                error="Gemini API not configured"
+                uuid=request.uuid, success=False, error="Gemini API not configured"
             )
-        
+
         try:
-        
             # Prepare prompts
             system_instruction = self._prepare_system_prompt(request)
             user_prompt = self._prepare_user_prompt(request)
-            
+
             # Prepare generation config
             generation_config = self._prepare_gemini_generation_config(request)
-            
+
             model_name = request.model
 
             # Use the new client-based API for generation
@@ -96,12 +98,14 @@ class GeminiProvider(LLMProviderBase):
             # Prepare thinking config for certain models
             thinking_config = None
             if model_name == "gemini-2.5-pro":
-                thinking_config=types.ThinkingConfig(thinking_budget=128)
-            elif model_name == "gemini-2.5-flash" or model_name == "gemini-2.5-flash-lite":
-                thinking_config=types.ThinkingConfig(thinking_budget=0)
+                thinking_config = types.ThinkingConfig(thinking_budget=128)
+            elif (
+                model_name == "gemini-2.5-flash"
+                or model_name == "gemini-2.5-flash-lite"
+            ):
+                thinking_config = types.ThinkingConfig(thinking_budget=0)
             elif model_name == "gemini-3-pro-preview":
-                thinking_config=types.ThinkingConfig(thinking_level="low")
-
+                thinking_config = types.ThinkingConfig(thinking_level="low")
 
             # Build a typed GenerateContentConfig from our generation_config dict
             config = types.GenerateContentConfig(
@@ -112,10 +116,17 @@ class GeminiProvider(LLMProviderBase):
                 thinking_config=thinking_config if thinking_config else None,
             )
 
-            logger.info(f"Sending metadata request to Gemini: {model_name} (timeout: {self.timeout}s)")
+            logger.info(
+                f"Sending metadata request to Gemini: {model_name} (timeout: {self.timeout}s)"
+            )
             try:
                 # contents may include the user prompt and an image part
-                contents = [user_prompt, types.Part.from_bytes(data=request.image_data, mime_type='image/jpeg')]
+                contents = [
+                    user_prompt,
+                    types.Part.from_bytes(
+                        data=request.image_data, mime_type="image/jpeg"
+                    ),
+                ]
                 response = self.client.models.generate_content(
                     model=model_name,
                     contents=contents,
@@ -126,73 +137,105 @@ class GeminiProvider(LLMProviderBase):
                 error_msg = f"Gemini request timed out after {self.timeout}s"
                 logger.warning(error_msg)
                 return MetadataGenerationResponse(
-                    uuid=request.uuid,
-                    success=False,
-                    error=error_msg
+                    uuid=request.uuid, success=False, error=error_msg
                 )
             except Exception as api_error:
                 # Catch API errors early and re-raise for main handler
-                if "DeadlineExceeded" in str(type(api_error).__name__) or "504" in str(api_error):
+                if "DeadlineExceeded" in str(type(api_error).__name__) or "504" in str(
+                    api_error
+                ):
                     logger.warning(f"Gemini API deadline exceeded: {api_error}")
                 raise  # Re-raise to be caught by the main exception handler
 
             # Check for prompt feedback (blocking)
-            if hasattr(response, 'prompt_feedback') and getattr(response.prompt_feedback, 'block_reason', None):
-                error_msg = f"Gemini blocked request: {response.prompt_feedback.block_reason}"
+            if hasattr(response, "prompt_feedback") and getattr(
+                response.prompt_feedback, "block_reason", None
+            ):
+                error_msg = (
+                    f"Gemini blocked request: {response.prompt_feedback.block_reason}"
+                )
                 logger.error(error_msg)
-                usage_metadata = getattr(response, 'usage', None) or getattr(response, 'metadata', None) or getattr(response, 'usage_metadata', None)
+                usage_metadata = (
+                    getattr(response, "usage", None)
+                    or getattr(response, "metadata", None)
+                    or getattr(response, "usage_metadata", None)
+                )
                 return MetadataGenerationResponse(
                     uuid=request.uuid,
                     success=False,
                     error=error_msg,
-                    input_tokens=getattr(usage_metadata, 'prompt_token_count', 0) if usage_metadata else 0,
-                    output_tokens=getattr(usage_metadata, 'candidates_token_count', 0) if usage_metadata else 0
+                    input_tokens=getattr(usage_metadata, "prompt_token_count", 0)
+                    if usage_metadata
+                    else 0,
+                    output_tokens=getattr(usage_metadata, "candidates_token_count", 0)
+                    if usage_metadata
+                    else 0,
                 )
-            
+
             # Extract text from response (support text, parsed, or parts)
-            if not getattr(response, 'text', None):
-                parsed = getattr(response, 'parsed', None)
+            if not getattr(response, "text", None):
+                parsed = getattr(response, "parsed", None)
                 if parsed:
                     text = json.dumps(parsed) if not isinstance(parsed, str) else parsed
                 else:
-                    parts = getattr(response, 'parts', None) or getattr(response, 'candidates', None)
+                    parts = getattr(response, "parts", None) or getattr(
+                        response, "candidates", None
+                    )
                     if parts:
                         collected = []
                         for p in parts:
-                            if hasattr(p, 'text') and p.text:
+                            if hasattr(p, "text") and p.text:
                                 collected.append(p.text)
-                            elif hasattr(p, 'content') and isinstance(p.content, str):
+                            elif hasattr(p, "content") and isinstance(p.content, str):
                                 collected.append(p.content)
-                        text = '\n'.join(collected)
+                        text = "\n".join(collected)
                     else:
                         error_msg = "Gemini returned no usable text in response"
                         logger.error(error_msg)
-                        return MetadataGenerationResponse(uuid=request.uuid, success=False, error=error_msg)
+                        return MetadataGenerationResponse(
+                            uuid=request.uuid, success=False, error=error_msg
+                        )
             else:
                 text = response.text
 
             # Clean Gemini-specific artifacts
             text = self._clean_gemini_response(text)
-            
+
             # Parse JSON
             parsed_data = json.loads(text)
-            
+
             # Extract metadata
-            keywords = self._normalize_keywords_structure(parsed_data.get("keywords", []))
+            keywords = self._normalize_keywords_structure(
+                parsed_data.get("keywords", [])
+            )
             # logger.debug(f"Extracted keywords: {keywords} .. type: {type(keywords)}")
-            
+
             caption = parsed_data.get("caption") if request.generate_caption else None
             title = parsed_data.get("title") if request.generate_title else None
-            alt_text = parsed_data.get("alt_text") if request.generate_alt_text else None
-            
+            alt_text = (
+                parsed_data.get("alt_text") if request.generate_alt_text else None
+            )
+
             # Token usage
-            usage_metadata = getattr(response, 'usage', None) or getattr(response, 'metadata', None) or getattr(response, 'usage_metadata', None)
-            input_tokens = getattr(usage_metadata, 'prompt_token_count', None) or getattr(usage_metadata, 'input_tokens', None) or getattr(usage_metadata, 'input_token_count', 0)
-            output_tokens = getattr(usage_metadata, 'candidates_token_count', None) or getattr(usage_metadata, 'output_tokens', None) or getattr(usage_metadata, 'output_token_count', 0)
-            
+            usage_metadata = (
+                getattr(response, "usage", None)
+                or getattr(response, "metadata", None)
+                or getattr(response, "usage_metadata", None)
+            )
+            input_tokens = (
+                getattr(usage_metadata, "prompt_token_count", None)
+                or getattr(usage_metadata, "input_tokens", None)
+                or getattr(usage_metadata, "input_token_count", 0)
+            )
+            output_tokens = (
+                getattr(usage_metadata, "candidates_token_count", None)
+                or getattr(usage_metadata, "output_tokens", None)
+                or getattr(usage_metadata, "output_token_count", 0)
+            )
+
             # Reset rate limit counter on success
             self.rate_limit_hit = 0
-            
+
             return MetadataGenerationResponse(
                 uuid=request.uuid,
                 success=True,
@@ -201,53 +244,57 @@ class GeminiProvider(LLMProviderBase):
                 title=title,
                 alt_text=alt_text,
                 input_tokens=input_tokens,
-                output_tokens=output_tokens
+                output_tokens=output_tokens,
             )
-            
+
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON from Gemini response: {e}")
             return MetadataGenerationResponse(
-                uuid=request.uuid,
-                success=False,
-                error=f"JSON parsing error: {str(e)}"
+                uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}"
             )
         except Exception as e:
             error_str = str(e)
             error_type = type(e).__name__
-            
+
             # Handle DeadlineExceeded (504 errors)
             if "DeadlineExceeded" in error_type or "504" in error_str:
-                logger.warning("Gemini API deadline exceeded (timeout) for metadata generation")
+                logger.warning(
+                    "Gemini API deadline exceeded (timeout) for metadata generation"
+                )
                 return MetadataGenerationResponse(
                     uuid=request.uuid,
                     success=False,
-                    error="Gemini API timeout (504 Deadline Exceeded). Try again later or use a different provider."
+                    error="Gemini API timeout (504 Deadline Exceeded). Try again later or use a different provider.",
                 )
-            
+
             # Handle rate limiting
-            if "429" in error_str or "RATE_LIMIT" in error_str or "quota" in error_str.lower():
+            if (
+                "429" in error_str
+                or "RATE_LIMIT" in error_str
+                or "quota" in error_str.lower()
+            ):
                 self.rate_limit_hit += 1
                 logger.warning(f"Gemini rate limit hit {self.rate_limit_hit} times")
-                
+
                 if self.rate_limit_hit >= 10:
                     return MetadataGenerationResponse(
                         uuid=request.uuid,
                         success=False,
-                        error="Rate limit exhausted after 10 retries"
+                        error="Rate limit exhausted after 10 retries",
                     )
-                
+
                 # Wait and retry
                 time.sleep(5)
                 return self.generate_metadata(request)
-            
+
             logger.error(f"Error generating metadata with Gemini: {e}", exc_info=True)
             return MetadataGenerationResponse(
-                uuid=request.uuid,
-                success=False,
-                error=str(e)
+                uuid=request.uuid, success=False, error=str(e)
             )
 
-    def generate_edit_recipe(self, request: EditGenerationRequest) -> EditGenerationResponse:
+    def generate_edit_recipe(
+        self, request: EditGenerationRequest
+    ) -> EditGenerationResponse:
         if request.api_key:
             self.api_key = request.api_key
             self._initialize_client()
@@ -258,7 +305,9 @@ class GeminiProvider(LLMProviderBase):
                     error="Gemini API not configured with provided API key",
                 )
         else:
-            return EditGenerationResponse(uuid=request.uuid, success=False, error="Gemini API not configured")
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error="Gemini API not configured"
+            )
 
         try:
             system_instruction = self._prepare_edit_system_prompt(request)
@@ -271,7 +320,10 @@ class GeminiProvider(LLMProviderBase):
             thinking_config = None
             if model_name == "gemini-2.5-pro":
                 thinking_config = types.ThinkingConfig(thinking_budget=128)
-            elif model_name == "gemini-2.5-flash" or model_name == "gemini-2.5-flash-lite":
+            elif (
+                model_name == "gemini-2.5-flash"
+                or model_name == "gemini-2.5-flash-lite"
+            ):
                 thinking_config = types.ThinkingConfig(thinking_budget=0)
             elif model_name == "gemini-3-pro-preview":
                 thinking_config = types.ThinkingConfig(thinking_level="low")
@@ -286,7 +338,12 @@ class GeminiProvider(LLMProviderBase):
 
             response = self.client.models.generate_content(
                 model=model_name,
-                contents=[user_prompt, types.Part.from_bytes(data=request.image_data, mime_type="image/jpeg")],
+                contents=[
+                    user_prompt,
+                    types.Part.from_bytes(
+                        data=request.image_data, mime_type="image/jpeg"
+                    ),
+                ],
                 config=config,
             )
 
@@ -301,9 +358,21 @@ class GeminiProvider(LLMProviderBase):
 
             parsed_data = json.loads(self._clean_gemini_response(text))
             recipe = self._normalize_edit_recipe(parsed_data)
-            usage_metadata = getattr(response, "usage", None) or getattr(response, "metadata", None) or getattr(response, "usage_metadata", None)
-            input_tokens = getattr(usage_metadata, "prompt_token_count", None) or getattr(usage_metadata, "input_tokens", None) or getattr(usage_metadata, "input_token_count", 0)
-            output_tokens = getattr(usage_metadata, "candidates_token_count", None) or getattr(usage_metadata, "output_tokens", None) or getattr(usage_metadata, "output_token_count", 0)
+            usage_metadata = (
+                getattr(response, "usage", None)
+                or getattr(response, "metadata", None)
+                or getattr(response, "usage_metadata", None)
+            )
+            input_tokens = (
+                getattr(usage_metadata, "prompt_token_count", None)
+                or getattr(usage_metadata, "input_tokens", None)
+                or getattr(usage_metadata, "input_token_count", 0)
+            )
+            output_tokens = (
+                getattr(usage_metadata, "candidates_token_count", None)
+                or getattr(usage_metadata, "output_tokens", None)
+                or getattr(usage_metadata, "output_token_count", 0)
+            )
             self.rate_limit_hit = 0
             return EditGenerationResponse(
                 uuid=request.uuid,
@@ -314,7 +383,9 @@ class GeminiProvider(LLMProviderBase):
             )
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse edit JSON from Gemini response: {e}")
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}")
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}"
+            )
         except Exception as e:
             error_str = str(e)
             error_type = type(e).__name__
@@ -322,106 +393,125 @@ class GeminiProvider(LLMProviderBase):
                 return EditGenerationResponse(
                     uuid=request.uuid,
                     success=False,
-                    error="Gemini API timeout (504 Deadline Exceeded). Try again later or use a different provider."
+                    error="Gemini API timeout (504 Deadline Exceeded). Try again later or use a different provider.",
                 )
-            if "429" in error_str or "RATE_LIMIT" in error_str or "quota" in error_str.lower():
+            if (
+                "429" in error_str
+                or "RATE_LIMIT" in error_str
+                or "quota" in error_str.lower()
+            ):
                 self.rate_limit_hit += 1
                 if self.rate_limit_hit >= 10:
-                    return EditGenerationResponse(uuid=request.uuid, success=False, error="Rate limit exhausted after 10 retries")
+                    return EditGenerationResponse(
+                        uuid=request.uuid,
+                        success=False,
+                        error="Rate limit exhausted after 10 retries",
+                    )
                 time.sleep(5)
                 return self.generate_edit_recipe(request)
-            logger.error(f"Error generating edit recipe with Gemini: {e}", exc_info=True)
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=str(e))
-    
-    def _prepare_gemini_generation_config(self, request: MetadataGenerationRequest) -> Dict[str, Any]:
+            logger.error(
+                f"Error generating edit recipe with Gemini: {e}", exc_info=True
+            )
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=str(e)
+            )
+
+    def _prepare_gemini_generation_config(
+        self, request: MetadataGenerationRequest
+    ) -> Dict[str, Any]:
         """Prepare Gemini-specific generation config"""
         schema = self._prepare_gemini_response_schema(request)
-        
+
         return {
             "response_mime_type": "application/json",
             "response_schema": schema,
             "temperature": request.temperature,
         }
 
-    def _prepare_gemini_edit_generation_config(self, request: EditGenerationRequest) -> Dict[str, Any]:
+    def _prepare_gemini_edit_generation_config(
+        self, request: EditGenerationRequest
+    ) -> Dict[str, Any]:
         return {
             "response_mime_type": "application/json",
             "response_schema": GEMINI_EDIT_RECIPE_SCHEMA,
             "temperature": request.temperature,
         }
-    
-    def _prepare_gemini_response_schema(self, request: MetadataGenerationRequest) -> Dict[str, Any]:
+
+    def _prepare_gemini_response_schema(
+        self, request: MetadataGenerationRequest
+    ) -> Dict[str, Any]:
         """Prepare Gemini-style response schema (uses different format than OpenAI)"""
         schema = {
             "type": "OBJECT",  # Gemini uses uppercase
-            "properties": {}
+            "properties": {},
         }
-        
+
         if request.generate_title:
             schema["properties"]["title"] = {"type": "STRING"}
-        
+
         if request.generate_caption:
             schema["properties"]["caption"] = {"type": "STRING"}
-        
+
         if request.generate_alt_text:
             schema["properties"]["alt_text"] = {"type": "STRING"}
-        
+
         if request.generate_keywords:
             if request.keyword_categories:
                 # Structured keywords (handles both flat and nested)
                 if isinstance(request.keyword_categories, dict):
                     # Nested structure - recursively build Gemini schema
                     keywords_schema = self._build_nested_gemini_keyword_schema(
-                        request.keyword_categories,
-                        request.bilingual_keywords
+                        request.keyword_categories, request.bilingual_keywords
                     )
                 else:
                     # Flat list
-                    keywords_schema = {
-                        "type": "OBJECT",
-                        "properties": {}
-                    }
+                    keywords_schema = {"type": "OBJECT", "properties": {}}
                     for category in request.keyword_categories:
                         keywords_schema["properties"][category] = {
                             "type": "ARRAY",
-                            "items": self._gemini_keyword_leaf_item_schema(request.bilingual_keywords)
+                            "items": self._gemini_keyword_leaf_item_schema(
+                                request.bilingual_keywords
+                            ),
                         }
                 schema["properties"]["keywords"] = keywords_schema
             else:
                 # Simple array
                 schema["properties"]["keywords"] = {
                     "type": "ARRAY",
-                    "items": self._gemini_keyword_leaf_item_schema(request.bilingual_keywords)
+                    "items": self._gemini_keyword_leaf_item_schema(
+                        request.bilingual_keywords
+                    ),
                 }
-        
+
         return schema
-    
-    def _build_nested_gemini_keyword_schema(self, categories: Dict[str, Any], bilingual: bool = False) -> Dict[str, Any]:
+
+    def _build_nested_gemini_keyword_schema(
+        self, categories: Dict[str, Any], bilingual: bool = False
+    ) -> Dict[str, Any]:
         """
         Recursively build Gemini JSON schema for nested keyword categories.
-        
+
         Args:
             categories: Dict where keys are category names and values are sub-dicts
-            
+
         Returns:
             Gemini-format JSON schema for nested structure
         """
-        schema = {
-            "type": "OBJECT",
-            "properties": {}
-        }
-        
+        schema = {"type": "OBJECT", "properties": {}}
+
         for category_name, subcategories in categories.items():
             if isinstance(subcategories, dict) and len(subcategories) > 0:
                 # Nested structure - recursively build
-                schema["properties"][category_name] = self._build_nested_gemini_keyword_schema(subcategories, bilingual)
+                schema["properties"][category_name] = (
+                    self._build_nested_gemini_keyword_schema(subcategories, bilingual)
+                )
             else:
                 # Leaf node - array of keywords
                 schema["properties"][category_name] = {
                     "type": "ARRAY",
-                    "items": self._gemini_keyword_leaf_item_schema(bilingual)
+                    "items": self._gemini_keyword_leaf_item_schema(bilingual),
                 }
-        
+
         return schema
 
     def _gemini_keyword_leaf_item_schema(self, bilingual: bool) -> Dict[str, Any]:
@@ -432,14 +522,11 @@ class GeminiProvider(LLMProviderBase):
             "type": "OBJECT",
             "properties": {
                 "name": {"type": "STRING"},
-                "synonyms": {
-                    "type": "ARRAY",
-                    "items": {"type": "STRING"}
-                }
+                "synonyms": {"type": "ARRAY", "items": {"type": "STRING"}},
             },
-            "required": ["name"]
+            "required": ["name"],
         }
-    
+
     def _clean_gemini_response(self, text: str) -> str:
         """Clean Gemini-specific response artifacts"""
         # Remove markdown code blocks
@@ -449,37 +536,36 @@ class GeminiProvider(LLMProviderBase):
             text = text[3:]
         if text.endswith("```"):
             text = text[:-3]
-        
+
         # Trim whitespace
         text = text.strip()
-        
+
         return text
-    
-    
+
     def list_available_models(self) -> list:
         """
         List available Gemini models.
-        
+
         Args:
             only_multimodal: If True, return only vision-capable models
-            
+
         Returns:
             List of model identifiers
         """
         # Return hardcoded list even if API key is not configured
         # This allows users to see which models are available
         # The actual API key will be provided when making requests
-        
+
         # Hardcoded list of vision-capable Gemini models
         # SDK-based filtering commented out as it returns too many irrelevant models
         vision_models = [
-            'gemini-2.5-flash-lite',
-            'gemini-2.5-flash',
-            'gemini-2.5-pro',
-            'gemini-3-flash-preview',
-            'gemini-3.1-flash-lite-preview',
-            'gemini-3.1-pro-preview',
+            "gemini-2.5-flash-lite",
+            "gemini-2.5-flash",
+            "gemini-2.5-pro",
+            "gemini-3-flash-preview",
+            "gemini-3.1-flash-lite-preview",
+            "gemini-3.1-pro-preview",
         ]
-        
+
         logger.info(f"Returning {len(vision_models)} hardcoded Gemini models")
         return vision_models

--- a/server/src/llm_provider_lmstudio.py
+++ b/server/src/llm_provider_lmstudio.py
@@ -1,6 +1,7 @@
 """
 LM Studio Provider for metadata generation using the lmstudio-python library
 """
+
 import json
 import lmstudio as lms
 from typing import Dict, Any
@@ -19,11 +20,11 @@ class LMStudioProvider(LLMProviderBase):
     Provider for LM Studio local inference.
     Uses the lmstudio-python library.
     """
-    
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
-        self.host = config.get('base_url', LMSTUDIO_HOST)
-        self.timeout = config.get('timeout', 720)
+        self.host = config.get("base_url", LMSTUDIO_HOST)
+        self.timeout = config.get("timeout", 720)
         # lmstudio-python's synchronous API defaults to timing out after ~60s of
         # inactivity when waiting for a response/stream event. Wire our configured
         # timeout through so metadata generation can run longer (e.g. 720s).
@@ -35,10 +36,13 @@ class LMStudioProvider(LLMProviderBase):
                 set_sync_timeout(self.timeout)
                 logger.info(f"LM Studio sync API timeout set to {self.timeout}s")
             else:
-                logger.debug("lmstudio-python set_sync_api_timeout not available; using SDK default timeout")
+                logger.debug(
+                    "lmstudio-python set_sync_api_timeout not available; using SDK default timeout"
+                )
         except Exception as e:
-            logger.warning(f"Failed to set lmstudio-python sync API timeout: {e}", exc_info=True)
-
+            logger.warning(
+                f"Failed to set lmstudio-python sync API timeout: {e}", exc_info=True
+            )
 
     def is_available(self) -> bool:
         """Check if LM Studio server is reachable with a short timeout"""
@@ -46,21 +50,23 @@ class LMStudioProvider(LLMProviderBase):
             # First, a basic validation of host format
             if not self.host or ":" not in self.host:
                 return False
-                
+
             # Use the SDK's validation but be aware it might block if the host is a dead IP.
             # In a future version, we might add a socket-level pre-check here.
             return lms.Client.is_valid_api_host(self.host)
         except Exception as e:
             logger.warning(f"LM Studio availability check failed for {self.host}: {e}")
             return False
-    
-    def generate_metadata(self, request: MetadataGenerationRequest) -> MetadataGenerationResponse:
+
+    def generate_metadata(
+        self, request: MetadataGenerationRequest
+    ) -> MetadataGenerationResponse:
         """
         Generate metadata using LM Studio API.
-        
+
         Args:
             request: MetadataGenerationRequest with image and options
-            
+
         Returns:
             MetadataGenerationResponse with generated metadata
         """
@@ -73,21 +79,25 @@ class LMStudioProvider(LLMProviderBase):
                 # Prepare image via client so we don't depend on the default client
                 image_handle = client.files.prepare_image(request.image_data)
                 model = client.llm.model(request.model)
-                
+
                 # Prepare prompts
                 system_prompt = self._prepare_system_prompt(request)
                 user_prompt = self._prepare_user_prompt(request)
-                
+
                 # Prepare OpenAI-style response format
                 response_schema = self._prepare_response_structure(request)
-                
+
                 # Make request to LM Studio
                 logger.debug("Sending request to LM Studio")
 
                 chat = lms.Chat(system_prompt)
                 chat.add_user_message(user_prompt, images=[image_handle])
 
-                response = model.respond(chat, response_format=response_schema, config={"temperature": request.temperature })
+                response = model.respond(
+                    chat,
+                    response_format=response_schema,
+                    config={"temperature": request.temperature},
+                )
 
             # Extract message content
             content = response.parsed
@@ -99,42 +109,62 @@ class LMStudioProvider(LLMProviderBase):
                 try:
                     content = json.loads(content)
                 except Exception as parse_err:
-                    raise ValueError(f"Unexpected non-JSON response from LM Studio: {content}") from parse_err
+                    raise ValueError(
+                        f"Unexpected non-JSON response from LM Studio: {content}"
+                    ) from parse_err
 
             if not isinstance(content, dict):
-                raise ValueError(f"Unexpected response type from LM Studio: {type(content)}")
-            
+                raise ValueError(
+                    f"Unexpected response type from LM Studio: {type(content)}"
+                )
+
             # Extract metadata
             keywords = self._normalize_keywords_structure(content.get("keywords", []))
-            
+
             caption = content.get("caption") if request.generate_caption else None
             title = content.get("title") if request.generate_title else None
             alt_text = content.get("alt_text") if request.generate_alt_text else None
-         
+
             # Token usage reporting
             input_tokens = 0
             output_tokens = 0
             try:
                 # 1. Try to get usage from the response object directly (lms 0.4.x+)
-                stats = getattr(response, "stats", None) or getattr(response, "usage", None)
+                stats = getattr(response, "stats", None) or getattr(
+                    response, "usage", None
+                )
                 if stats:
-                    input_tokens = getattr(stats, "prompt_tokens", 0) or getattr(stats, "input_tokens", 0)
-                    output_tokens = getattr(stats, "completion_tokens", 0) or getattr(stats, "output_tokens", 0)
-                
+                    input_tokens = getattr(stats, "prompt_tokens", 0) or getattr(
+                        stats, "input_tokens", 0
+                    )
+                    output_tokens = getattr(stats, "completion_tokens", 0) or getattr(
+                        stats, "output_tokens", 0
+                    )
+
                 # 2. Fallback: Manual tokenization for accuracy
                 if input_tokens == 0 and hasattr(model, "tokenize"):
                     # For input, we should tokenize the full prompt as seen by the model
                     try:
                         # model.apply_prompt_template(chat) returns the raw string if available
-                        full_prompt = model.apply_prompt_template(chat) if hasattr(model, "apply_prompt_template") else user_prompt
+                        full_prompt = (
+                            model.apply_prompt_template(chat)
+                            if hasattr(model, "apply_prompt_template")
+                            else user_prompt
+                        )
                         input_tokens = len(model.tokenize(full_prompt))
                     except Exception:
                         input_tokens = len(model.tokenize(user_prompt))
-                
-                if output_tokens == 0 and hasattr(model, "tokenize") and isinstance(content, dict):
+
+                if (
+                    output_tokens == 0
+                    and hasattr(model, "tokenize")
+                    and isinstance(content, dict)
+                ):
                     output_tokens = len(model.tokenize(json.dumps(content)))
-                
-                logger.info(f"LM Studio token usage for {request.uuid}: input={input_tokens}, output={output_tokens}")
+
+                logger.info(
+                    f"LM Studio token usage for {request.uuid}: input={input_tokens}, output={output_tokens}"
+                )
             except Exception as usage_err:
                 logger.debug(f"Could not calculate LM Studio token usage: {usage_err}")
 
@@ -146,14 +176,20 @@ class LMStudioProvider(LLMProviderBase):
                 title=title,
                 alt_text=alt_text,
                 input_tokens=input_tokens,
-                output_tokens=output_tokens
+                output_tokens=output_tokens,
             )
-            
-        except Exception as e:
-            logger.error(f"Error generating metadata with LM Studio: {e}", exc_info=True)
-            return MetadataGenerationResponse(uuid=request.uuid, success=False, error=str(e))
 
-    def generate_edit_recipe(self, request: EditGenerationRequest) -> EditGenerationResponse:
+        except Exception as e:
+            logger.error(
+                f"Error generating metadata with LM Studio: {e}", exc_info=True
+            )
+            return MetadataGenerationResponse(
+                uuid=request.uuid, success=False, error=str(e)
+            )
+
+    def generate_edit_recipe(
+        self, request: EditGenerationRequest
+    ) -> EditGenerationResponse:
         try:
             host = getattr(request, "lmstudio_base_url", None) or self.host
             with lms.Client(host) as client:
@@ -165,31 +201,47 @@ class LMStudioProvider(LLMProviderBase):
 
                 chat = lms.Chat(system_prompt)
                 chat.add_user_message(user_prompt, images=[image_handle])
-                response = model.respond(chat, response_format=response_schema, config={"temperature": request.temperature})
+                response = model.respond(
+                    chat,
+                    response_format=response_schema,
+                    config={"temperature": request.temperature},
+                )
 
             content = response.parsed
             if isinstance(content, str):
                 content = json.loads(content)
             if not isinstance(content, dict):
-                raise ValueError(f"Unexpected response type from LM Studio: {type(content)}")
+                raise ValueError(
+                    f"Unexpected response type from LM Studio: {type(content)}"
+                )
 
             recipe = self._normalize_edit_recipe(content)
             # Token usage reporting
             input_tokens = 0
             output_tokens = 0
             try:
-                stats = getattr(response, "stats", None) or getattr(response, "usage", None)
+                stats = getattr(response, "stats", None) or getattr(
+                    response, "usage", None
+                )
                 if stats:
-                    input_tokens = getattr(stats, "prompt_tokens", 0) or getattr(stats, "input_tokens", 0)
-                    output_tokens = getattr(stats, "completion_tokens", 0) or getattr(stats, "output_tokens", 0)
-                
+                    input_tokens = getattr(stats, "prompt_tokens", 0) or getattr(
+                        stats, "input_tokens", 0
+                    )
+                    output_tokens = getattr(stats, "completion_tokens", 0) or getattr(
+                        stats, "output_tokens", 0
+                    )
+
                 if input_tokens == 0 and hasattr(model, "tokenize"):
                     try:
-                        full_prompt = model.apply_prompt_template(chat) if hasattr(model, "apply_prompt_template") else user_prompt
+                        full_prompt = (
+                            model.apply_prompt_template(chat)
+                            if hasattr(model, "apply_prompt_template")
+                            else user_prompt
+                        )
                         input_tokens = len(model.tokenize(full_prompt))
                     except Exception:
                         input_tokens = len(model.tokenize(user_prompt))
-                
+
                 if output_tokens == 0 and hasattr(model, "tokenize"):
                     output_tokens = len(model.tokenize(json.dumps(content)))
             except Exception:
@@ -203,20 +255,26 @@ class LMStudioProvider(LLMProviderBase):
                 output_tokens=output_tokens,
             )
         except Exception as e:
-            logger.error(f"Error generating edit recipe with LM Studio: {e}", exc_info=True)
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=str(e))
-    
-    def _prepare_openai_response_format(self, request: MetadataGenerationRequest) -> Dict[str, Any]:
+            logger.error(
+                f"Error generating edit recipe with LM Studio: {e}", exc_info=True
+            )
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=str(e)
+            )
+
+    def _prepare_openai_response_format(
+        self, request: MetadataGenerationRequest
+    ) -> Dict[str, Any]:
         """Prepare OpenAI-style response format with JSON schema"""
         schema = self._prepare_response_structure(request)
-        
+
         return {
             "type": "json_schema",
             "json_schema": {
                 "name": "metadata_response",
                 "schema": schema,
-                "strict": True
-            }
+                "strict": True,
+            },
         }
 
     def _prepare_openai_edit_response_format(self) -> Dict[str, Any]:
@@ -226,14 +284,14 @@ class LMStudioProvider(LLMProviderBase):
             "json_schema": {
                 "name": "lightroom_edit_recipe",
                 "schema": schema,
-                "strict": True
-            }
+                "strict": True,
+            },
         }
-    
+
     def list_available_models(self) -> list:
         """
         List available LM Studio models using the lmstudio-python library.
-        
+
         Returns:
             List of model identifiers for vision-capable models.
         """
@@ -244,7 +302,10 @@ class LMStudioProvider(LLMProviderBase):
                 models = client.llm.list_downloaded()
                 all_models = [model.model_key for model in models]
                 return all_models
-            
+
         except Exception as e:
-            logger.error(f"An unexpected error occurred while listing LM Studio models: {e}", exc_info=True)
+            logger.error(
+                f"An unexpected error occurred while listing LM Studio models: {e}",
+                exc_info=True,
+            )
             return []

--- a/server/src/llm_provider_ollama.py
+++ b/server/src/llm_provider_ollama.py
@@ -1,6 +1,7 @@
 """
 Ollama Provider for metadata generation using the official Ollama Python SDK
 """
+
 import json
 from typing import Dict, Any, Optional
 
@@ -24,11 +25,11 @@ class OllamaProvider(LLMProviderBase):
     Provider for Ollama local inference.
     Uses Ollama's chat completion API with vision models.
     """
-    
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
-        self.base_url = config.get('base_url', OLLAMA_BASE_URL)
-        self.timeout = config.get('timeout', 120)
+        self.base_url = config.get("base_url", OLLAMA_BASE_URL)
+        self.timeout = config.get("timeout", 120)
         # Initialize Ollama client targeting the configured host
         try:
             self.client = Client(host=self.base_url) if Client else None
@@ -36,14 +37,16 @@ class OllamaProvider(LLMProviderBase):
             # Defer failures to is_available/generate methods
             logger.warning(f"Failed to initialize Ollama client: {e}")
             self.client = None  # type: ignore[assignment]
-    
+
     def is_available(self) -> bool:
         """Check if Ollama server is reachable with a short timeout"""
         try:
             if Client is None:
-                logger.warning("Ollama SDK not installed. Please install 'ollama' Python package.")
+                logger.warning(
+                    "Ollama SDK not installed. Please install 'ollama' Python package."
+                )
                 return False
-            
+
             # Use a specialized client with a very short timeout for the health check
             # to avoid blocking the backend server if Ollama is down/slow.
             temp_client = Client(host=self.base_url, timeout=2.0)
@@ -52,19 +55,21 @@ class OllamaProvider(LLMProviderBase):
         except Exception as e:
             logger.warning(f"Ollama not available at {self.base_url}: {e}")
             return False
-    
+
     def _get_client(self, base_url_override: Optional[str] = None):
         """Get Ollama client, using base_url_override when provided (e.g. from request)."""
         url = base_url_override or self.base_url
         return Client(host=url) if Client else None
 
-    def generate_metadata(self, request: MetadataGenerationRequest) -> MetadataGenerationResponse:
+    def generate_metadata(
+        self, request: MetadataGenerationRequest
+    ) -> MetadataGenerationResponse:
         """
         Generate metadata using Ollama API.
-        
+
         Args:
             request: MetadataGenerationRequest with image and options
-            
+
         Returns:
             MetadataGenerationResponse with generated metadata
         """
@@ -75,7 +80,7 @@ class OllamaProvider(LLMProviderBase):
                     success=False,
                     error="Ollama SDK not installed. Please install the 'ollama' Python package.",
                 )
-            client = self._get_client(getattr(request, 'ollama_base_url', None))
+            client = self._get_client(getattr(request, "ollama_base_url", None))
 
             # Convert image to base64
             image_b64 = self._image_to_base64(request.image_data)
@@ -111,11 +116,15 @@ class OllamaProvider(LLMProviderBase):
                 content = message.get("content")
             else:
                 message = getattr(result, "message", None)
-                content = getattr(message, "content", None) if message is not None else None
+                content = (
+                    getattr(message, "content", None) if message is not None else None
+                )
             if not content:
                 error_msg = "Empty response content from Ollama"
                 logger.error(error_msg)
-                return MetadataGenerationResponse(uuid=request.uuid, success=False, error=error_msg)
+                return MetadataGenerationResponse(
+                    uuid=request.uuid, success=False, error=error_msg
+                )
 
             logger.debug(f"Ollama raw response: {content}")
 
@@ -123,10 +132,14 @@ class OllamaProvider(LLMProviderBase):
             parsed_data = json.loads(content)
 
             # Extract metadata
-            keywords = self._normalize_keywords_structure(parsed_data.get("keywords", []))
+            keywords = self._normalize_keywords_structure(
+                parsed_data.get("keywords", [])
+            )
             caption = parsed_data.get("caption") if request.generate_caption else None
             title = parsed_data.get("title") if request.generate_title else None
-            alt_text = parsed_data.get("alt_text") if request.generate_alt_text else None
+            alt_text = (
+                parsed_data.get("alt_text") if request.generate_alt_text else None
+            )
 
             return MetadataGenerationResponse(
                 uuid=request.uuid,
@@ -154,7 +167,9 @@ class OllamaProvider(LLMProviderBase):
                 error=str(e),
             )
 
-    def generate_edit_recipe(self, request: EditGenerationRequest) -> EditGenerationResponse:
+    def generate_edit_recipe(
+        self, request: EditGenerationRequest
+    ) -> EditGenerationResponse:
         try:
             if Client is None:
                 return EditGenerationResponse(
@@ -188,9 +203,15 @@ class OllamaProvider(LLMProviderBase):
                 content = message.get("content")
             else:
                 message = getattr(result, "message", None)
-                content = getattr(message, "content", None) if message is not None else None
+                content = (
+                    getattr(message, "content", None) if message is not None else None
+                )
             if not content:
-                return EditGenerationResponse(uuid=request.uuid, success=False, error="Empty response content from Ollama")
+                return EditGenerationResponse(
+                    uuid=request.uuid,
+                    success=False,
+                    error="Empty response content from Ollama",
+                )
 
             recipe = self._normalize_edit_recipe(json.loads(content))
             return EditGenerationResponse(
@@ -202,18 +223,24 @@ class OllamaProvider(LLMProviderBase):
             )
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse edit JSON from Ollama response: {e}")
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}")
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=f"JSON parsing error: {str(e)}"
+            )
         except Exception as e:
-            logger.error(f"Error generating edit recipe with Ollama: {e}", exc_info=True)
-            return EditGenerationResponse(uuid=request.uuid, success=False, error=str(e))
+            logger.error(
+                f"Error generating edit recipe with Ollama: {e}", exc_info=True
+            )
+            return EditGenerationResponse(
+                uuid=request.uuid, success=False, error=str(e)
+            )
 
     def list_available_models(self) -> list:
         """
         List available Ollama models using Ollama API.
-        
+
         Args:
             only_multimodal: If True, return only vision-capable models
-            
+
         Returns:
             List of model identifiers
         """

--- a/server/src/open_clip_compat.py
+++ b/server/src/open_clip_compat.py
@@ -11,7 +11,9 @@ class _HFTokenizerWrapper:
     def __init__(self, inner):
         self._inner = inner
 
-    def __call__(self, texts: Union[str, List[str]], context_length: Optional[int] = None) -> torch.Tensor:
+    def __call__(
+        self, texts: Union[str, List[str]], context_length: Optional[int] = None
+    ) -> torch.Tensor:
         if isinstance(texts, str):
             texts = [texts]
         ctx = context_length or self._inner.context_length
@@ -29,9 +31,10 @@ class _HFTokenizerWrapper:
             truncation=True,
         )
         input_ids = encoded.input_ids
-        if getattr(self._inner, "strip_sep_token", False) and getattr(
-            self._inner.tokenizer, "sep_token_id", None
-        ) is not None:
+        if (
+            getattr(self._inner, "strip_sep_token", False)
+            and getattr(self._inner.tokenizer, "sep_token_id", None) is not None
+        ):
             input_ids = torch.where(
                 input_ids == self._inner.tokenizer.sep_token_id,
                 torch.zeros_like(input_ids),
@@ -77,7 +80,10 @@ def wrap_tokenizer(tok):
         return None
     try:
         from open_clip.tokenizer import HFTokenizer
-        if isinstance(tok, HFTokenizer) and not hasattr(tok.tokenizer, "batch_encode_plus"):
+
+        if isinstance(tok, HFTokenizer) and not hasattr(
+            tok.tokenizer, "batch_encode_plus"
+        ):
             return _HFTokenizerWrapper(tok)
     except Exception:
         pass

--- a/server/src/routes_clip.py
+++ b/server/src/routes_clip.py
@@ -1,24 +1,29 @@
-
 from flask import Blueprint, jsonify
 from server_lifecycle import is_model_cached
 from service_clip import start_download_clip_model, get_download_status
 from config import logger
 
-clip_bp = Blueprint('clip', __name__)
+clip_bp = Blueprint("clip", __name__)
 
-@clip_bp.route('/clip/status', methods=['GET'])
+
+@clip_bp.route("/clip/status", methods=["GET"])
 def clip_cached():
     try:
         if is_model_cached():
-            return jsonify({"clip": "ready", "message": "CLIP model is loaded and ready."})
+            return jsonify(
+                {"clip": "ready", "message": "CLIP model is loaded and ready."}
+            )
         else:
-            return jsonify({"clip": "not_ready", "message": "CLIP model is not loaded."})           
-        
+            return jsonify(
+                {"clip": "not_ready", "message": "CLIP model is not loaded."}
+            )
+
     except Exception as e:
         logger.error(f"Error checking CLIP model status: {e}", exc_info=True)
         return jsonify({"clip": "not_ready", "message": str(e)})
-    
-@clip_bp.route('/clip/download/start', methods=['POST'])
+
+
+@clip_bp.route("/clip/download/start", methods=["POST"])
 def download_clip_model_start():
     logger.info("Download CLIP model request received")
 
@@ -29,7 +34,8 @@ def download_clip_model_start():
         logger.error(f"Error while starting to download CLIP model: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
 
-@clip_bp.route('/clip/download/status', methods=['GET'])
+
+@clip_bp.route("/clip/download/status", methods=["GET"])
 def download_clip_model_status():
     logger.info("Download CLIP model status request received")
 
@@ -37,7 +43,7 @@ def download_clip_model_status():
         status = get_download_status()
         return jsonify(status)
     except Exception as e:
-        logger.error(f"Error while getting download status for CLIP model: {e}", exc_info=True)
+        logger.error(
+            f"Error while getting download status for CLIP model: {e}", exc_info=True
+        )
         return jsonify({"error": str(e)}), 500
-        
-

--- a/server/src/routes_db.py
+++ b/server/src/routes_db.py
@@ -5,10 +5,10 @@ from config import logger
 import service_db
 
 
-db_bp = Blueprint('db', __name__)
+db_bp = Blueprint("db", __name__)
 
 
-@db_bp.route('/db/stats', methods=['GET'])
+@db_bp.route("/db/stats", methods=["GET"])
 def database_stats():
     """
     Return database statistics: indexed photos, faces, persons, and metadata/embedding counts.
@@ -19,7 +19,7 @@ def database_stats():
         "persons": { "total" }
     }
     """
-    catalog_id = request.args.get('catalog_id')
+    catalog_id = request.args.get("catalog_id")
     try:
         return jsonify(service_db.get_database_stats(catalog_id=catalog_id))
     except Exception as e:
@@ -27,7 +27,7 @@ def database_stats():
         return jsonify({"error": str(e)}), 500
 
 
-@db_bp.route('/db/backup', methods=['GET'])
+@db_bp.route("/db/backup", methods=["GET"])
 def backup_database():
     try:
         zip_path, backup_name = service_db.build_backup_zip()
@@ -39,7 +39,9 @@ def backup_database():
             except FileNotFoundError:
                 pass
             except Exception as e:
-                logger.warning("Could not remove temporary backup zip %s: %s", zip_path, e)
+                logger.warning(
+                    "Could not remove temporary backup zip %s: %s", zip_path, e
+                )
             return response
 
         return send_file(
@@ -54,7 +56,7 @@ def backup_database():
         return jsonify({"error": str(e)}), 500
 
 
-@db_bp.route('/db/migrate-photo-ids', methods=['POST'])
+@db_bp.route("/db/migrate-photo-ids", methods=["POST"])
 def migrate_photo_ids():
     """Migrate existing Chroma IDs from legacy uuid to new photo_id values."""
     try:

--- a/server/src/routes_edit.py
+++ b/server/src/routes_edit.py
@@ -22,14 +22,24 @@ def _has_items(values) -> bool:
         return False
 
 
-def _persist_edit_recipe(photo_id: str, filename: str | None, recipe: dict, options: dict) -> None:
+def _persist_edit_recipe(
+    photo_id: str, filename: str | None, recipe: dict, options: dict
+) -> None:
     catalog_id = options.get("catalog_id")
     existing = chroma_service.get_image(photo_id)
     existing_has_ids = existing is not None and _has_items(existing.get("ids"))
-    existing_has_metadatas = existing is not None and _has_items(existing.get("metadatas"))
-    existing_has_embeddings = existing is not None and _has_items(existing.get("embeddings"))
+    existing_has_metadatas = existing is not None and _has_items(
+        existing.get("metadatas")
+    )
+    existing_has_embeddings = existing is not None and _has_items(
+        existing.get("embeddings")
+    )
 
-    existing_meta = dict(existing["metadatas"][0]) if existing_has_ids and existing_has_metadatas else {}
+    existing_meta = (
+        dict(existing["metadatas"][0])
+        if existing_has_ids and existing_has_metadatas
+        else {}
+    )
     existing_embedding = None
     if existing_has_ids and existing_has_embeddings:
         try:
@@ -42,22 +52,34 @@ def _persist_edit_recipe(photo_id: str, filename: str | None, recipe: dict, opti
         metadata["filename"] = filename
     metadata["edit_recipe"] = json.dumps(recipe, ensure_ascii=False)
     metadata["edit_summary"] = recipe.get("summary", "")
-    metadata["edit_warnings"] = json.dumps(recipe.get("warnings", []), ensure_ascii=False)
-    metadata["edit_model"] = options.get("model") or metadata.get("edit_model") or metadata.get("model")
+    metadata["edit_warnings"] = json.dumps(
+        recipe.get("warnings", []), ensure_ascii=False
+    )
+    metadata["edit_model"] = (
+        options.get("model") or metadata.get("edit_model") or metadata.get("model")
+    )
     if options.get("provider"):
         metadata["edit_provider"] = options["provider"]
     metadata["edit_run_date"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     metadata.setdefault("provider", options.get("provider"))
     metadata.setdefault("model", options.get("model"))
-    metadata.setdefault("has_embedding", bool(existing_meta.get("has_embedding", False)))
+    metadata.setdefault(
+        "has_embedding", bool(existing_meta.get("has_embedding", False))
+    )
 
     if existing_has_ids:
-        chroma_service.update_image(photo_id, metadata, embedding=existing_embedding, catalog_id=catalog_id)
+        chroma_service.update_image(
+            photo_id, metadata, embedding=existing_embedding, catalog_id=catalog_id
+        )
     else:
-        chroma_service.add_image(photo_id, existing_embedding, metadata, catalog_id=catalog_id)
+        chroma_service.add_image(
+            photo_id, existing_embedding, metadata, catalog_id=catalog_id
+        )
 
 
-def _success_payload(photo_id: str, recipe: dict, options: dict, warning: str | None = None) -> dict:
+def _success_payload(
+    photo_id: str, recipe: dict, options: dict, warning: str | None = None
+) -> dict:
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     payload = {
         "status": "success",
@@ -82,9 +104,17 @@ def generate_edit_recipe():
     options = _extract_options(request.form)
 
     if not images or not photo_ids or len(images) != len(photo_ids):
-        return jsonify({"error": "Mismatch between number of images and photo IDs, or no images provided"}), 400
+        return jsonify(
+            {
+                "error": "Mismatch between number of images and photo IDs, or no images provided"
+            }
+        ), 400
     if len(images) != 1:
-        return jsonify({"error": "The /edit endpoint currently supports exactly one photo per request"}), 400
+        return jsonify(
+            {
+                "error": "The /edit endpoint currently supports exactly one photo per request"
+            }
+        ), 400
 
     file = images[0]
     photo_id = photo_ids[0]
@@ -92,12 +122,18 @@ def generate_edit_recipe():
         return jsonify({"error": "Missing file or photo_id"}), 400
 
     analysis_service = get_analysis_service()
-    response = analysis_service.generate_edit_recipe_single(photo_id, file.read(), options)
+    response = analysis_service.generate_edit_recipe_single(
+        photo_id, file.read(), options
+    )
     if not response.success or not response.recipe:
-        return jsonify({"status": "error", "error": response.error or "Edit generation failed"}), 500
+        return jsonify(
+            {"status": "error", "error": response.error or "Edit generation failed"}
+        ), 500
 
     _persist_edit_recipe(photo_id, file.filename, response.recipe, options)
-    payload = _success_payload(photo_id, response.recipe, options, warning=response.warning)
+    payload = _success_payload(
+        photo_id, response.recipe, options, warning=response.warning
+    )
     payload["input_tokens"] = response.input_tokens
     payload["output_tokens"] = response.output_tokens
     return jsonify(payload), 200
@@ -112,16 +148,24 @@ def generate_edit_recipe_base64():
     filename = data.get("filename")
 
     if not image_b64 or not photo_id or not filename:
-        return jsonify({"error": "Missing required fields: image, photo_id, filename"}), 400
+        return jsonify(
+            {"error": "Missing required fields: image, photo_id, filename"}
+        ), 400
 
     options = _extract_options(data)
     analysis_service = get_analysis_service()
-    response = analysis_service.generate_edit_recipe_single(photo_id, base64.b64decode(image_b64.encode("ascii")), options)
+    response = analysis_service.generate_edit_recipe_single(
+        photo_id, base64.b64decode(image_b64.encode("ascii")), options
+    )
     if not response.success or not response.recipe:
-        return jsonify({"status": "error", "error": response.error or "Edit generation failed"}), 500
+        return jsonify(
+            {"status": "error", "error": response.error or "Edit generation failed"}
+        ), 500
 
     _persist_edit_recipe(photo_id, filename, response.recipe, options)
-    payload = _success_payload(photo_id, response.recipe, options, warning=response.warning)
+    payload = _success_payload(
+        photo_id, response.recipe, options, warning=response.warning
+    )
     payload["input_tokens"] = response.input_tokens
     payload["output_tokens"] = response.output_tokens
     return jsonify(payload), 200

--- a/server/src/routes_faces.py
+++ b/server/src/routes_faces.py
@@ -6,10 +6,10 @@ import service_persons as persons_service
 import base64
 
 
-faces_bp = Blueprint('faces', __name__)
+faces_bp = Blueprint("faces", __name__)
 
 
-@faces_bp.route('/faces/detect', methods=['POST'])
+@faces_bp.route("/faces/detect", methods=["POST"])
 def detect_faces_in_image():
     """
     Detect all faces in an image and return thumbnails for selection.
@@ -38,7 +38,7 @@ def detect_faces_in_image():
     return jsonify({"status": "ok", "faces": result_faces}), 200
 
 
-@faces_bp.route('/faces/query', methods=['POST'])
+@faces_bp.route("/faces/query", methods=["POST"])
 def query_faces_by_image():
     """
     Find indexed faces similar to the face(s) in the given image.
@@ -70,7 +70,14 @@ def query_faces_by_image():
     distances = result.get("distances", [[]])[0]
     metadatas = result.get("metadatas", [[]])[0]
     results = [
-        {"face_id": fid, "photo_id": m.get("photo_id") or m.get("photo_uuid"), "photo_uuid": m.get("photo_uuid") or m.get("photo_id"), "thumbnail": m.get("thumbnail", ""), "person_id": m.get("person_id", ""), "distance": d}
+        {
+            "face_id": fid,
+            "photo_id": m.get("photo_id") or m.get("photo_uuid"),
+            "photo_uuid": m.get("photo_uuid") or m.get("photo_id"),
+            "thumbnail": m.get("thumbnail", ""),
+            "person_id": m.get("person_id", ""),
+            "distance": d,
+        }
         for fid, m, d in zip(ids, metadatas or [], distances or [])
     ]
     return jsonify({"status": "ok", "results": results}), 200
@@ -78,7 +85,8 @@ def query_faces_by_image():
 
 # --- Person grouping (cluster + name) ---
 
-@faces_bp.route('/faces/cluster', methods=['POST'])
+
+@faces_bp.route("/faces/cluster", methods=["POST"])
 def cluster_faces():
     """
     Run clustering on all face embeddings and assign person_id to each face.
@@ -111,7 +119,7 @@ def cluster_faces():
         return jsonify({"error": str(e)}), 500
 
 
-@faces_bp.route('/faces/persons', methods=['GET'])
+@faces_bp.route("/faces/persons", methods=["GET"])
 def list_persons():
     """List all persons (cluster groups) with name, face_count, photo_count (no thumbnails)."""
     logger.info("List persons request received")
@@ -123,19 +131,21 @@ def list_persons():
         return jsonify({"error": str(e)}), 500
 
 
-@faces_bp.route('/faces/persons/<person_id>/thumbnail', methods=['GET'])
+@faces_bp.route("/faces/persons/<person_id>/thumbnail", methods=["GET"])
 def get_person_thumbnail(person_id):
     """Return base64 JPEG thumbnail for one face of this person (lazy load for UI)."""
     logger.info("Get person thumbnail request received for person_id=%s", person_id)
     try:
         thumb = persons_service.get_person_thumbnail_b64(person_id)
-        return jsonify({"status": "ok", "person_id": person_id, "thumbnail": thumb}), 200
+        return jsonify(
+            {"status": "ok", "person_id": person_id, "thumbnail": thumb}
+        ), 200
     except Exception as e:
         logger.error(f"Get person thumbnail failed: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 
-@faces_bp.route('/faces/persons/<person_id>', methods=['PUT'])
+@faces_bp.route("/faces/persons/<person_id>", methods=["PUT"])
 def set_person_name_route(person_id):
     """Set display name for a person. Body: { \"name\": \"Alice\" }."""
     logger.info("Set person name request received for person_id=%s", person_id)
@@ -145,19 +155,28 @@ def set_person_name_route(person_id):
         name = str(name)
     try:
         persons_service.set_person_name(person_id, name)
-        return jsonify({"status": "ok", "person_id": person_id, "name": name.strip()}), 200
+        return jsonify(
+            {"status": "ok", "person_id": person_id, "name": name.strip()}
+        ), 200
     except Exception as e:
         logger.error(f"Set person name failed: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
 
 
-@faces_bp.route('/faces/persons/<person_id>/photos', methods=['GET'])
+@faces_bp.route("/faces/persons/<person_id>/photos", methods=["GET"])
 def get_photos_for_person(person_id):
     """Get list of photo IDs that contain this person."""
     logger.info("Get photos for person request received for person_id=%s", person_id)
     try:
         photo_ids = persons_service.get_photo_ids_for_person(person_id)
-        return jsonify({"status": "ok", "person_id": person_id, "photo_ids": photo_ids, "photo_uuids": photo_ids}), 200
+        return jsonify(
+            {
+                "status": "ok",
+                "person_id": person_id,
+                "photo_ids": photo_ids,
+                "photo_uuids": photo_ids,
+            }
+        ), 200
     except Exception as e:
         logger.error(f"Get photos for person failed: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500

--- a/server/src/routes_import.py
+++ b/server/src/routes_import.py
@@ -2,9 +2,10 @@ from flask import Blueprint, request, jsonify
 from config import logger
 import service_import as import_service
 
-import_bp = Blueprint('import', __name__)
+import_bp = Blueprint("import", __name__)
 
-@import_bp.route('/import/metadata', methods=['POST'])
+
+@import_bp.route("/import/metadata", methods=["POST"])
 def import_metadata_batch():
     """
     Receives a batch of metadata from previous LLM runs and imports them to ChromaDB.
@@ -12,19 +13,29 @@ def import_metadata_batch():
     logger.info("Import metadata request received")
     data = request.get_json()
 
-    if not data or 'metadata_items' not in data:
+    if not data or "metadata_items" not in data:
         return jsonify({"error": "No data or metadata_items provided"}), 400
 
-    metadata_items = data['metadata_items']
+    metadata_items = data["metadata_items"]
     if not isinstance(metadata_items, list):
         return jsonify({"error": "metadata_items should be a list"}), 400
 
-    catalog_id = data.get('catalog_id')
-    success_count, failure_count = import_service.import_metadata_task(metadata_items, catalog_id=catalog_id)
+    catalog_id = data.get("catalog_id")
+    success_count, failure_count = import_service.import_metadata_task(
+        metadata_items, catalog_id=catalog_id
+    )
 
-    logger.info(f"Metadata import complete. Success: {success_count}, Failures: {failure_count}.")
+    logger.info(
+        f"Metadata import complete. Success: {success_count}, Failures: {failure_count}."
+    )
 
     if success_count == 0 and failure_count > 0:
         return jsonify({"error": "No metadata was successfully imported"}), 500
 
-    return jsonify({"status": "processed", "success_count": success_count, "failure_count": failure_count}), 200
+    return jsonify(
+        {
+            "status": "processed",
+            "success_count": success_count,
+            "failure_count": failure_count,
+        }
+    ), 200

--- a/server/src/routes_index.py
+++ b/server/src/routes_index.py
@@ -9,7 +9,7 @@ from service_index import process_image_task, get_photo_ids_needing_processing
 import base64
 import json
 
-index_bp = Blueprint('index', __name__)
+index_bp = Blueprint("index", __name__)
 
 # Store timestamps of the last 100 requests to calculate processing speed
 request_timestamps = deque(maxlen=100)
@@ -26,155 +26,193 @@ def _parse_json_field(value, default=None):
             return default
     return value
 
+
 def _extract_options(data):
     """Extracts options from request data (form or json)."""
     options = {}
     try:
         from config import logger as _tmp_logger
-        _tmp_logger.info(f"Raw indexing option keys received: {list(getattr(data, 'keys', lambda: [])())}")
+
+        _tmp_logger.info(
+            f"Raw indexing option keys received: {list(getattr(data, 'keys', lambda: [])())}"
+        )
     except Exception:
         pass
-    options['provider'] = data.get('provider')
-    options['model'] = data.get('model')
-    options['api_key'] = data.get('api_key')
-    options['language'] = data.get('language', 'German')
-    options['temperature'] = float(data.get('temperature', 0.2))
-    options['max_tokens'] = data.get('max_tokens')
-    options['generate_keywords'] = str(data.get('generate_keywords', 'true')).lower() == 'true'
-    options['generate_caption'] = str(data.get('generate_caption', 'true')).lower() == 'true'
-    options['generate_title'] = str(data.get('generate_title', 'true')).lower() == 'true'
-    options['generate_alt_text'] = str(data.get('generate_alt_text', 'true')).lower() == 'true'
-    options['submit_gps'] = str(data.get('submit_gps', 'false')).lower() == 'true'
-    options['submit_keywords'] = str(data.get('submit_keywords', 'false')).lower() == 'true'
-    options['submit_folder_names'] = str(data.get('submit_folder_names', 'false')).lower() == 'true'
-    raw_existing = _parse_json_field(data.get('existing_keywords'))
+    options["provider"] = data.get("provider")
+    options["model"] = data.get("model")
+    options["api_key"] = data.get("api_key")
+    options["language"] = data.get("language", "German")
+    options["temperature"] = float(data.get("temperature", 0.2))
+    options["max_tokens"] = data.get("max_tokens")
+    options["generate_keywords"] = (
+        str(data.get("generate_keywords", "true")).lower() == "true"
+    )
+    options["generate_caption"] = (
+        str(data.get("generate_caption", "true")).lower() == "true"
+    )
+    options["generate_title"] = (
+        str(data.get("generate_title", "true")).lower() == "true"
+    )
+    options["generate_alt_text"] = (
+        str(data.get("generate_alt_text", "true")).lower() == "true"
+    )
+    options["submit_gps"] = str(data.get("submit_gps", "false")).lower() == "true"
+    options["submit_keywords"] = (
+        str(data.get("submit_keywords", "false")).lower() == "true"
+    )
+    options["submit_folder_names"] = (
+        str(data.get("submit_folder_names", "false")).lower() == "true"
+    )
+    raw_existing = _parse_json_field(data.get("existing_keywords"))
     # Lightroom may send keywordTagsForExport as a comma-separated string; normalize to list
     # so ", ".join(existing_keywords) in the prompt does not iterate over characters (issue #45).
     if raw_existing is None:
-        options['existing_keywords'] = None
+        options["existing_keywords"] = None
     elif isinstance(raw_existing, str):
-        options['existing_keywords'] = [k.strip() for k in raw_existing.split(',') if k.strip()]
+        options["existing_keywords"] = [
+            k.strip() for k in raw_existing.split(",") if k.strip()
+        ]
     elif isinstance(raw_existing, list):
-        options['existing_keywords'] = [str(k).strip() for k in raw_existing if str(k).strip()]
+        options["existing_keywords"] = [
+            str(k).strip() for k in raw_existing if str(k).strip()
+        ]
     else:
-        options['existing_keywords'] = None
-    options['gps_coordinates'] = _parse_json_field(data.get('gps_coordinates'))
-    options['folder_names'] = data.get('folder_names')
-    options['user_context'] = data.get('user_context')
-    
-    keyword_categories_raw = data.get('keyword_categories', '[]')
+        options["existing_keywords"] = None
+    options["gps_coordinates"] = _parse_json_field(data.get("gps_coordinates"))
+    options["folder_names"] = data.get("folder_names")
+    options["user_context"] = data.get("user_context")
+
+    keyword_categories_raw = data.get("keyword_categories", "[]")
     if isinstance(keyword_categories_raw, str):
         try:
-            options['keyword_categories'] = json.loads(keyword_categories_raw)
+            options["keyword_categories"] = json.loads(keyword_categories_raw)
         except json.JSONDecodeError:
-            options['keyword_categories'] = []
+            options["keyword_categories"] = []
     else:
-        options['keyword_categories'] = keyword_categories_raw
+        options["keyword_categories"] = keyword_categories_raw
 
-    options['bilingual_keywords'] = str(data.get('bilingual_keywords', 'false')).lower() == 'true'
-    options['keyword_secondary_language'] = data.get('keyword_secondary_language') or None
+    options["bilingual_keywords"] = (
+        str(data.get("bilingual_keywords", "false")).lower() == "true"
+    )
+    options["keyword_secondary_language"] = (
+        data.get("keyword_secondary_language") or None
+    )
 
-    options['replace_ss'] = str(data.get('replace_ss', 'false')).lower() == 'true'
-    options['ollama_base_url'] = data.get('ollama_base_url') or None  # Optional: use custom Ollama host
-    options['lmstudio_base_url'] = data.get('lmstudio_base_url') or None  # Optional: use custom LM Studio host
+    options["replace_ss"] = str(data.get("replace_ss", "false")).lower() == "true"
+    options["ollama_base_url"] = (
+        data.get("ollama_base_url") or None
+    )  # Optional: use custom Ollama host
+    options["lmstudio_base_url"] = (
+        data.get("lmstudio_base_url") or None
+    )  # Optional: use custom LM Studio host
     # Support both snake_case and camelCase keys from clients
-    reg_val = data.get('regenerate_metadata')
+    reg_val = data.get("regenerate_metadata")
     if reg_val is None:
-        reg_val = data.get('regenerateMetadata', 'true')
-    options['regenerate_metadata'] = str(reg_val).lower() == 'true'
-    options['prompt'] = data.get('prompt')
-    options['edit_intent'] = data.get('edit_intent')
+        reg_val = data.get("regenerateMetadata", "true")
+    options["regenerate_metadata"] = str(reg_val).lower() == "true"
+    options["prompt"] = data.get("prompt")
+    options["edit_intent"] = data.get("edit_intent")
     try:
-        options['style_strength'] = float(data.get('style_strength', 0.5))
+        options["style_strength"] = float(data.get("style_strength", 0.5))
     except (TypeError, ValueError):
-        options['style_strength'] = 0.5
-    if options['style_strength'] < 0.0:
-        options['style_strength'] = 0.0
-    if options['style_strength'] > 1.0:
-        options['style_strength'] = 1.0
-    include_masks_val = data.get('include_masks')
+        options["style_strength"] = 0.5
+    if options["style_strength"] < 0.0:
+        options["style_strength"] = 0.0
+    if options["style_strength"] > 1.0:
+        options["style_strength"] = 1.0
+    include_masks_val = data.get("include_masks")
     if include_masks_val is None:
-        include_masks_val = 'true'
-    options['include_masks'] = str(include_masks_val).lower() == 'true'
-    adjust_wb_val = data.get('adjust_white_balance')
+        include_masks_val = "true"
+    options["include_masks"] = str(include_masks_val).lower() == "true"
+    adjust_wb_val = data.get("adjust_white_balance")
     if adjust_wb_val is None:
-        adjust_wb_val = 'true'
-    options['adjust_white_balance'] = str(adjust_wb_val).lower() == 'true'
-    adjust_basic_tone_val = data.get('adjust_basic_tone')
+        adjust_wb_val = "true"
+    options["adjust_white_balance"] = str(adjust_wb_val).lower() == "true"
+    adjust_basic_tone_val = data.get("adjust_basic_tone")
     if adjust_basic_tone_val is None:
-        adjust_basic_tone_val = 'true'
-    options['adjust_basic_tone'] = str(adjust_basic_tone_val).lower() == 'true'
-    adjust_presence_val = data.get('adjust_presence')
+        adjust_basic_tone_val = "true"
+    options["adjust_basic_tone"] = str(adjust_basic_tone_val).lower() == "true"
+    adjust_presence_val = data.get("adjust_presence")
     if adjust_presence_val is None:
-        adjust_presence_val = 'true'
-    options['adjust_presence'] = str(adjust_presence_val).lower() == 'true'
-    adjust_color_mix_val = data.get('adjust_color_mix')
+        adjust_presence_val = "true"
+    options["adjust_presence"] = str(adjust_presence_val).lower() == "true"
+    adjust_color_mix_val = data.get("adjust_color_mix")
     if adjust_color_mix_val is None:
-        adjust_color_mix_val = 'true'
-    options['adjust_color_mix'] = str(adjust_color_mix_val).lower() == 'true'
-    do_color_grading_val = data.get('do_color_grading')
+        adjust_color_mix_val = "true"
+    options["adjust_color_mix"] = str(adjust_color_mix_val).lower() == "true"
+    do_color_grading_val = data.get("do_color_grading")
     if do_color_grading_val is None:
-        do_color_grading_val = 'true'
-    options['do_color_grading'] = str(do_color_grading_val).lower() == 'true'
-    use_tone_curve_val = data.get('use_tone_curve')
+        do_color_grading_val = "true"
+    options["do_color_grading"] = str(do_color_grading_val).lower() == "true"
+    use_tone_curve_val = data.get("use_tone_curve")
     if use_tone_curve_val is None:
-        use_tone_curve_val = 'true'
-    options['use_tone_curve'] = str(use_tone_curve_val).lower() == 'true'
-    use_point_curve_val = data.get('use_point_curve')
+        use_tone_curve_val = "true"
+    options["use_tone_curve"] = str(use_tone_curve_val).lower() == "true"
+    use_point_curve_val = data.get("use_point_curve")
     if use_point_curve_val is None:
-        use_point_curve_val = 'true'
-    options['use_point_curve'] = str(use_point_curve_val).lower() == 'true'
-    adjust_detail_val = data.get('adjust_detail')
+        use_point_curve_val = "true"
+    options["use_point_curve"] = str(use_point_curve_val).lower() == "true"
+    adjust_detail_val = data.get("adjust_detail")
     if adjust_detail_val is None:
-        adjust_detail_val = 'true'
-    options['adjust_detail'] = str(adjust_detail_val).lower() == 'true'
-    adjust_effects_val = data.get('adjust_effects')
+        adjust_detail_val = "true"
+    options["adjust_detail"] = str(adjust_detail_val).lower() == "true"
+    adjust_effects_val = data.get("adjust_effects")
     if adjust_effects_val is None:
-        adjust_effects_val = 'true'
-    options['adjust_effects'] = str(adjust_effects_val).lower() == 'true'
-    adjust_lens_corrections_val = data.get('adjust_lens_corrections')
+        adjust_effects_val = "true"
+    options["adjust_effects"] = str(adjust_effects_val).lower() == "true"
+    adjust_lens_corrections_val = data.get("adjust_lens_corrections")
     if adjust_lens_corrections_val is None:
-        adjust_lens_corrections_val = 'true'
-    options['adjust_lens_corrections'] = str(adjust_lens_corrections_val).lower() == 'true'
-    allow_auto_crop_val = data.get('allow_auto_crop')
+        adjust_lens_corrections_val = "true"
+    options["adjust_lens_corrections"] = (
+        str(adjust_lens_corrections_val).lower() == "true"
+    )
+    allow_auto_crop_val = data.get("allow_auto_crop")
     if allow_auto_crop_val is None:
-        allow_auto_crop_val = 'true'
-    options['allow_auto_crop'] = str(allow_auto_crop_val).lower() == 'true'
-    composition_mode = str(data.get('composition_mode', 'subtle')).lower().strip()
-    if composition_mode not in ('none', 'subtle', 'aggressive'):
-        composition_mode = 'subtle'
-    options['composition_mode'] = composition_mode
+        allow_auto_crop_val = "true"
+    options["allow_auto_crop"] = str(allow_auto_crop_val).lower() == "true"
+    composition_mode = str(data.get("composition_mode", "subtle")).lower().strip()
+    if composition_mode not in ("none", "subtle", "aggressive"):
+        composition_mode = "subtle"
+    options["composition_mode"] = composition_mode
     # Optional capture time from Lightroom catalog.
     # `date_time_unix` is a float seconds-since-epoch value; `date_time` is an
     # ISO/W3C string kept for backwards compatibility.
-    options['date_time'] = data.get('date_time')
-    options['date_time_unix'] = data.get('date_time_unix')
+    options["date_time"] = data.get("date_time")
+    options["date_time_unix"] = data.get("date_time_unix")
 
-    tasks_raw = data.get('tasks')
+    tasks_raw = data.get("tasks")
     if tasks_raw:
         if isinstance(tasks_raw, str):
             try:
-                tasks = json.loads(tasks_raw) if tasks_raw.startswith('[') else [t.strip() for t in tasks_raw.split(',')]
+                tasks = (
+                    json.loads(tasks_raw)
+                    if tasks_raw.startswith("[")
+                    else [t.strip() for t in tasks_raw.split(",")]
+                )
             except (json.JSONDecodeError, AttributeError):
-                tasks = [t.strip() for t in tasks_raw.split(',')]
+                tasks = [t.strip() for t in tasks_raw.split(",")]
         else:
             tasks = tasks_raw
     else:
-        tasks = ['embeddings'] # Default tasks
+        tasks = ["embeddings"]  # Default tasks
 
-    options['compute_embeddings'] = 'embeddings' in tasks
-    options['compute_metadata'] = 'metadata' in tasks
-    options['compute_faces'] = 'faces' in tasks
-    options['compute_vertexai'] = 'vertexai' in tasks
+    options["compute_embeddings"] = "embeddings" in tasks
+    options["compute_metadata"] = "metadata" in tasks
+    options["compute_faces"] = "faces" in tasks
+    options["compute_vertexai"] = "vertexai" in tasks
 
     # Vertex AI config (from Lightroom plugin manager)
-    options['vertex_project_id'] = data.get('vertex_project_id') or data.get('vertexProjectId')
-    options['vertex_location'] = data.get('vertex_location') or data.get('vertexLocation')
+    options["vertex_project_id"] = data.get("vertex_project_id") or data.get(
+        "vertexProjectId"
+    )
+    options["vertex_location"] = data.get("vertex_location") or data.get(
+        "vertexLocation"
+    )
 
     # Cross-catalog: optional catalog_id for soft-state and filtered reads
-    options['catalog_id'] = data.get('catalog_id') or None
-    if options['catalog_id'] and isinstance(options['catalog_id'], str):
-        options['catalog_id'] = options['catalog_id'].strip() or None
+    options["catalog_id"] = data.get("catalog_id") or None
+    if options["catalog_id"] and isinstance(options["catalog_id"], str):
+        options["catalog_id"] = options["catalog_id"].strip() or None
 
     return options
 
@@ -192,20 +230,25 @@ def _extract_photo_ids(form_or_json):
     uuid = form_or_json.get("uuid")
     return [uuid] if uuid else []
 
-@index_bp.route('/index', methods=['POST'])
+
+@index_bp.route("/index", methods=["POST"])
 def index_images_batch():
     """
     Receives a batch of images, processes them synchronously, and indexes them.
     Returns a 200 OK status once all images are processed.
     """
     logger.info("Index request received")
-    images = request.files.getlist('image')
+    images = request.files.getlist("image")
     photo_ids = _extract_photo_ids(request.form)
-    
+
     options = _extract_options(request.form)
 
     if not images or not photo_ids or len(images) != len(photo_ids):
-        return jsonify({"error": "Mismatch between number of images and photo IDs, or no images provided"}), 400
+        return jsonify(
+            {
+                "error": "Mismatch between number of images and photo IDs, or no images provided"
+            }
+        ), 400
 
     batch_size = len(images)
     current_time = time.time()
@@ -224,19 +267,27 @@ def index_images_batch():
         photo_id = photo_ids[i]
 
         if not file or not photo_id:
-            logger.warning("Skipping an entry in the batch due to missing file or photo_id.")
+            logger.warning(
+                "Skipping an entry in the batch due to missing file or photo_id."
+            )
             continue
 
         image_triplets.append((file.read(), photo_id, file.filename))
 
     if not image_triplets:
         logger.info("No valid images to process in the batch.")
-        return jsonify({"status": "processed", "success_count": 0, "failure_count": batch_size}), 200
+        return jsonify(
+            {"status": "processed", "success_count": 0, "failure_count": batch_size}
+        ), 200
 
-    success_count, failure_count, error_messages, warnings = process_image_task(image_triplets, options)
-    
-    logger.info(f"Batch processing complete. Success: {success_count}, Failures: {failure_count}.")
-    
+    success_count, failure_count, error_messages, warnings = process_image_task(
+        image_triplets, options
+    )
+
+    logger.info(
+        f"Batch processing complete. Success: {success_count}, Failures: {failure_count}."
+    )
+
     if success_count == 0:
         logger.warning("No images were successfully processed in the batch.")
         err_msg = "No images were successfully processed"
@@ -244,16 +295,19 @@ def index_images_batch():
             unique_errs = list(dict.fromkeys(error_messages))
             err_msg += ": " + " | ".join(unique_errs[:5])
         return jsonify({"error": err_msg}), 500
-    
-    return jsonify({
-        "status": "processed",
-        "success_count": success_count,
-        "failure_count": failure_count,
-        "error_messages": error_messages,
-        "warnings": warnings
-    }), 200
 
-@index_bp.route('/index_base64', methods=['POST'])
+    return jsonify(
+        {
+            "status": "processed",
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "error_messages": error_messages,
+            "warnings": warnings,
+        }
+    ), 200
+
+
+@index_bp.route("/index_base64", methods=["POST"])
 def index_images_batch_base64():
     """
     Receives a single image base64 encoded, processes it, and indexes it.
@@ -264,24 +318,27 @@ def index_images_batch_base64():
 
     if not data:
         return jsonify({"error": "No JSON payload provided"}), 400
-    
+
     # Extract required fields
-    image = data.get('image')
-    photo_id = data.get('photo_id') or data.get('uuid')
-    filename = data.get('filename')
+    image = data.get("image")
+    photo_id = data.get("photo_id") or data.get("uuid")
+    filename = data.get("filename")
 
     if not image or not photo_id or not filename:
         logger.info(f"{image}, {photo_id}, {filename}")
-        return jsonify({"error": "Missing required fields: image, photo_id, filename"}), 400
+        return jsonify(
+            {"error": "Missing required fields: image, photo_id, filename"}
+        ), 400
 
     options = _extract_options(data)
 
     success_count, failure_count, error_messages, warnings = process_image_task(
-        [(base64.b64decode(image.encode('ascii')), photo_id, filename)],
-        options=options
+        [(base64.b64decode(image.encode("ascii")), photo_id, filename)], options=options
     )
-    
-    logger.info(f"Batch processing complete. Success: {success_count}, Failures: {failure_count}.")
+
+    logger.info(
+        f"Batch processing complete. Success: {success_count}, Failures: {failure_count}."
+    )
 
     if success_count == 0:
         logger.warning("No images were successfully processed in the batch.")
@@ -290,20 +347,22 @@ def index_images_batch_base64():
             unique_errs = list(dict.fromkeys(error_messages))
             err_msg += ": " + " | ".join(unique_errs[:5])
         return jsonify({"error": err_msg}), 500
-        
-    return jsonify({
-        "status": "processed",
-        "success_count": success_count,
-        "failure_count": failure_count,
-        "error_messages": error_messages,
-        "warnings": warnings or []
-    }), 200
+
+    return jsonify(
+        {
+            "status": "processed",
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "error_messages": error_messages,
+            "warnings": warnings or [],
+        }
+    ), 200
 
 
-@index_bp.route('/index_by_reference', methods=['POST'])
+@index_bp.route("/index_by_reference", methods=["POST"])
 def index_images_batch_by_reference():
     """
-    Receives a batch of image references in a JSON payload, processes them, 
+    Receives a batch of image references in a JSON payload, processes them,
     and indexes them.
     """
     logger.info("Index by reference request received")
@@ -311,21 +370,25 @@ def index_images_batch_by_reference():
 
     if not data:
         return jsonify({"error": "No JSON payload provided"}), 400
-    
+
     logger.debug(f"Index by reference payload: {data}")
 
     options = _extract_options(data)
-    
+
     # Extract image list
-    images_data = data.get('images', [])
+    images_data = data.get("images", [])
 
     # Use a list comprehension to extract paths and photo IDs.
-    paths = [item.get('path') for item in images_data]
-    photo_ids = [item.get('photo_id') or item.get('uuid') for item in images_data]
+    paths = [item.get("path") for item in images_data]
+    photo_ids = [item.get("photo_id") or item.get("uuid") for item in images_data]
 
     # Check for missing keys or mismatched lengths (robustness).
     if not all(paths) or not all(photo_ids) or len(paths) != len(photo_ids):
-        return jsonify({"error": "Mismatch in data, or missing 'path' or 'photo_id' keys in some objects"}), 400
+        return jsonify(
+            {
+                "error": "Mismatch in data, or missing 'path' or 'photo_id' keys in some objects"
+            }
+        ), 400
 
     batch_size = len(paths)
 
@@ -336,11 +399,13 @@ def index_images_batch_by_reference():
         photo_id = photo_ids[i]
 
         if not path or not photo_id:
-            logger.warning("Skipping an entry in the batch due to missing file or photo_id.")
+            logger.warning(
+                "Skipping an entry in the batch due to missing file or photo_id."
+            )
             continue
 
         try:
-            with open(path, 'rb') as file:
+            with open(path, "rb") as file:
                 image_data = file.read()
 
             filename = os.path.basename(path)
@@ -355,15 +420,18 @@ def index_images_batch_by_reference():
     read_failures = len(failed_paths)
     if not image_triplets:
         logger.info("No valid image paths to process in the batch.")
-        return jsonify({"status": "processed", "success_count": 0, "failure_count": read_failures}), 200
+        return jsonify(
+            {"status": "processed", "success_count": 0, "failure_count": read_failures}
+        ), 200
 
     success_count, processing_failures, error_messages = process_image_task(
-        image_triplets,
-        options=options
+        image_triplets, options=options
     )
     total_failures = read_failures + processing_failures
-    
-    logger.info(f"Batch processing by reference complete. Success: {success_count}, Failures: {total_failures} ({read_failures} read failures, {processing_failures} processing failures).")
+
+    logger.info(
+        f"Batch processing by reference complete. Success: {success_count}, Failures: {total_failures} ({read_failures} read failures, {processing_failures} processing failures)."
+    )
 
     if success_count == 0:
         logger.warning("No images were successfully processed in the batch.")
@@ -372,29 +440,37 @@ def index_images_batch_by_reference():
             unique_errs = list(dict.fromkeys(error_messages))
             err_msg += ": " + " | ".join(unique_errs[:5])
         return jsonify({"error": err_msg}), 500
-    
-    return jsonify({"status": "processed", "success_count": success_count, "failure_count": total_failures}), 200
+
+    return jsonify(
+        {
+            "status": "processed",
+            "success_count": success_count,
+            "failure_count": total_failures,
+        }
+    ), 200
 
 
-@index_bp.route('/remove', methods=['POST'])
+@index_bp.route("/remove", methods=["POST"])
 def remove_image():
     logger.info("Remove request received")
     body = request.json or {}
-    photo_id = body.get('photo_id') or body.get('uuid')
+    photo_id = body.get("photo_id") or body.get("uuid")
     if not photo_id:
         return jsonify({"error": "No photo_id provided"}), 400
-    
+
     try:
         chroma_service.delete_image(photo_id)
         chroma_service.delete_faces_by_photo_uuid(photo_id)
-        logger.info(f"Image ID {photo_id} removed from ChromaDB (including face embeddings).")
+        logger.info(
+            f"Image ID {photo_id} removed from ChromaDB (including face embeddings)."
+        )
         return jsonify({"status": "removed", "photo_id": photo_id, "uuid": photo_id})
     except Exception as e:
         logger.error(f"Error removing image {photo_id}: {e}")
         return jsonify({"error": "photo_id not found or error during removal"}), 404
 
 
-@index_bp.route('/remove/metadata', methods=['POST'])
+@index_bp.route("/remove/metadata", methods=["POST"])
 def remove_metadata():
     """
     Clear only AI-generated metadata (title, caption, keywords, alt_text, etc.) for a photo.
@@ -403,7 +479,7 @@ def remove_metadata():
     """
     logger.info("Remove metadata request received")
     body = request.json or {}
-    photo_id = body.get('photo_id') or body.get('uuid')
+    photo_id = body.get("photo_id") or body.get("uuid")
     if not photo_id:
         return jsonify({"error": "No photo_id provided"}), 400
     try:
@@ -414,66 +490,66 @@ def remove_metadata():
         return jsonify({"status": "ok", "photo_id": photo_id, "uuid": photo_id})
     except Exception as e:
         logger.error(f"Error clearing metadata for {photo_id}: {e}", exc_info=True)
-        return jsonify({"error": "photo_id not found or error during metadata clear"}), 404
+        return jsonify(
+            {"error": "photo_id not found or error during metadata clear"}
+        ), 404
 
 
-@index_bp.route('/get', methods=['POST'])
+@index_bp.route("/get", methods=["POST"])
 def get_photo_data():
     """
     Retrieves stored metadata for a photo by photo_id.
-    
+
     JSON body parameters:
     - photo_id (string): The ID of the photo to retrieve
-    
+
     Returns:
     - status: "success" or "error"
     - photo_id: The photo ID
     - metadata: Dictionary with all metadata fields (title, caption, keywords, etc.)
     """
     logger.info("Get photo data request received")
-    
+
     body = request.json or {}
-    photo_id = body.get('photo_id') or body.get('uuid')
+    photo_id = body.get("photo_id") or body.get("uuid")
     if not photo_id:
         return jsonify({"status": "error", "error": "No photo_id provided"}), 400
-    
-    catalog_id = body.get('catalog_id')
+
+    catalog_id = body.get("catalog_id")
     try:
         # Get photo data from ChromaDB (catalog-scoped when catalog_id provided)
         photo_data = chroma_service.get_image(photo_id, catalog_id=catalog_id)
         logger.debug(f"Retrieved photo data for photo_id {photo_id}: {photo_data}")
-        
-        if not photo_data or not photo_data['ids']:
+
+        if not photo_data or not photo_data["ids"]:
             logger.warning(f"Photo with photo_id {photo_id} not found in database")
             return jsonify({"status": "error", "error": "Photo not found"}), 404
-        
+
         # Extract metadata
-        metadata_dict = photo_data['metadatas'][0] if photo_data['metadatas'] else {}
-        
+        metadata_dict = photo_data["metadatas"][0] if photo_data["metadatas"] else {}
+
         # Separate user-facing metadata from internal indexing fields
         metadata_fields = {}
         edit_recipe = None
         edit_warnings = []
-        
+
         # User metadata field names (from metadata generation)
-        metadata_keys = {
-            'title', 'caption', 'keywords', 'alt_text'
-        }
-        
-        ai_model = metadata_dict.get('model')
-        ai_rundate = metadata_dict.get('run_date')
+        metadata_keys = {"title", "caption", "keywords", "alt_text"}
+
+        ai_model = metadata_dict.get("model")
+        ai_rundate = metadata_dict.get("run_date")
 
         for key, value in metadata_dict.items():
             if key in metadata_keys:
                 logger.info(f"Processing metadata field {key}: {value}")
                 # Keywords must be returned as JSON string (not parsed) for plugin to handle
-                if key == 'keywords' and isinstance(value, str) and value:
+                if key == "keywords" and isinstance(value, str) and value:
                     # Keep keywords as JSON string for plugin to parse
                     # The plugin expects either:
                     # - JSON array: ["kw1", "kw2"]
                     # - JSON object: {"Category": ["kw1"], ...}
                     metadata_fields[key] = json.loads(value)
-                elif key == 'tokens_used' and isinstance(value, str) and value:
+                elif key == "tokens_used" and isinstance(value, str) and value:
                     try:
                         metadata_fields[key] = json.loads(value) if value else []
                     except (json.JSONDecodeError, ValueError):
@@ -481,82 +557,90 @@ def get_photo_data():
                         metadata_fields[key] = []
                 else:
                     metadata_fields[key] = value
-            elif key == 'edit_recipe' and isinstance(value, str) and value:
+            elif key == "edit_recipe" and isinstance(value, str) and value:
                 try:
                     edit_recipe = json.loads(value)
                 except (json.JSONDecodeError, ValueError):
                     logger.warning(f"Error decoding edit_recipe JSON for {photo_id}")
-            elif key == 'edit_warnings' and isinstance(value, str) and value:
+            elif key == "edit_warnings" and isinstance(value, str) and value:
                 try:
                     decoded_warnings = json.loads(value)
                     if isinstance(decoded_warnings, list):
                         edit_warnings = decoded_warnings
                 except (json.JSONDecodeError, ValueError):
                     logger.warning(f"Error decoding edit_warnings JSON for {photo_id}")
-        
-        logger.info(f"Retrieved data for photo {photo_id}: {len(metadata_fields)} metadata fields")
-        
-        return jsonify({
-            "status": "success",
-            "photo_id": photo_id,
-            "uuid": photo_id,
-            "metadata": metadata_fields,
-            "edit": edit_recipe,
-            "edit_summary": metadata_dict.get("edit_summary"),
-            "edit_warnings": edit_warnings,
-            "edit_model": metadata_dict.get("edit_model"),
-            "edit_rundate": metadata_dict.get("edit_run_date"),
-            "ai_model": ai_model,
-            "ai_rundate": ai_rundate
-        })
-        
+
+        logger.info(
+            f"Retrieved data for photo {photo_id}: {len(metadata_fields)} metadata fields"
+        )
+
+        return jsonify(
+            {
+                "status": "success",
+                "photo_id": photo_id,
+                "uuid": photo_id,
+                "metadata": metadata_fields,
+                "edit": edit_recipe,
+                "edit_summary": metadata_dict.get("edit_summary"),
+                "edit_warnings": edit_warnings,
+                "edit_model": metadata_dict.get("edit_model"),
+                "edit_rundate": metadata_dict.get("edit_run_date"),
+                "ai_model": ai_model,
+                "ai_rundate": ai_rundate,
+            }
+        )
+
     except Exception as e:
         logger.error(f"Error retrieving photo data for {photo_id}: {e}", exc_info=True)
         return jsonify({"status": "error", "error": str(e)}), 500
 
 
-@index_bp.route('/get/ids', methods=['GET'])
+@index_bp.route("/get/ids", methods=["GET"])
 def get_ids():
     """Get all indexed image IDs, optionally filtered by embedding status.
-    
+
     Query parameters:
         has_embedding (string): 'true' to get only images with real embeddings,
                                'false' to get only images with dummy embeddings,
                                omit to get all images.
     """
     logger.info("Get IDs request received")
-    
+
     # Parse has_embedding parameter
-    has_embedding_param = request.args.get('has_embedding')
+    has_embedding_param = request.args.get("has_embedding")
     has_embedding = None
     if has_embedding_param is not None:
-        has_embedding = has_embedding_param.lower() == 'true'
+        has_embedding = has_embedding_param.lower() == "true"
         logger.info(f"Filtering IDs by has_embedding={has_embedding}")
 
-    catalog_id = request.args.get('catalog_id')
-    ids_data = chroma_service.get_all_image_ids(has_embedding=has_embedding, catalog_id=catalog_id)
+    catalog_id = request.args.get("catalog_id")
+    ids_data = chroma_service.get_all_image_ids(
+        has_embedding=has_embedding, catalog_id=catalog_id
+    )
     logger.info(f"Returning {len(ids_data)} image IDs")
     return jsonify(ids_data)
 
 
-@index_bp.route('/index/check-unprocessed', methods=['POST'])
+@index_bp.route("/index/check-unprocessed", methods=["POST"])
 def check_unprocessed():
     """
     Returns UUIDs that need processing based on selected tasks and existing backend data.
     Used by the Lightroom plugin for "New or unprocessed photos" scope.
     """
     data = request.get_json() or {}
-    photo_ids = data.get('photo_ids') or data.get('uuids', [])
+    photo_ids = data.get("photo_ids") or data.get("uuids", [])
     if not photo_ids:
         return jsonify({"photo_ids": [], "uuids": []}), 200
 
     options = _extract_options(data)
     needing = get_photo_ids_needing_processing(photo_ids, options)
-    logger.info(f"check-unprocessed: {len(needing)} of {len(photo_ids)} photos need processing")
+    logger.info(
+        f"check-unprocessed: {len(needing)} of {len(photo_ids)} photos need processing"
+    )
     return jsonify({"photo_ids": needing, "uuids": needing}), 200
 
 
-@index_bp.route('/sync/cleanup', methods=['POST'])
+@index_bp.route("/sync/cleanup", methods=["POST"])
 def sync_cleanup():
     """
     Disassociate the given catalog_id from photos that are no longer in the provided photo_ids list.
@@ -564,8 +648,8 @@ def sync_cleanup():
     Body: { "catalog_id": "...", "photo_ids": ["id1", "id2", ...] }
     """
     data = request.get_json() or {}
-    catalog_id = data.get('catalog_id')
-    photo_ids = data.get('photo_ids')
+    catalog_id = data.get("catalog_id")
+    photo_ids = data.get("photo_ids")
     if not catalog_id:
         return jsonify({"error": "catalog_id is required"}), 400
     if photo_ids is not None and not isinstance(photo_ids, list):
@@ -578,7 +662,7 @@ def sync_cleanup():
         return jsonify({"error": str(e)}), 500
 
 
-@index_bp.route('/sync/claim', methods=['POST'])
+@index_bp.route("/sync/claim", methods=["POST"])
 def sync_claim():
     """
     Claim backend photos for this catalog: add catalog_id to each photo's catalog_ids.
@@ -588,7 +672,11 @@ def sync_claim():
     data = request.get_json() or {}
     catalog_id = data.get("catalog_id")
     photo_ids = data.get("photo_ids")
-    logger.info("sync/claim request: catalog_id=%s, photo_ids count=%s", catalog_id, len(photo_ids) if isinstance(photo_ids, list) else "n/a")
+    logger.info(
+        "sync/claim request: catalog_id=%s, photo_ids count=%s",
+        catalog_id,
+        len(photo_ids) if isinstance(photo_ids, list) else "n/a",
+    )
     if not catalog_id:
         return jsonify({"error": "catalog_id is required"}), 400
     if not isinstance(photo_ids, list):
@@ -599,4 +687,3 @@ def sync_claim():
     except Exception as e:
         logger.error(f"Sync claim failed: {e}", exc_info=True)
         return jsonify({"error": str(e)}), 500
-

--- a/server/src/routes_search.py
+++ b/server/src/routes_search.py
@@ -2,83 +2,106 @@ from flask import Blueprint, request, jsonify
 from config import logger, get_available_culling_presets
 import service_search
 
-search_bp = Blueprint('search', __name__)
+search_bp = Blueprint("search", __name__)
 
 
 def _parse_grouping_params(data):
-    photo_ids = data.get('photo_ids') or data.get('uuids')
+    photo_ids = data.get("photo_ids") or data.get("uuids")
 
-    phash_threshold_param = data.get('phash_threshold', 'auto')
-    if phash_threshold_param != 'auto':
+    phash_threshold_param = data.get("phash_threshold", "auto")
+    if phash_threshold_param != "auto":
         try:
             phash_threshold_param = int(phash_threshold_param)
         except (ValueError, TypeError):
             return None, jsonify({"error": "Invalid phash_threshold value"}), 400
 
-    clip_threshold_param = data.get('clip_threshold', 'auto')
-    if clip_threshold_param != 'auto':
+    clip_threshold_param = data.get("clip_threshold", "auto")
+    if clip_threshold_param != "auto":
         try:
             clip_threshold_param = float(clip_threshold_param)
         except (ValueError, TypeError):
             return None, jsonify({"error": "Invalid clip_threshold value"}), 400
 
-    time_delta_param = data.get('time_delta_seconds', 1)
+    time_delta_param = data.get("time_delta_seconds", 1)
     try:
         time_delta_param = int(time_delta_param)
     except (ValueError, TypeError):
         return None, jsonify({"error": "Invalid time_delta_seconds value"}), 400
 
-    culling_preset_param = data.get('culling_preset', 'default')
+    culling_preset_param = data.get("culling_preset", "default")
     if culling_preset_param is not None:
         culling_preset_param = str(culling_preset_param).strip().lower()
     if not culling_preset_param:
-        culling_preset_param = 'default'
+        culling_preset_param = "default"
     if culling_preset_param not in get_available_culling_presets():
-        return None, jsonify({
-            "error": "Invalid culling_preset value",
-            "available_presets": get_available_culling_presets(),
-        }), 400
+        return (
+            None,
+            jsonify(
+                {
+                    "error": "Invalid culling_preset value",
+                    "available_presets": get_available_culling_presets(),
+                }
+            ),
+            400,
+        )
 
     if not photo_ids or not isinstance(photo_ids, list):
-        return None, jsonify({"error": "Missing or invalid 'photo_ids' list in request body"}), 400
+        return (
+            None,
+            jsonify({"error": "Missing or invalid 'photo_ids' list in request body"}),
+            400,
+        )
 
-    return {
-        "photo_ids": photo_ids,
-        "phash_threshold": phash_threshold_param,
-        "clip_threshold": clip_threshold_param,
-        "time_delta_seconds": time_delta_param,
-        "culling_preset": culling_preset_param,
-    }, None, None
+    return (
+        {
+            "photo_ids": photo_ids,
+            "phash_threshold": phash_threshold_param,
+            "clip_threshold": clip_threshold_param,
+            "time_delta_seconds": time_delta_param,
+            "culling_preset": culling_preset_param,
+        },
+        None,
+        None,
+    )
 
-@search_bp.route('/search', methods=['GET', 'POST'])
+
+@search_bp.route("/search", methods=["GET", "POST"])
 def search_route():
     logger.info("Search request received")
     try:
-        term = request.args.get('term') or (request.is_json and request.get_json().get('term'))
+        term = request.args.get("term") or (
+            request.is_json and request.get_json().get("term")
+        )
         if not term:
             return jsonify({"error": "No search term provided"}), 400
 
-        quality_sort = request.args.get('quality_sort', None)
+        quality_sort = request.args.get("quality_sort", None)
 
         photo_ids_to_search = None
         search_sources = None
         vertex_project_id = None
         vertex_location = None
         catalog_id = None
-        if request.method == 'POST' and request.is_json:
+        if request.method == "POST" and request.is_json:
             body = request.get_json()
-            photo_ids_to_search = body.get('photo_ids') or body.get('uuids')
-            search_sources = body.get('search_sources')
-            vertex_project_id = body.get('vertex_project_id') or body.get('vertexProjectId')
-            vertex_location = body.get('vertex_location') or body.get('vertexLocation')
-            catalog_id = body.get('catalog_id')
+            photo_ids_to_search = body.get("photo_ids") or body.get("uuids")
+            search_sources = body.get("search_sources")
+            vertex_project_id = body.get("vertex_project_id") or body.get(
+                "vertexProjectId"
+            )
+            vertex_location = body.get("vertex_location") or body.get("vertexLocation")
+            catalog_id = body.get("catalog_id")
         if catalog_id is None:
-            catalog_id = request.args.get('catalog_id')
+            catalog_id = request.args.get("catalog_id")
 
         results, warning = service_search.search_images(
-            term, quality_sort, photo_ids_to_search, search_sources,
-            vertex_project_id=vertex_project_id, vertex_location=vertex_location,
-            catalog_id=catalog_id
+            term,
+            quality_sort,
+            photo_ids_to_search,
+            search_sources,
+            vertex_project_id=vertex_project_id,
+            vertex_location=vertex_location,
+            catalog_id=catalog_id,
         )
         response = {"results": results}
         if warning:
@@ -87,8 +110,9 @@ def search_route():
     except Exception as e:
         logger.error(f"Error during search: {e}", exc_info=True)
         return jsonify({"error": "An internal error occurred"}), 500
-    
-@search_bp.route('/group_similar', methods=['POST'])
+
+
+@search_bp.route("/group_similar", methods=["POST"])
 def group_similar_route():
     """Groups a list of images by similarity and sorts them by quality."""
     if not request.is_json:
@@ -116,44 +140,48 @@ def group_similar_route():
         return jsonify({"error": str(e)}), 500
 
 
-@search_bp.route('/find_similar', methods=['POST'])
+@search_bp.route("/find_similar", methods=["POST"])
 def find_similar_route():
     """Find photos similar to a given photo by perceptual hash (and optionally CLIP)."""
     if not request.is_json:
         return jsonify({"error": "Request must be JSON"}), 400
 
     data = request.get_json()
-    photo_id = data.get('photo_id') or data.get('uuid')
+    photo_id = data.get("photo_id") or data.get("uuid")
     if not photo_id or not str(photo_id).strip():
         return jsonify({"error": "Missing or invalid 'photo_id' in request body"}), 400
 
-    scope_photo_ids = data.get('scope_photo_ids') or data.get('scope_uuids')
-    max_results = data.get('max_results', 100)
+    scope_photo_ids = data.get("scope_photo_ids") or data.get("scope_uuids")
+    max_results = data.get("max_results", 100)
     try:
         max_results = max(1, min(int(max_results), 2000))
     except (TypeError, ValueError):
         max_results = 100
 
-    phash_max_hamming = data.get('phash_max_hamming', 10)
+    phash_max_hamming = data.get("phash_max_hamming", 10)
     if phash_max_hamming != "auto":
         try:
             phash_max_hamming = max(0, min(int(phash_max_hamming), 64))
         except (TypeError, ValueError):
             phash_max_hamming = 10
 
-    use_clip = data.get('use_clip', True)
+    use_clip = data.get("use_clip", True)
     if not isinstance(use_clip, bool):
         use_clip = str(use_clip).lower() in ("true", "1", "yes")
 
-    similarity_mode = (data.get('similarity_mode') or "phash").strip().lower()
+    similarity_mode = (data.get("similarity_mode") or "phash").strip().lower()
     if similarity_mode not in ("phash", "clip"):
         similarity_mode = "phash"
 
-    catalog_id = data.get('catalog_id') or request.args.get('catalog_id')
+    catalog_id = data.get("catalog_id") or request.args.get("catalog_id")
 
     logger.info(
         "find_similar: photo_id=%s similarity_mode=%s max_results=%s phash_max_hamming=%s use_clip=%s scope_photo_ids=%s catalog_id=%s",
-        photo_id, similarity_mode, max_results, phash_max_hamming, use_clip,
+        photo_id,
+        similarity_mode,
+        max_results,
+        phash_max_hamming,
+        use_clip,
         len(scope_photo_ids) if scope_photo_ids else 0,
         catalog_id or "(none)",
     )
@@ -177,7 +205,7 @@ def find_similar_route():
         return jsonify({"error": str(e)}), 500
 
 
-@search_bp.route('/cull', methods=['POST'])
+@search_bp.route("/cull", methods=["POST"])
 def cull_route():
     """High-level culling endpoint returning groups plus summary."""
     if not request.is_json:

--- a/server/src/routes_server.py
+++ b/server/src/routes_server.py
@@ -7,40 +7,41 @@ from config import logger
 from service_metadata import get_analysis_service
 import service_version
 
-server_bp = Blueprint('server', __name__)
+server_bp = Blueprint("server", __name__)
 
-@server_bp.route('/ping', methods=['GET'])
+
+@server_bp.route("/ping", methods=["GET"])
 def ping():
-    #logger.info("Ping request received")
+    # logger.info("Ping request received")
     return "pong"
 
 
-@server_bp.route('/shutdown', methods=['POST'])
+@server_bp.route("/shutdown", methods=["POST"])
 def shutdown():
     server_lifecycle.request_shutdown()
     return jsonify({"status": "Server is shutting down..."})
 
 
-@server_bp.route('/unload', methods=['POST'])
+@server_bp.route("/unload", methods=["POST"])
 def unload():
-    """ Unload models and collections from memory without stopping the server. """
+    """Unload models and collections from memory without stopping the server."""
     logger.info("Unload request received via API")
     server_lifecycle.unload_all_resources()
     return jsonify({"status": "Resources unloaded successfully."})
 
 
-@server_bp.route('/restart', methods=['POST'])
+@server_bp.route("/restart", methods=["POST"])
 def restart():
-    """ 
-    Gracefully shut down the server. 
-    If running as an OS service (launchd/Windows Service), it will be automatically restarted. 
+    """
+    Gracefully shut down the server.
+    If running as an OS service (launchd/Windows Service), it will be automatically restarted.
     """
     logger.info("Restart request received via API")
     server_lifecycle.request_shutdown()
     return jsonify({"status": "Restarting..."})
 
 
-@server_bp.route('/initialize', methods=['POST'])
+@server_bp.route("/initialize", methods=["POST"])
 def initialize():
     """
     Called by the Lightroom plugin to 'attach' the running service to a specific catalog.
@@ -50,20 +51,20 @@ def initialize():
     db_path = data.get("db_path")
     if not db_path:
         return jsonify({"error": "db_path is required"}), 400
-    
+
     import config
     import service_chroma
-    
+
     prev_db_path = config.DB_PATH
     if prev_db_path == db_path:
         return jsonify({"status": "already_initialized", "db_path": db_path})
-    
+
     logger.info(f"Initializing/Switching catalog database: {db_path}")
-    
+
     config.update_log_path(db_path)
     # Re-initialize logger if needed
     # but for now we focus on the database connection).
-    
+
     service_chroma.reset_chroma_client()
     # Trigger lazy re-initialization on next use or do it now:
     try:
@@ -76,20 +77,19 @@ def initialize():
         return jsonify({"error": str(e)}), 500
 
 
-
-@server_bp.route('/models', methods=['GET', 'POST'])
+@server_bp.route("/models", methods=["GET", "POST"])
 def list_models():
     """
     Returns all available multimodal models from all providers.
-    
+
     Dynamically checks availability of Ollama and LM Studio on each request.
     Always filters for multimodal (vision-capable) models only.
-    
-    POST JSON: { 
+
+    POST JSON: {
         openai_apikey?: str,  # Optional OpenAI API key for ChatGPT models
         gemini_apikey?: str   # Optional Gemini API key for Gemini models
     }
-    
+
     Returns: {
         "models": {
             "qwen": ["model1", "model2"],
@@ -101,21 +101,21 @@ def list_models():
     }
     """
     # Parse API keys and options from request
-    if request.method == 'POST':
+    if request.method == "POST":
         data = request.get_json(silent=True) or {}
-        openai_apikey = data.get('openai_apikey')
-        gemini_apikey = data.get('gemini_apikey')
-        ollama_base_url = data.get('ollama_base_url')
-        lmstudio_base_url = data.get('lmstudio_base_url')
+        openai_apikey = data.get("openai_apikey")
+        gemini_apikey = data.get("gemini_apikey")
+        ollama_base_url = data.get("ollama_base_url")
+        lmstudio_base_url = data.get("lmstudio_base_url")
     else:
         # Support GET for backward compatibility
-        openai_apikey = request.args.get('openai_apikey')
-        gemini_apikey = request.args.get('gemini_apikey')
-        ollama_base_url = request.args.get('ollama_base_url')
-        lmstudio_base_url = request.args.get('lmstudio_base_url')
+        openai_apikey = request.args.get("openai_apikey")
+        gemini_apikey = request.args.get("gemini_apikey")
+        ollama_base_url = request.args.get("ollama_base_url")
+        lmstudio_base_url = request.args.get("lmstudio_base_url")
 
     logger.info("Models request received - checking all providers")
-    
+
     try:
         # Get all available multimodal models
         # This will dynamically re-check Ollama and LM Studio availability
@@ -131,12 +131,12 @@ def list_models():
         return jsonify({"error": str(e)}), 500
 
 
-@server_bp.route('/version', methods=['GET'])
+@server_bp.route("/version", methods=["GET"])
 def version():
     return jsonify(service_version.get_backend_version_info())
 
 
-@server_bp.route('/version/check', methods=['POST'])
+@server_bp.route("/version/check", methods=["POST"])
 def version_check():
     data = request.get_json(silent=True) or {}
     plugin_version = data.get("plugin_version")
@@ -150,19 +150,21 @@ def version_check():
     )
     return jsonify(result), 200
 
-@server_bp.route('/health', methods=['GET'])
+
+@server_bp.route("/health", methods=["GET"])
 def health():
     """Return health status of various backend components."""
     health_data = {}
-    
+
     # Model health (CLIP)
     health_data.update(server_lifecycle.get_health_status())
-    
+
     # LLM Provider health
     health_data.update(get_analysis_service().get_health_status())
-    
+
     # Add face model status (simplified for now)
     import service_face
+
     try:
         service_face._get_face_app()
         health_data["face_model"] = "loaded"
@@ -174,14 +176,14 @@ def health():
     return jsonify(health_data)
 
 
-@server_bp.route('/logs', methods=['GET'])
+@server_bp.route("/logs", methods=["GET"])
 def get_logs():
     """
     Returns backend logs and optionally local Ollama logs if accessible.
     """
     logger.debug("GET /logs request received")
     logs = {}
-    
+
     # 1. Backend logs
     log_path = config.LOG_PATH
     if os.path.isfile(log_path):
@@ -197,7 +199,7 @@ def get_logs():
         except Exception as e:
             logger.error(f"Failed to read backend logs: {e}")
             logs["backend_error"] = str(e)
-            
+
     # 2. Try to find Ollama logs on the server's machine
     ollama_log_paths = [
         os.path.expanduser("~/.ollama/logs/server.log"),
@@ -213,7 +215,7 @@ def get_logs():
                 with open(p, "r", encoding="utf-8", errors="ignore") as f:
                     f.seek(0, 2)
                     size = f.tell()
-                    f.seek(max(0, size - 512 * 1024)) # Last 512KB
+                    f.seek(max(0, size - 512 * 1024))  # Last 512KB
                     logs["ollama"] = f.read()
                 break
             except Exception as e:
@@ -243,13 +245,13 @@ def get_logs():
     return jsonify(logs)
 
 
-@server_bp.route('/logs/raw/<log_type>', methods=['GET'])
+@server_bp.route("/logs/raw/<log_type>", methods=["GET"])
 def get_raw_log(log_type):
     """
     Returns the raw log file for the specified type (backend, ollama, lmstudio).
     """
     logger.debug(f"GET /logs/raw/{log_type} request received")
-    
+
     path = None
     if log_type == "backend":
         path = config.LOG_PATH
@@ -274,10 +276,8 @@ def get_raw_log(log_type):
             if os.path.isfile(p):
                 path = p
                 break
-    
+
     if path and os.path.isfile(path):
-        return send_file(path, mimetype='text/plain')
-    
+        return send_file(path, mimetype="text/plain")
+
     return jsonify({"error": f"Log file for {log_type} not found"}), 404
-
-

--- a/server/src/routes_style_edit.py
+++ b/server/src/routes_style_edit.py
@@ -9,6 +9,7 @@ When the training set is too small or confidence is too low and
 ``use_llm_fallback=true``, the request is transparently forwarded to
 the regular LLM-backed edit pipeline (re-using existing few-shot injection).
 """
+
 from __future__ import annotations
 
 
@@ -30,6 +31,7 @@ def _get_clip_embedding(photo_id: str):
         existing = chroma_service.get_image(photo_id)
         if existing and existing.get("ids") and existing.get("embeddings"):
             import numpy as np
+
             raw_emb = existing["embeddings"][0]
             if raw_emb is not None:
                 emb_arr = np.asarray(raw_emb, dtype=np.float32)
@@ -61,9 +63,17 @@ def style_edit():
     options = _extract_options(request.form)
 
     if not images or not photo_ids or len(images) != len(photo_ids):
-        return jsonify({"error": "Mismatch between number of images and photo IDs, or no images provided"}), 400
+        return jsonify(
+            {
+                "error": "Mismatch between number of images and photo IDs, or no images provided"
+            }
+        ), 400
     if len(images) != 1:
-        return jsonify({"error": "The /style_edit endpoint currently supports exactly one photo per request"}), 400
+        return jsonify(
+            {
+                "error": "The /style_edit endpoint currently supports exactly one photo per request"
+            }
+        ), 400
 
     file = images[0]
     photo_id = photo_ids[0]
@@ -71,7 +81,11 @@ def style_edit():
         return jsonify({"error": "Missing file or photo_id"}), 400
 
     image_bytes = file.read()
-    use_llm_fallback = request.form.get("use_llm_fallback", "false").lower() in ("1", "true", "yes")
+    use_llm_fallback = request.form.get("use_llm_fallback", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
     focal_length: float | None = None
     try:
@@ -107,7 +121,9 @@ def style_edit():
     # -------------------------------------------------------------------
     # LLM fallback when style engine couldn't produce a confident result
     # -------------------------------------------------------------------
-    if (result.engine == "none" or result.confidence < CONFIDENCE_LOW) and use_llm_fallback:
+    if (
+        result.engine == "none" or result.confidence < CONFIDENCE_LOW
+    ) and use_llm_fallback:
         logger.info(
             "Style engine confidence %.3f below threshold for photo_id=%s, falling back to LLM",
             result.confidence,
@@ -118,24 +134,32 @@ def style_edit():
 
         # Inject training examples as few-shot context in the LLM request
         if clip_embedding is not None:
-            training_examples = training_service.query_similar_training_examples(clip_embedding, n_results=3)
+            training_examples = training_service.query_similar_training_examples(
+                clip_embedding, n_results=3
+            )
         else:
             training_examples = []
         options["use_training_style"] = False  # already handled above
         options["_injected_training_examples"] = training_examples
 
         analysis_service = get_analysis_service()
-        llm_response = analysis_service.generate_edit_recipe_single(photo_id, image_bytes, options)
+        llm_response = analysis_service.generate_edit_recipe_single(
+            photo_id, image_bytes, options
+        )
 
         if not llm_response.success or not llm_response.recipe:
-            return jsonify({
-                "status": "error",
-                "engine": "llm",
-                "error": llm_response.error or "LLM edit generation failed",
-            }), 500
+            return jsonify(
+                {
+                    "status": "error",
+                    "engine": "llm",
+                    "error": llm_response.error or "LLM edit generation failed",
+                }
+            ), 500
 
         _persist_edit_recipe(photo_id, file.filename, llm_response.recipe, options)
-        payload = _success_payload(photo_id, llm_response.recipe, options, warning=llm_response.warning)
+        payload = _success_payload(
+            photo_id, llm_response.recipe, options, warning=llm_response.warning
+        )
         payload["engine"] = "llm"
         payload["confidence"] = round(result.confidence, 3)
         payload["matched_examples"] = result.matched_count
@@ -148,25 +172,29 @@ def style_edit():
     # Style engine had no result and fallback disabled — return error
     # -------------------------------------------------------------------
     if result.engine == "none":
-        return jsonify({
-            "status": "error",
-            "engine": "none",
-            "confidence": 0.0,
-            "matched_examples": 0,
-            "error": result.warning or "Style engine could not produce a result.",
-        }), 422  # Unprocessable – not a server error, just insufficient data
+        return jsonify(
+            {
+                "status": "error",
+                "engine": "none",
+                "confidence": 0.0,
+                "matched_examples": 0,
+                "error": result.warning or "Style engine could not produce a result.",
+            }
+        ), 422  # Unprocessable – not a server error, just insufficient data
 
     # -------------------------------------------------------------------
     # Successful style engine result
     # -------------------------------------------------------------------
     if not result.recipe:
-        return jsonify({
-            "status": "error",
-            "engine": "style",
-            "confidence": round(result.confidence, 3),
-            "matched_examples": result.matched_count,
-            "error": "Style engine returned an empty recipe.",
-        }), 500
+        return jsonify(
+            {
+                "status": "error",
+                "engine": "style",
+                "confidence": round(result.confidence, 3),
+                "matched_examples": result.matched_count,
+                "error": "Style engine returned an empty recipe.",
+            }
+        ), 500
 
     _persist_edit_recipe(photo_id, file.filename, result.recipe, options)
 

--- a/server/src/routes_training.py
+++ b/server/src/routes_training.py
@@ -10,6 +10,7 @@ GET  /training/stats    – Return aggregate style-profile statistics
 DELETE /training/<id>   – Remove one training example by photo_id
 DELETE /training        – Clear all training examples
 """
+
 from __future__ import annotations
 
 import json
@@ -56,21 +57,22 @@ def _compute_clip_embedding(image_bytes: bytes):
 # POST /training/add
 # ---------------------------------------------------------------------------
 
+
 @training_bp.route("/training/add", methods=["POST"])
 def add_training_example():
     """Accept a multipart/form-data upload with:
-        - photo_id          (form field, required)
-        - develop_settings  (form field, JSON string, required)
-        - image             (file, optional – used to compute CLIP embedding + exposure/scene metrics)
-        - label             (form field, optional)
-        - summary           (form field, optional)
-        - focal_length      (form field, float mm, optional)
-        - capture_time      (form field, float unix timestamp, optional)
-        - camera_make       (form field, string, optional)
-        - camera_model      (form field, string, optional)
-        - iso               (form field, float, optional)
-        - aperture          (form field, float, optional)
-        - shutter_speed     (form field, string, optional)
+    - photo_id          (form field, required)
+    - develop_settings  (form field, JSON string, required)
+    - image             (file, optional – used to compute CLIP embedding + exposure/scene metrics)
+    - label             (form field, optional)
+    - summary           (form field, optional)
+    - focal_length      (form field, float mm, optional)
+    - capture_time      (form field, float unix timestamp, optional)
+    - camera_make       (form field, string, optional)
+    - camera_model      (form field, string, optional)
+    - iso               (form field, float, optional)
+    - aperture          (form field, float, optional)
+    - shutter_speed     (form field, string, optional)
     """
     photo_id = request.form.get("photo_id", "").strip()
     if not photo_id:
@@ -160,10 +162,17 @@ def add_training_example():
         count = training_service.get_training_count()
         response_data = {"status": "ok", "photo_id": photo_id, "total_count": count}
         if image_file and embedding is None:
-            response_data["warning"] = "Could not compute CLIP embedding for training example. AI style prediction may be less accurate."
+            response_data["warning"] = (
+                "Could not compute CLIP embedding for training example. AI style prediction may be less accurate."
+            )
         return jsonify(response_data), 200
     except Exception as exc:
-        logger.error("Failed to add training example photo_id=%s: %s", photo_id, exc, exc_info=True)
+        logger.error(
+            "Failed to add training example photo_id=%s: %s",
+            photo_id,
+            exc,
+            exc_info=True,
+        )
         return jsonify({"error": str(exc)}), 500
 
 
@@ -171,11 +180,14 @@ def add_training_example():
 # GET /training/list
 # ---------------------------------------------------------------------------
 
+
 @training_bp.route("/training/list", methods=["GET"])
 def list_training_examples():
     try:
         examples = training_service.list_training_examples()
-        return jsonify({"status": "ok", "examples": examples, "count": len(examples)}), 200
+        return jsonify(
+            {"status": "ok", "examples": examples, "count": len(examples)}
+        ), 200
     except Exception as exc:
         logger.error("Failed to list training examples: %s", exc, exc_info=True)
         return jsonify({"error": str(exc)}), 500
@@ -184,6 +196,7 @@ def list_training_examples():
 # ---------------------------------------------------------------------------
 # GET /training/stats
 # ---------------------------------------------------------------------------
+
 
 @training_bp.route("/training/stats", methods=["GET"])
 def get_training_stats():
@@ -200,6 +213,7 @@ def get_training_stats():
 # GET /training/count
 # ---------------------------------------------------------------------------
 
+
 @training_bp.route("/training/count", methods=["GET"])
 def get_training_count():
     try:
@@ -214,22 +228,33 @@ def get_training_count():
 # DELETE /training/<photo_id>
 # ---------------------------------------------------------------------------
 
+
 @training_bp.route("/training/<path:photo_id>", methods=["DELETE"])
 def delete_training_example(photo_id: str):
     try:
         deleted = training_service.delete_training_example(photo_id)
         if deleted:
             count = training_service.get_training_count()
-            return jsonify({"status": "ok", "photo_id": photo_id, "total_count": count}), 200
-        return jsonify({"error": f"No training example found for photo_id={photo_id}"}), 404
+            return jsonify(
+                {"status": "ok", "photo_id": photo_id, "total_count": count}
+            ), 200
+        return jsonify(
+            {"error": f"No training example found for photo_id={photo_id}"}
+        ), 404
     except Exception as exc:
-        logger.error("Failed to delete training example photo_id=%s: %s", photo_id, exc, exc_info=True)
+        logger.error(
+            "Failed to delete training example photo_id=%s: %s",
+            photo_id,
+            exc,
+            exc_info=True,
+        )
         return jsonify({"error": str(exc)}), 500
 
 
 # ---------------------------------------------------------------------------
 # DELETE /training  (clear all)
 # ---------------------------------------------------------------------------
+
 
 @training_bp.route("/training", methods=["DELETE"])
 def clear_training_examples():

--- a/server/src/server_lifecycle.py
+++ b/server/src/server_lifecycle.py
@@ -56,17 +56,19 @@ def is_model_cached() -> bool:
     with _model_lock:
         if model is not None:
             return True
-        
+
         try:
             cached_model_file = hf_hub_download(
                 repo_id=IMAGE_MODEL_ID,
                 filename="open_clip_model.safetensors",
-                local_files_only=True
+                local_files_only=True,
             )
             cached_model_dir = os.path.dirname(cached_model_file)
             if os.path.isdir(cached_model_dir):
-                config_file = os.path.join(cached_model_dir, 'open_clip_config.json')
-                weights_file = os.path.join(cached_model_dir, 'open_clip_model.safetensors')
+                config_file = os.path.join(cached_model_dir, "open_clip_config.json")
+                weights_file = os.path.join(
+                    cached_model_dir, "open_clip_model.safetensors"
+                )
                 if os.path.isfile(config_file) and os.path.isfile(weights_file):
                     return True
             return False
@@ -89,21 +91,27 @@ def load_model():
                 cached_model_file = hf_hub_download(
                     repo_id=IMAGE_MODEL_ID,
                     filename="open_clip_model.safetensors",
-                    local_files_only=True
+                    local_files_only=True,
                 )
 
                 cached_model_dir = os.path.dirname(cached_model_file)
 
                 logger.info(f"Checking for cached model at: {cached_model_dir}")
-                
+
                 # Check if local model directory exists (production/bundled scenario)
                 if os.path.isdir(cached_model_dir):
                     # Verify model files exist
-                    config_file = os.path.join(cached_model_dir, 'open_clip_config.json')
-                    weights_file = os.path.join(cached_model_dir, 'open_clip_model.safetensors')
+                    config_file = os.path.join(
+                        cached_model_dir, "open_clip_config.json"
+                    )
+                    weights_file = os.path.join(
+                        cached_model_dir, "open_clip_model.safetensors"
+                    )
 
                     if os.path.isfile(config_file) and os.path.isfile(weights_file):
-                        logger.info(f"Loading OpenCLIP model from cached directory: {cached_model_dir}")
+                        logger.info(
+                            f"Loading OpenCLIP model from cached directory: {cached_model_dir}"
+                        )
 
                         # Preferred path for pip-installed open_clip_torch:
                         # use known architecture name + local checkpoint path.
@@ -117,8 +125,7 @@ def load_model():
                             # Backward compatibility for older vendored open_clip forks.
                             local_model_uri = f"local-dir:{cached_model_dir}"
                             model_obj, _, proc = open_clip.create_model_and_transforms(
-                                local_model_uri,
-                                pretrained=None
+                                local_model_uri, pretrained=None
                             )
                             try:
                                 tok = open_clip.get_tokenizer(local_model_uri)
@@ -128,23 +135,34 @@ def load_model():
                         _set_last_used()
                         logger.info("Loaded OpenCLIP model (lazy)")
                     else:
-                        logger.warning("Bundled model directory exists but required files missing")
-                        logger.warning(f"Config file exists: {os.path.isfile(config_file)}")
-                        logger.warning(f"Weights file exists: {os.path.isfile(weights_file)}")
+                        logger.warning(
+                            "Bundled model directory exists but required files missing"
+                        )
+                        logger.warning(
+                            f"Config file exists: {os.path.isfile(config_file)}"
+                        )
+                        logger.warning(
+                            f"Weights file exists: {os.path.isfile(weights_file)}"
+                        )
                         raise FileNotFoundError("Bundled model files incomplete")
 
                     try:
                         model_obj.to(TORCH_DEVICE)
                         logger.info(f"Text and vision model moved to {TORCH_DEVICE}")
                     except Exception as e:
-                        logger.warning(f"Failed to move text and vision model to {TORCH_DEVICE}: {e}.")
+                        logger.warning(
+                            f"Failed to move text and vision model to {TORCH_DEVICE}: {e}."
+                        )
 
                     model = model_obj
                     processor = proc
                     tokenizer = wrap_tokenizer(tok)
 
             except Exception as e:
-                logger.warning(f"Failed to load OpenCLIP model from local cache. This can happen if the model is not fully downloaded, is corrupted, or if there is a configuration issue. The error was: {e}", exc_info=True)
+                logger.warning(
+                    f"Failed to load OpenCLIP model from local cache. This can happen if the model is not fully downloaded, is corrupted, or if there is a configuration issue. The error was: {e}",
+                    exc_info=True,
+                )
                 logger.info("Falling back to loading OpenCLIP model via hf-hub")
                 model_obj, _, proc = open_clip.create_model_and_transforms(
                     CLIP_MODEL_NAME,
@@ -155,7 +173,9 @@ def load_model():
                     model_obj.to(TORCH_DEVICE)
                     logger.info(f"Text and vision model moved to {TORCH_DEVICE}")
                 except Exception as move_exc:
-                    logger.warning(f"Failed to move text and vision model to {TORCH_DEVICE}: {move_exc}.")
+                    logger.warning(
+                        f"Failed to move text and vision model to {TORCH_DEVICE}: {move_exc}."
+                    )
 
                 model = model_obj
                 processor = proc
@@ -167,7 +187,6 @@ def load_model():
             _model_load_error = str(e)
             logger.error(f"Failed to load OpenCLIP model (lazy): {e}", exc_info=True)
             raise
-
 
 
 def unload_model():
@@ -207,27 +226,28 @@ def unload_model():
 def unload_all_resources():
     """Unload all heavy models and resources from memory."""
     logger.info("Unloading all resources (CLIP, InsightFace, ChromaDB)...")
-    
+
     # 1. CLIP (OpenCLIP)
     try:
         unload_model()
     except Exception as e:
         logger.error(f"Failed to unload CLIP model: {e}")
-        
+
     # 2. InsightFace
     try:
         service_face.unload_face_app()
     except Exception as e:
         logger.error(f"Failed to unload InsightFace model: {e}")
-        
+
     # 3. ChromaDB
     try:
         service_chroma.unload_collections()
     except Exception as e:
         logger.error(f"Failed to unload ChromaDB: {e}")
-        
+
     # 4. Final GC
     import gc
+
     gc.collect()
     logger.info("All resources unloaded successfully.")
 
@@ -251,7 +271,9 @@ def _idle_unloader_loop():
 def _ensure_unloader_thread():
     global _unloader_thread
     if _unloader_thread is None or not _unloader_thread.is_alive():
-        _unloader_thread = threading.Thread(target=_idle_unloader_loop, daemon=True, name="server_lifecycle_unloader")
+        _unloader_thread = threading.Thread(
+            target=_idle_unloader_loop, daemon=True, name="server_lifecycle_unloader"
+        )
         _unloader_thread.start()
 
 
@@ -273,8 +295,10 @@ def get_tokenizer():
     _ensure_unloader_thread()
     return tokenizer
 
+
 def get_db_dir():
     return os.path.dirname(DB_PATH) if DB_PATH else None
+
 
 def write_pid_file():
     db_dir = get_db_dir()
@@ -283,6 +307,7 @@ def write_pid_file():
     pid_file = os.path.join(db_dir, "lrgenius-server.pid")
     with open(pid_file, "w") as f:
         f.write(str(os.getpid()))
+
 
 def remove_pid_file():
     db_dir = get_db_dir()
@@ -294,6 +319,7 @@ def remove_pid_file():
     except FileNotFoundError:
         pass
 
+
 def write_ok_file():
     db_dir = get_db_dir()
     if not db_dir:
@@ -301,6 +327,7 @@ def write_ok_file():
     ok_file = os.path.join(db_dir, "lrgenius-server.OK")
     with open(ok_file, "w") as f:
         f.write("OK\n")
+
 
 def remove_ok_file():
     db_dir = get_db_dir()
@@ -312,10 +339,12 @@ def remove_ok_file():
     except FileNotFoundError:
         pass
 
+
 def request_shutdown():
     logger.info("Shutdown request received")
-    time.sleep(1) # Give time for the response to be sent
+    time.sleep(1)  # Give time for the response to be sent
     os.kill(os.getpid(), signal.SIGINT)
+
 
 def get_health_status():
     """Return health status of the model."""
@@ -324,8 +353,5 @@ def get_health_status():
         status = "loaded"
     elif _model_load_error is not None:
         status = "failed"
-    
-    return {
-        "clip_model": status,
-        "clip_error": _model_load_error
-    }
+
+    return {"clip_model": status, "clip_error": _model_load_error}

--- a/server/src/service_chroma.py
+++ b/server/src/service_chroma.py
@@ -11,9 +11,12 @@ collection = None
 face_collection = None
 vertex_collection = None
 
+
 class DatabaseNotReadyError(Exception):
     """Raised when a database modification is attempted but the DB_PATH is not yet set."""
+
     pass
+
 
 # InsightFace embeddings are 512-dimensional
 FACE_EMBEDDING_DIM = 512
@@ -128,15 +131,18 @@ def _ensure_initialized():
     global chroma_client, collection, face_collection, vertex_collection
     if chroma_client is not None:
         return
-    
+
     import config
+
     if not config.DB_PATH:
         logger.debug("ChromaDB initialization skipped: DB_PATH not set yet.")
         return
 
     logger.info(f"Initializing ChromaDB client at {config.DB_PATH} (lazy)...")
-    chroma_client = chromadb.PersistentClient(path=config.DB_PATH, settings=Settings(anonymized_telemetry=False))
-    
+    chroma_client = chromadb.PersistentClient(
+        path=config.DB_PATH, settings=Settings(anonymized_telemetry=False)
+    )
+
     # Initialize image_embeddings collection
     try:
         collection = chroma_client.get_collection(name="image_embeddings")
@@ -158,7 +164,9 @@ def _ensure_initialized():
         vertex_collection = chroma_client.get_collection(name="image_embeddings_vertex")
         logger.info("Loaded existing ChromaDB image_embeddings_vertex collection.")
     except Exception:
-        vertex_collection = chroma_client.create_collection(name="image_embeddings_vertex")
+        vertex_collection = chroma_client.create_collection(
+            name="image_embeddings_vertex"
+        )
         logger.info("Created new ChromaDB image_embeddings_vertex collection.")
 
 
@@ -183,6 +191,7 @@ def unload_collections():
     face_collection = None
     vertex_collection = None
     import gc
+
     gc.collect()
     logger.info("Unloaded ChromaDB collections.")
 
@@ -193,7 +202,7 @@ def add_image(photo_id, embedding, metadata, *, legacy_uuid=None, catalog_id=Non
     embedding may be None for metadata-only records; in that case we add
     a dummy zero vector with the expected dimensionality (1152) to satisfy
     ChromaDB's requirements while still allowing metadata-only storage.
-    
+
     Note: Metadata-only entries are marked with has_embedding=False in their
     metadata and are filtered out of semantic search results in service_search.py.
     They can still be found via metadata keyword searches.
@@ -202,7 +211,9 @@ def add_image(photo_id, embedding, metadata, *, legacy_uuid=None, catalog_id=Non
     """
     _ensure_initialized()
     if collection is None:
-        raise DatabaseNotReadyError("Cannot add image: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot add image: database not initialized (DB_PATH missing)."
+        )
     photo_id = _normalize_photo_id(photo_id, legacy_uuid)
     if not photo_id:
         raise ValueError("photo_id is required")
@@ -214,19 +225,28 @@ def add_image(photo_id, embedding, metadata, *, legacy_uuid=None, catalog_id=Non
             # Add metadata-only record with a dummy zero embedding
             # The collection expects 1152-dimensional embeddings (from vision model)
             dummy_embedding = np.zeros(1152, dtype=np.float32).tolist()
-            collection.add(embeddings=[dummy_embedding], metadatas=[metadata], ids=[photo_id])
+            collection.add(
+                embeddings=[dummy_embedding], metadatas=[metadata], ids=[photo_id]
+            )
         else:
             collection.add(embeddings=[embedding], metadatas=[metadata], ids=[photo_id])
     except Exception as e:
         # Surface a helpful log message and re-raise so callers can decide what to do.
-        logger.error(f"Failed to add image {photo_id} to ChromaDB (embedding provided: {embedding is not None}): {e}", exc_info=True)
+        logger.error(
+            f"Failed to add image {photo_id} to ChromaDB (embedding provided: {embedding is not None}): {e}",
+            exc_info=True,
+        )
         raise
 
 
-def update_image(photo_id, metadata, embedding=None, *, legacy_uuid=None, catalog_id=None):
+def update_image(
+    photo_id, metadata, embedding=None, *, legacy_uuid=None, catalog_id=None
+):
     _ensure_initialized()
     if collection is None:
-        raise DatabaseNotReadyError("Cannot update image: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot update image: database not initialized (DB_PATH missing)."
+        )
     photo_id = _normalize_photo_id(photo_id, legacy_uuid)
     if not photo_id:
         raise ValueError("photo_id is required")
@@ -270,11 +290,24 @@ def delete_image(photo_id, *, legacy_uuid=None):
 
 
 # Keys that hold AI-generated metadata; cleared by clear_image_metadata so the photo stays indexed.
-AI_METADATA_KEYS = frozenset({
-    "title", "caption", "keywords", "alt_text",
-    "model", "run_date", "tokens_used", "flattened_keywords",
-    "edit_recipe", "edit_summary", "edit_warnings", "edit_model", "edit_provider", "edit_run_date",
-})
+AI_METADATA_KEYS = frozenset(
+    {
+        "title",
+        "caption",
+        "keywords",
+        "alt_text",
+        "model",
+        "run_date",
+        "tokens_used",
+        "flattened_keywords",
+        "edit_recipe",
+        "edit_summary",
+        "edit_warnings",
+        "edit_model",
+        "edit_provider",
+        "edit_run_date",
+    }
+)
 
 
 def clear_image_metadata(photo_id, *, legacy_uuid=None):
@@ -293,7 +326,9 @@ def clear_image_metadata(photo_id, *, legacy_uuid=None):
     # Main collection: get current, strip AI fields, update (keep embedding)
     data = collection.get(ids=[photo_id], include=["metadatas", "embeddings"])
     if not data or not data.get("ids"):
-        logger.debug("clear_image_metadata: photo_id %s not in main collection", photo_id)
+        logger.debug(
+            "clear_image_metadata: photo_id %s not in main collection", photo_id
+        )
         return False
     meta = dict(data["metadatas"][0]) if data.get("metadatas") else {}
     embedding = _first_result_item(data.get("embeddings"))
@@ -306,7 +341,9 @@ def clear_image_metadata(photo_id, *, legacy_uuid=None):
         collection.update(ids=[photo_id], metadatas=[meta])
     # Vertex collection: same if present
     try:
-        vdata = vertex_collection.get(ids=[photo_id], include=["metadatas", "embeddings"])
+        vdata = vertex_collection.get(
+            ids=[photo_id], include=["metadatas", "embeddings"]
+        )
         if vdata and vdata.get("ids"):
             vmeta = dict(vdata["metadatas"][0]) if vdata.get("metadatas") else {}
             vemb = _first_result_item(vdata.get("embeddings"))
@@ -314,7 +351,9 @@ def clear_image_metadata(photo_id, *, legacy_uuid=None):
                 vmeta.pop(key, None)
             vmeta = _ensure_photo_metadata(photo_id, vmeta, legacy_uuid=legacy_uuid)
             if vemb is not None:
-                vertex_collection.update(ids=[photo_id], metadatas=[vmeta], embeddings=[vemb])
+                vertex_collection.update(
+                    ids=[photo_id], metadatas=[vmeta], embeddings=[vemb]
+                )
             else:
                 vertex_collection.update(ids=[photo_id], metadatas=[vmeta])
     except Exception as e:
@@ -324,11 +363,14 @@ def clear_image_metadata(photo_id, *, legacy_uuid=None):
 
 # --- Vertex AI image embeddings collection API ---
 
+
 def add_vertex_image(photo_id, embedding, metadata=None, *, legacy_uuid=None):
     """Add or overwrite Vertex AI embedding for an image."""
     _ensure_initialized()
     if vertex_collection is None:
-        raise DatabaseNotReadyError("Cannot add vertex image: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot add vertex image: database not initialized (DB_PATH missing)."
+        )
     photo_id = _normalize_photo_id(photo_id, legacy_uuid)
     if not photo_id:
         raise ValueError("photo_id is required")
@@ -337,23 +379,31 @@ def add_vertex_image(photo_id, embedding, metadata=None, *, legacy_uuid=None):
     metadata = _ensure_photo_metadata(photo_id, metadata, legacy_uuid=legacy_uuid)
     existing = vertex_collection.get(ids=[photo_id], include=[])
     if existing and existing.get("ids"):
-        vertex_collection.update(ids=[photo_id], embeddings=[embedding], metadatas=[metadata])
+        vertex_collection.update(
+            ids=[photo_id], embeddings=[embedding], metadatas=[metadata]
+        )
     else:
-        vertex_collection.add(ids=[photo_id], embeddings=[embedding], metadatas=[metadata])
+        vertex_collection.add(
+            ids=[photo_id], embeddings=[embedding], metadatas=[metadata]
+        )
 
 
 def update_vertex_image(photo_id, embedding=None, metadata=None, *, legacy_uuid=None):
     """Update Vertex AI embedding and/or metadata for an existing document."""
     _ensure_initialized()
     if vertex_collection is None:
-        raise DatabaseNotReadyError("Cannot update vertex image: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot update vertex image: database not initialized (DB_PATH missing)."
+        )
     photo_id = _normalize_photo_id(photo_id, legacy_uuid)
     if not photo_id:
         raise ValueError("photo_id is required")
     if metadata is not None:
         metadata = _ensure_photo_metadata(photo_id, metadata, legacy_uuid=legacy_uuid)
     if embedding is not None and metadata is not None:
-        vertex_collection.update(ids=[photo_id], embeddings=[embedding], metadatas=[metadata])
+        vertex_collection.update(
+            ids=[photo_id], embeddings=[embedding], metadatas=[metadata]
+        )
     elif embedding is not None:
         vertex_collection.update(ids=[photo_id], embeddings=[embedding])
     elif metadata is not None:
@@ -368,7 +418,7 @@ def get_vertex_image(photo_id, *, legacy_uuid=None):
     photo_id = _normalize_photo_id(photo_id, legacy_uuid)
     if not photo_id:
         return {"ids": [], "metadatas": [], "embeddings": []}
-    return vertex_collection.get(ids=[photo_id], include=['metadatas', 'embeddings'])
+    return vertex_collection.get(ids=[photo_id], include=["metadatas", "embeddings"])
 
 
 def delete_vertex_image(photo_id, *, legacy_uuid=None):
@@ -415,7 +465,12 @@ def query_vertex_images(query_embedding, n_results, where_clause=None, catalog_i
             n_results=min(n_fetch, STATS_GET_LIMIT),
             include=["metadatas", "distances"],
         )
-        if not catalog_id or not result or not result.get("ids") or not result["ids"][0]:
+        if (
+            not catalog_id
+            or not result
+            or not result.get("ids")
+            or not result["ids"][0]
+        ):
             return result
         allowed = set(get_all_image_ids(catalog_id=catalog_id))
         ids0 = result["ids"][0]
@@ -452,7 +507,12 @@ def query_images(query_embedding, n_results, where_clause=None, catalog_id=None)
             n_results=min(n_fetch, STATS_GET_LIMIT),
             include=["metadatas", "distances"],
         )
-        if not catalog_id or not result or not result.get("ids") or not result["ids"][0]:
+        if (
+            not catalog_id
+            or not result
+            or not result.get("ids")
+            or not result["ids"][0]
+        ):
             return result
         catalog_id_str = str(catalog_id).strip()
         keep = []
@@ -472,6 +532,7 @@ def query_images(query_embedding, n_results, where_clause=None, catalog_id=None)
     except Exception as e:
         logger.error(f"Error querying images: {e}", exc_info=True)
         return {"ids": [[]], "distances": [[]], "metadatas": [[]]}
+
 
 def get_image_count():
     """Return total number of indexed images (photos) in the collection."""
@@ -598,18 +659,29 @@ def sync_claim(catalog_id, photo_ids):
                 if emb is not None:
                     update_ids.append(pid)
                     update_metadatas.append(meta)
-                    update_embeddings.append(emb if not isinstance(emb, np.ndarray) else emb.tolist())
+                    update_embeddings.append(
+                        emb if not isinstance(emb, np.ndarray) else emb.tolist()
+                    )
                 else:
                     no_emb_ids.append(pid)
                     no_emb_metadatas.append(meta)
             if update_ids:
-                collection.update(ids=update_ids, metadatas=update_metadatas, embeddings=update_embeddings)
+                collection.update(
+                    ids=update_ids,
+                    metadatas=update_metadatas,
+                    embeddings=update_embeddings,
+                )
                 claimed += len(update_ids)
             if no_emb_ids:
                 collection.update(ids=no_emb_ids, metadatas=no_emb_metadatas)
                 claimed += len(no_emb_ids)
         except Exception as e:
-            logger.warning("sync_claim batch failed for chunk %s..%s: %s", start, start + len(chunk), e)
+            logger.warning(
+                "sync_claim batch failed for chunk %s..%s: %s",
+                start,
+                start + len(chunk),
+                e,
+            )
             errors += len(chunk)
     return {"claimed": claimed, "errors": errors}
 
@@ -647,7 +719,7 @@ def sync_cleanup(catalog_id, active_photo_ids):
 
 def get_all_image_ids(has_embedding=None, catalog_id=None):
     """Get all image IDs, optionally filtered by embedding status and/or catalog_id.
-    
+
     Args:
         has_embedding: If True, only return IDs with real embeddings.
                       If False, only return IDs with dummy embeddings.
@@ -728,7 +800,9 @@ def _phash_hamming_distance(left_hash, right_hash):
     return int((left_hash ^ right_hash).bit_count())
 
 
-def _derive_grouping_thresholds(phash_threshold, clip_threshold, time_delta, culling_config=None):
+def _derive_grouping_thresholds(
+    phash_threshold, clip_threshold, time_delta, culling_config=None
+):
     culling_config = culling_config or CULLING_CONFIG
     try:
         time_window_seconds = max(0, int(time_delta))
@@ -747,19 +821,28 @@ def _derive_grouping_thresholds(phash_threshold, clip_threshold, time_delta, cul
         phash_hamming_threshold = int(culling_config["grouping"]["phash_hamming_auto"])
     else:
         try:
-            phash_hamming_threshold = int(max(0.0, min(float(phash_threshold), culling_config["grouping"]["phash_max"])))
+            phash_hamming_threshold = int(
+                max(
+                    0.0,
+                    min(
+                        float(phash_threshold), culling_config["grouping"]["phash_max"]
+                    ),
+                )
+            )
         except (TypeError, ValueError):
-            phash_hamming_threshold = int(culling_config["grouping"]["phash_hamming_auto"])
+            phash_hamming_threshold = int(
+                culling_config["grouping"]["phash_hamming_auto"]
+            )
 
     phash_max = culling_config["grouping"]["phash_max"]
     normalized = max(0.0, min(float(phash_hamming_threshold), phash_max)) / phash_max
-    duplicate_distance_threshold = (
-        culling_config["grouping"]["duplicate_distance_min"]
-        + (normalized * culling_config["grouping"]["duplicate_distance_span"])
-    )
+    duplicate_distance_threshold = culling_config["grouping"][
+        "duplicate_distance_min"
+    ] + (normalized * culling_config["grouping"]["duplicate_distance_span"])
 
     duplicate_time_window_seconds = max(
-        time_window_seconds * culling_config["grouping"]["duplicate_time_window_multiplier"],
+        time_window_seconds
+        * culling_config["grouping"]["duplicate_time_window_multiplier"],
         culling_config["grouping"]["duplicate_time_window_min_seconds"],
     )
     return (
@@ -821,7 +904,10 @@ def _rank_group_records(component_records, group_type, culling_config=None):
         technical_score = _extract_culling_metric(
             metadata,
             "cull_technical_score",
-            (0.5 * sharpness) + (0.3 * exposure) + (0.1 * (1.0 - noise_penalty)) + (0.1 * (1.0 - clipping_penalty)),
+            (0.5 * sharpness)
+            + (0.3 * exposure)
+            + (0.1 * (1.0 - noise_penalty))
+            + (0.1 * (1.0 - clipping_penalty)),
         )
         aesthetic_score = _extract_culling_metric(metadata, "cull_aesthetic", 0.0)
         face_count = int(_safe_float((metadata or {}).get("cull_face_count"), 0) or 0)
@@ -835,64 +921,82 @@ def _rank_group_records(component_records, group_type, culling_config=None):
             "cull_face_score",
             (
                 (
-                    culling_config["face_metrics"]["score_weight_sharpness"] * face_sharpness
-                    + culling_config["face_metrics"]["score_weight_prominence"] * face_prominence
-                    + culling_config["face_metrics"]["score_weight_visibility"] * face_visibility
-                    + culling_config["face_metrics"]["score_weight_eye_openness"] * eye_openness
-                    + culling_config["face_metrics"]["score_weight_occlusion"] * (1.0 - occlusion_penalty)
-                ) / max(
+                    culling_config["face_metrics"]["score_weight_sharpness"]
+                    * face_sharpness
+                    + culling_config["face_metrics"]["score_weight_prominence"]
+                    * face_prominence
+                    + culling_config["face_metrics"]["score_weight_visibility"]
+                    * face_visibility
+                    + culling_config["face_metrics"]["score_weight_eye_openness"]
+                    * eye_openness
+                    + culling_config["face_metrics"]["score_weight_occlusion"]
+                    * (1.0 - occlusion_penalty)
+                )
+                / max(
                     1e-6,
                     culling_config["face_metrics"]["score_weight_sharpness"]
                     + culling_config["face_metrics"]["score_weight_prominence"]
                     + culling_config["face_metrics"]["score_weight_visibility"]
                     + culling_config["face_metrics"]["score_weight_eye_openness"]
-                    + culling_config["face_metrics"]["score_weight_occlusion"]
+                    + culling_config["face_metrics"]["score_weight_occlusion"],
                 )
             ),
         )
         blink_penalty = _extract_culling_metric(metadata, "cull_blink_penalty", 1.0)
 
-        scored_records.append({
-            **record,
-            "cull_sharpness": sharpness,
-            "cull_exposure": exposure,
-            "cull_noise": noise_penalty,
-            "cull_highlight_clip": highlight_clip,
-            "cull_shadow_clip": shadow_clip,
-            "cull_technical_score": technical_score,
-            "cull_aesthetic": aesthetic_score,
-            "cull_face_count": face_count,
-            "cull_face_sharpness": face_sharpness,
-            "cull_face_prominence": face_prominence,
-            "cull_face_visibility": face_visibility,
-            "cull_face_score": face_score,
-            "cull_occlusion": occlusion_penalty,
-            "cull_eye_openness": eye_openness,
-            "cull_blink_penalty": blink_penalty,
-        })
+        scored_records.append(
+            {
+                **record,
+                "cull_sharpness": sharpness,
+                "cull_exposure": exposure,
+                "cull_noise": noise_penalty,
+                "cull_highlight_clip": highlight_clip,
+                "cull_shadow_clip": shadow_clip,
+                "cull_technical_score": technical_score,
+                "cull_aesthetic": aesthetic_score,
+                "cull_face_count": face_count,
+                "cull_face_sharpness": face_sharpness,
+                "cull_face_prominence": face_prominence,
+                "cull_face_visibility": face_visibility,
+                "cull_face_score": face_score,
+                "cull_occlusion": occlusion_penalty,
+                "cull_eye_openness": eye_openness,
+                "cull_blink_penalty": blink_penalty,
+            }
+        )
 
     group_has_faces = any(item["cull_face_count"] > 0 for item in scored_records)
     for item in scored_records:
         if group_has_faces:
             if item["cull_face_count"] > 0:
                 weighted_score = (
-                    culling_config["ranking"]["face_group_weight_technical"] * item["cull_technical_score"]
-                    + culling_config["ranking"]["face_group_weight_face"] * item["cull_face_score"]
-                    + culling_config["ranking"]["face_group_weight_aesthetic"] * item["cull_aesthetic"]
+                    culling_config["ranking"]["face_group_weight_technical"]
+                    * item["cull_technical_score"]
+                    + culling_config["ranking"]["face_group_weight_face"]
+                    * item["cull_face_score"]
+                    + culling_config["ranking"]["face_group_weight_aesthetic"]
+                    * item["cull_aesthetic"]
                 )
                 weight_sum = (
                     culling_config["ranking"]["face_group_weight_technical"]
                     + culling_config["ranking"]["face_group_weight_face"]
                     + culling_config["ranking"]["face_group_weight_aesthetic"]
                 )
-                item["cull_score"] = max(0.0, min(1.0, weighted_score / max(1e-6, weight_sum)))
+                item["cull_score"] = max(
+                    0.0, min(1.0, weighted_score / max(1e-6, weight_sum))
+                )
                 item["cull_score"] = max(
                     0.0,
                     min(
                         1.0,
-                        item["cull_score"] - (
-                            culling_config["ranking"]["face_group_blink_penalty_weight"] * item["cull_blink_penalty"]
-                            + culling_config["ranking"]["face_group_occlusion_penalty_weight"] * item["cull_occlusion"]
+                        item["cull_score"]
+                        - (
+                            culling_config["ranking"]["face_group_blink_penalty_weight"]
+                            * item["cull_blink_penalty"]
+                            + culling_config["ranking"][
+                                "face_group_occlusion_penalty_weight"
+                            ]
+                            * item["cull_occlusion"]
                         ),
                     ),
                 )
@@ -901,25 +1005,33 @@ def _rank_group_records(component_records, group_type, culling_config=None):
                 item["cull_score"] = max(
                     0.0,
                     (
-                        culling_config["ranking"]["face_missing_technical_weight"] * item["cull_technical_score"]
-                    ) - culling_config["ranking"]["face_missing_penalty"],
+                        culling_config["ranking"]["face_missing_technical_weight"]
+                        * item["cull_technical_score"]
+                    )
+                    - culling_config["ranking"]["face_missing_penalty"],
                 )
         else:
-            weighted_score = (
-                item["cull_technical_score"]
-                + (culling_config["ranking"]["no_face_group_weight_aesthetic"] * item["cull_aesthetic"])
+            weighted_score = item["cull_technical_score"] + (
+                culling_config["ranking"]["no_face_group_weight_aesthetic"]
+                * item["cull_aesthetic"]
             )
-            weight_sum = 1.0 + culling_config["ranking"]["no_face_group_weight_aesthetic"]
-            item["cull_score"] = max(0.0, min(1.0, weighted_score / max(1e-6, weight_sum)))
+            weight_sum = (
+                1.0 + culling_config["ranking"]["no_face_group_weight_aesthetic"]
+            )
+            item["cull_score"] = max(
+                0.0, min(1.0, weighted_score / max(1e-6, weight_sum))
+            )
 
-    scored_records.sort(key=lambda item: (
-        -item["cull_score"],
-        -item["cull_face_score"],
-        -item["cull_sharpness"],
-        -item["cull_exposure"],
-        item["cull_noise"],
-        item["photo_id"],
-    ))
+    scored_records.sort(
+        key=lambda item: (
+            -item["cull_score"],
+            -item["cull_face_score"],
+            -item["cull_sharpness"],
+            -item["cull_exposure"],
+            item["cull_noise"],
+            item["photo_id"],
+        )
+    )
 
     if not scored_records:
         return []
@@ -934,37 +1046,60 @@ def _rank_group_records(component_records, group_type, culling_config=None):
         reason_codes = []
         if item["cull_sharpness"] < culling_config["ranking"]["reason_blur_threshold"]:
             reason_codes.append("blurred")
-        if item["cull_exposure"] < culling_config["ranking"]["reason_exposure_threshold"]:
+        if (
+            item["cull_exposure"]
+            < culling_config["ranking"]["reason_exposure_threshold"]
+        ):
             if item["cull_shadow_clip"] >= item["cull_highlight_clip"]:
                 reason_codes.append("underexposed")
             else:
                 reason_codes.append("overexposed")
-        if item["cull_aesthetic"] < culling_config["ranking"]["reason_low_aesthetic_threshold"] and item["cull_aesthetic"] < max(0.0, max_aesthetic - 0.08):
+        if item["cull_aesthetic"] < culling_config["ranking"][
+            "reason_low_aesthetic_threshold"
+        ] and item["cull_aesthetic"] < max(0.0, max_aesthetic - 0.08):
             reason_codes.append("low_aesthetic")
-        if index == 1 and len(scored_records) > 1 and item["cull_sharpness"] >= (
-            max_sharpness - culling_config["ranking"]["reason_sharpest_delta"]
+        if (
+            index == 1
+            and len(scored_records) > 1
+            and item["cull_sharpness"]
+            >= (max_sharpness - culling_config["ranking"]["reason_sharpest_delta"])
         ):
             reason_codes.append("sharpest_in_group")
         if group_has_faces:
             if item["cull_face_count"] == 0:
                 reason_codes.append("no_face_detected_in_group")
-            elif item["cull_face_score"] >= (
-                max_face_score - culling_config["ranking"]["reason_best_face_delta"]
-            ) and index == 1:
+            elif (
+                item["cull_face_score"]
+                >= (
+                    max_face_score - culling_config["ranking"]["reason_best_face_delta"]
+                )
+                and index == 1
+            ):
                 reason_codes.append("best_face_quality")
             elif item["cull_face_score"] < max(
                 0.0,
                 max_face_score - culling_config["ranking"]["reason_weak_face_delta"],
             ):
                 reason_codes.append("weak_face_quality")
-            if item["cull_occlusion"] > culling_config["ranking"]["reason_occlusion_threshold"]:
+            if (
+                item["cull_occlusion"]
+                > culling_config["ranking"]["reason_occlusion_threshold"]
+            ):
                 reason_codes.append("possible_occlusion")
-            if item["cull_eye_openness"] >= max(
-                0.0,
-                max_eye_openness - culling_config["ranking"]["reason_eyes_open_delta"],
-            ) and index == 1:
+            if (
+                item["cull_eye_openness"]
+                >= max(
+                    0.0,
+                    max_eye_openness
+                    - culling_config["ranking"]["reason_eyes_open_delta"],
+                )
+                and index == 1
+            ):
                 reason_codes.append("eyes_open_best")
-            elif item["cull_blink_penalty"] > culling_config["ranking"]["reason_possible_blink_threshold"]:
+            elif (
+                item["cull_blink_penalty"]
+                > culling_config["ranking"]["reason_possible_blink_threshold"]
+            ):
                 reason_codes.append("possible_blink")
         if index > 1 and group_type != "single":
             reason_codes.append("near_duplicate_weaker")
@@ -972,23 +1107,31 @@ def _rank_group_records(component_records, group_type, culling_config=None):
         reject_candidate = False
         if len(scored_records) > 1:
             reject_candidate = (
-                item["cull_score"] <= max(0.0, winner_score - culling_config["ranking"]["reject_score_delta"])
-                or item["cull_sharpness"] < culling_config["ranking"]["reason_blur_threshold"]
-                or item["cull_exposure"] < culling_config["ranking"]["reject_exposure_threshold"]
+                item["cull_score"]
+                <= max(
+                    0.0, winner_score - culling_config["ranking"]["reject_score_delta"]
+                )
+                or item["cull_sharpness"]
+                < culling_config["ranking"]["reason_blur_threshold"]
+                or item["cull_exposure"]
+                < culling_config["ranking"]["reject_exposure_threshold"]
                 or (
                     group_has_faces
                     and item["cull_face_count"] > 0
-                    and item["cull_face_score"] < culling_config["ranking"]["reject_face_score_threshold"]
+                    and item["cull_face_score"]
+                    < culling_config["ranking"]["reject_face_score_threshold"]
                 )
                 or (
                     group_has_faces
                     and item["cull_face_count"] > 0
-                    and item["cull_blink_penalty"] > culling_config["ranking"]["reject_blink_penalty_threshold"]
+                    and item["cull_blink_penalty"]
+                    > culling_config["ranking"]["reject_blink_penalty_threshold"]
                 )
                 or (
                     group_has_faces
                     and item["cull_face_count"] > 0
-                    and item["cull_occlusion"] > culling_config["ranking"]["reject_occlusion_threshold"]
+                    and item["cull_occlusion"]
+                    > culling_config["ranking"]["reject_occlusion_threshold"]
                 )
             )
 
@@ -1001,7 +1144,9 @@ def _rank_group_records(component_records, group_type, culling_config=None):
     return scored_records
 
 
-def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, culling_preset="default"):
+def group_and_sort_images(
+    uuids, phash_threshold, clip_threshold, time_delta, culling_preset="default"
+):
     """
     Group indexed images into stable similarity clusters for culling workflows.
 
@@ -1017,7 +1162,13 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
 
     culling_config = get_culling_config(culling_preset)
 
-    phash_hamming_threshold, duplicate_distance_threshold, burst_distance_threshold, duplicate_time_window_seconds, time_window_seconds = _derive_grouping_thresholds(
+    (
+        phash_hamming_threshold,
+        duplicate_distance_threshold,
+        burst_distance_threshold,
+        duplicate_time_window_seconds,
+        time_window_seconds,
+    ) = _derive_grouping_thresholds(
         phash_threshold, clip_threshold, time_delta, culling_config=culling_config
     )
 
@@ -1038,22 +1189,30 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
     for idx, photo_id in enumerate(raw.get("ids", [])):
         metadata_list = raw.get("metadatas", [])
         embedding_list = raw.get("embeddings", [])
-        metadata_by_id[photo_id] = metadata_list[idx] if idx < len(metadata_list) else {}
-        embedding_by_id[photo_id] = embedding_list[idx] if idx < len(embedding_list) else None
+        metadata_by_id[photo_id] = (
+            metadata_list[idx] if idx < len(metadata_list) else {}
+        )
+        embedding_by_id[photo_id] = (
+            embedding_list[idx] if idx < len(embedding_list) else None
+        )
 
     records = []
     for photo_id in unique_photo_ids:
         metadata = metadata_by_id.get(photo_id, {}) or {}
         capture_time = _safe_float(metadata.get("capture_time"))
         filename = str(metadata.get("filename") or "")
-        records.append({
-            "photo_id": photo_id,
-            "filename": filename,
-            "capture_time": capture_time,
-            "embedding": _embedding_to_array(embedding_by_id.get(photo_id)),
-            "phash": _phash_to_int(metadata.get("cull_phash") or metadata.get("phash")),
-            "metadata": metadata,
-        })
+        records.append(
+            {
+                "photo_id": photo_id,
+                "filename": filename,
+                "capture_time": capture_time,
+                "embedding": _embedding_to_array(embedding_by_id.get(photo_id)),
+                "phash": _phash_to_int(
+                    metadata.get("cull_phash") or metadata.get("phash")
+                ),
+                "metadata": metadata,
+            }
+        )
 
     records.sort(key=_record_sort_key)
 
@@ -1070,16 +1229,20 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
             time_gap = None
             if left["capture_time"] is not None and right["capture_time"] is not None:
                 time_gap = abs(right["capture_time"] - left["capture_time"])
-                if time_gap > duplicate_time_window_seconds and distance is None and phash_distance is None:
+                if (
+                    time_gap > duplicate_time_window_seconds
+                    and distance is None
+                    and phash_distance is None
+                ):
                     break
 
             is_near_duplicate = (
                 (
-                    (phash_distance is not None and phash_distance <= phash_hamming_threshold)
-                    or (distance is not None and distance <= duplicate_distance_threshold)
+                    phash_distance is not None
+                    and phash_distance <= phash_hamming_threshold
                 )
-                and (time_gap is None or time_gap <= duplicate_time_window_seconds)
-            )
+                or (distance is not None and distance <= duplicate_distance_threshold)
+            ) and (time_gap is None or time_gap <= duplicate_time_window_seconds)
             is_burst_neighbor = (
                 distance is not None
                 and distance <= burst_distance_threshold
@@ -1094,7 +1257,9 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
             right_id = right["photo_id"]
             adjacency[left_id].add(right_id)
             adjacency[right_id].add(left_id)
-            edge_kinds[tuple(sorted((left_id, right_id)))] = "near_duplicate" if is_near_duplicate else "burst"
+            edge_kinds[tuple(sorted((left_id, right_id)))] = (
+                "near_duplicate" if is_near_duplicate else "burst"
+            )
 
     groups = []
     visited = set()
@@ -1119,11 +1284,17 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
                     stack.append(neighbor_id)
 
         component_id_set = set(component_ids)
-        component_records = [item for item in records if item["photo_id"] in component_id_set]
+        component_records = [
+            item for item in records if item["photo_id"] in component_id_set
+        ]
         component_records.sort(key=_record_sort_key)
 
         group_photo_ids = [item["photo_id"] for item in component_records]
-        capture_times = [item["capture_time"] for item in component_records if item["capture_time"] is not None]
+        capture_times = [
+            item["capture_time"]
+            for item in component_records
+            if item["capture_time"] is not None
+        ]
         time_span_seconds = 0.0
         if len(capture_times) >= 2:
             time_span_seconds = float(max(capture_times) - min(capture_times))
@@ -1141,7 +1312,9 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
                     pair_distances.append(round(distance, 4))
                 if phash_distance is not None:
                     pair_phash_distances.append(phash_distance)
-                edge_type = edge_kinds.get(tuple(sorted((left["photo_id"], right["photo_id"]))))
+                edge_type = edge_kinds.get(
+                    tuple(sorted((left["photo_id"], right["photo_id"])))
+                )
                 if edge_type:
                     group_edge_types.add(edge_type)
 
@@ -1154,107 +1327,127 @@ def group_and_sort_images(uuids, phash_threshold, clip_threshold, time_delta, cu
         else:
             group_type = "near_duplicate"
 
-        ranked_records = _rank_group_records(component_records, group_type, culling_config=culling_config)
+        ranked_records = _rank_group_records(
+            component_records, group_type, culling_config=culling_config
+        )
         group_id = f"group_{group_counter:04d}"
-        winner_photo_id = ranked_records[0]["photo_id"] if ranked_records else group_photo_ids[0]
-        alternate_photo_ids = [item["photo_id"] for item in ranked_records[1:] if not item["cull_reject_candidate"]]
-        reject_candidate_photo_ids = [item["photo_id"] for item in ranked_records if item["cull_reject_candidate"]]
+        winner_photo_id = (
+            ranked_records[0]["photo_id"] if ranked_records else group_photo_ids[0]
+        )
+        alternate_photo_ids = [
+            item["photo_id"]
+            for item in ranked_records[1:]
+            if not item["cull_reject_candidate"]
+        ]
+        reject_candidate_photo_ids = [
+            item["photo_id"] for item in ranked_records if item["cull_reject_candidate"]
+        ]
 
         for ranked in ranked_records:
             updated_metadata = dict(ranked["metadata"] or {})
-            updated_metadata.update({
-                "cull_group_id": group_id,
-                "cull_group_size": len(group_photo_ids),
-                "cull_group_rank": ranked["cull_group_rank"],
-                "cull_group_winner": ranked["cull_group_winner"],
-                "cull_score": round(ranked["cull_score"], 4),
-                "cull_reject_candidate": ranked["cull_reject_candidate"],
-                "cull_reason_codes": json.dumps(ranked["cull_reason_codes"]),
-                "cull_explanation": ranked["cull_explanation"],
-                "cull_sharpness": round(ranked["cull_sharpness"], 4),
-                "cull_exposure": round(ranked["cull_exposure"], 4),
-                "cull_noise": round(ranked["cull_noise"], 4),
-                "cull_highlight_clip": round(ranked["cull_highlight_clip"], 4),
-                "cull_shadow_clip": round(ranked["cull_shadow_clip"], 4),
-                "cull_technical_score": round(ranked["cull_technical_score"], 4),
-                "cull_aesthetic": round(ranked["cull_aesthetic"], 4),
-                "cull_face_count": int(ranked["cull_face_count"]),
-                "cull_face_sharpness": round(ranked["cull_face_sharpness"], 4),
-                "cull_face_prominence": round(ranked["cull_face_prominence"], 4),
-                "cull_face_visibility": round(ranked["cull_face_visibility"], 4),
-                "cull_face_score": round(ranked["cull_face_score"], 4),
-                "cull_occlusion": round(ranked["cull_occlusion"], 4),
-                "cull_eye_openness": round(ranked["cull_eye_openness"], 4),
-                "cull_blink_penalty": round(ranked["cull_blink_penalty"], 4),
-            })
+            updated_metadata.update(
+                {
+                    "cull_group_id": group_id,
+                    "cull_group_size": len(group_photo_ids),
+                    "cull_group_rank": ranked["cull_group_rank"],
+                    "cull_group_winner": ranked["cull_group_winner"],
+                    "cull_score": round(ranked["cull_score"], 4),
+                    "cull_reject_candidate": ranked["cull_reject_candidate"],
+                    "cull_reason_codes": json.dumps(ranked["cull_reason_codes"]),
+                    "cull_explanation": ranked["cull_explanation"],
+                    "cull_sharpness": round(ranked["cull_sharpness"], 4),
+                    "cull_exposure": round(ranked["cull_exposure"], 4),
+                    "cull_noise": round(ranked["cull_noise"], 4),
+                    "cull_highlight_clip": round(ranked["cull_highlight_clip"], 4),
+                    "cull_shadow_clip": round(ranked["cull_shadow_clip"], 4),
+                    "cull_technical_score": round(ranked["cull_technical_score"], 4),
+                    "cull_aesthetic": round(ranked["cull_aesthetic"], 4),
+                    "cull_face_count": int(ranked["cull_face_count"]),
+                    "cull_face_sharpness": round(ranked["cull_face_sharpness"], 4),
+                    "cull_face_prominence": round(ranked["cull_face_prominence"], 4),
+                    "cull_face_visibility": round(ranked["cull_face_visibility"], 4),
+                    "cull_face_score": round(ranked["cull_face_score"], 4),
+                    "cull_occlusion": round(ranked["cull_occlusion"], 4),
+                    "cull_eye_openness": round(ranked["cull_eye_openness"], 4),
+                    "cull_blink_penalty": round(ranked["cull_blink_penalty"], 4),
+                }
+            )
             metadata_updates.append((ranked["photo_id"], updated_metadata))
 
-        groups.append({
-            "group_id": group_id,
-            "group_type": group_type,
-            "group_size": len(group_photo_ids),
-            "primary_photo_id": group_photo_ids[0],
-            "photo_ids": group_photo_ids,
-            "winner_photo_id": winner_photo_id,
-            "alternate_photo_ids": alternate_photo_ids,
-            "reject_candidate_photo_ids": reject_candidate_photo_ids,
-            "photos": [
-                {
-                    "photo_id": item["photo_id"],
-                    "rank": item["cull_group_rank"],
-                    "cull_score": round(item["cull_score"], 4),
-                    "winner": item["cull_group_winner"],
-                    "reject_candidate": item["cull_reject_candidate"],
-                    "reason_codes": item["cull_reason_codes"],
-                    "explanation": item["cull_explanation"],
-                    "metrics": {
-                        "sharpness": round(item["cull_sharpness"], 4),
-                        "exposure": round(item["cull_exposure"], 4),
-                        "noise": round(item["cull_noise"], 4),
-                        "highlight_clip": round(item["cull_highlight_clip"], 4),
-                        "shadow_clip": round(item["cull_shadow_clip"], 4),
-                        "technical_score": round(item["cull_technical_score"], 4),
-                        "aesthetic": round(item["cull_aesthetic"], 4),
-                        "face_count": int(item["cull_face_count"]),
-                        "face_sharpness": round(item["cull_face_sharpness"], 4),
-                        "face_prominence": round(item["cull_face_prominence"], 4),
-                        "face_visibility": round(item["cull_face_visibility"], 4),
-                        "face_score": round(item["cull_face_score"], 4),
-                        "occlusion": round(item["cull_occlusion"], 4),
-                        "eye_openness": round(item["cull_eye_openness"], 4),
-                        "blink_penalty": round(item["cull_blink_penalty"], 4),
+        groups.append(
+            {
+                "group_id": group_id,
+                "group_type": group_type,
+                "group_size": len(group_photo_ids),
+                "primary_photo_id": group_photo_ids[0],
+                "photo_ids": group_photo_ids,
+                "winner_photo_id": winner_photo_id,
+                "alternate_photo_ids": alternate_photo_ids,
+                "reject_candidate_photo_ids": reject_candidate_photo_ids,
+                "photos": [
+                    {
+                        "photo_id": item["photo_id"],
+                        "rank": item["cull_group_rank"],
+                        "cull_score": round(item["cull_score"], 4),
+                        "winner": item["cull_group_winner"],
+                        "reject_candidate": item["cull_reject_candidate"],
+                        "reason_codes": item["cull_reason_codes"],
+                        "explanation": item["cull_explanation"],
+                        "metrics": {
+                            "sharpness": round(item["cull_sharpness"], 4),
+                            "exposure": round(item["cull_exposure"], 4),
+                            "noise": round(item["cull_noise"], 4),
+                            "highlight_clip": round(item["cull_highlight_clip"], 4),
+                            "shadow_clip": round(item["cull_shadow_clip"], 4),
+                            "technical_score": round(item["cull_technical_score"], 4),
+                            "aesthetic": round(item["cull_aesthetic"], 4),
+                            "face_count": int(item["cull_face_count"]),
+                            "face_sharpness": round(item["cull_face_sharpness"], 4),
+                            "face_prominence": round(item["cull_face_prominence"], 4),
+                            "face_visibility": round(item["cull_face_visibility"], 4),
+                            "face_score": round(item["cull_face_score"], 4),
+                            "occlusion": round(item["cull_occlusion"], 4),
+                            "eye_openness": round(item["cull_eye_openness"], 4),
+                            "blink_penalty": round(item["cull_blink_penalty"], 4),
+                        },
+                    }
+                    for item in ranked_records
+                ],
+                "min_capture_time": min(capture_times) if capture_times else None,
+                "max_capture_time": max(capture_times) if capture_times else None,
+                "time_span_seconds": round(time_span_seconds, 3),
+                "debug": {
+                    "culling_preset": culling_preset,
+                    "thresholds": {
+                        "phash_hamming_threshold": phash_hamming_threshold,
+                        "duplicate_distance": round(duplicate_distance_threshold, 4),
+                        "burst_distance": round(burst_distance_threshold, 4),
+                        "duplicate_time_window_seconds": duplicate_time_window_seconds,
+                        "time_window_seconds": time_window_seconds,
                     },
-                }
-                for item in ranked_records
-            ],
-            "min_capture_time": min(capture_times) if capture_times else None,
-            "max_capture_time": max(capture_times) if capture_times else None,
-            "time_span_seconds": round(time_span_seconds, 3),
-            "debug": {
-                "culling_preset": culling_preset,
-                "thresholds": {
-                    "phash_hamming_threshold": phash_hamming_threshold,
-                    "duplicate_distance": round(duplicate_distance_threshold, 4),
-                    "burst_distance": round(burst_distance_threshold, 4),
-                    "duplicate_time_window_seconds": duplicate_time_window_seconds,
-                    "time_window_seconds": time_window_seconds,
+                    "pairwise_distances": pair_distances,
+                    "pairwise_phash_distances": pair_phash_distances,
+                    "edge_types": sorted(group_edge_types),
                 },
-                "pairwise_distances": pair_distances,
-                "pairwise_phash_distances": pair_phash_distances,
-                "edge_types": sorted(group_edge_types),
-            },
-        })
+            }
+        )
         group_counter += 1
 
-    groups.sort(key=lambda group: (
-        group["min_capture_time"] is None,
-        group["min_capture_time"] if group["min_capture_time"] is not None else float("inf"),
-        group["primary_photo_id"],
-    ))
+    groups.sort(
+        key=lambda group: (
+            group["min_capture_time"] is None,
+            group["min_capture_time"]
+            if group["min_capture_time"] is not None
+            else float("inf"),
+            group["primary_photo_id"],
+        )
+    )
 
     if metadata_updates:
         if collection is None:
-            raise DatabaseNotReadyError("Cannot update metadata: database not initialized (DB_PATH missing).")
+            raise DatabaseNotReadyError(
+                "Cannot update metadata: database not initialized (DB_PATH missing)."
+            )
         update_ids = [photo_id for photo_id, _ in metadata_updates]
         update_metadatas = [metadata for _, metadata in metadata_updates]
         collection.update(ids=update_ids, metadatas=update_metadatas)
@@ -1310,20 +1503,36 @@ def find_similar_to_photo(
         logger.warning("find_similar_to_photo: empty or invalid photo_id")
         return [], "empty or invalid photo_id"
 
-    scope_source = "scope_photo_ids (%s)" % len(scope_photo_ids) if scope_photo_ids is not None else ("catalog_id=%s" % (catalog_id or "all"))
+    scope_source = (
+        "scope_photo_ids (%s)" % len(scope_photo_ids)
+        if scope_photo_ids is not None
+        else ("catalog_id=%s" % (catalog_id or "all"))
+    )
     logger.info(
         "find_similar_to_photo: photo_id=%s max_results=%s phash_max_hamming=%s use_clip=%s scope=%s",
-        photo_id, max_results, phash_max_hamming, use_clip, scope_source,
+        photo_id,
+        max_results,
+        phash_max_hamming,
+        use_clip,
+        scope_source,
     )
 
     target_data = get_image(photo_id, catalog_id=catalog_id)
     if not target_data or not target_data.get("ids"):
-        logger.warning("find_similar_to_photo: reference photo_id %s not found or not in catalog", photo_id)
+        logger.warning(
+            "find_similar_to_photo: reference photo_id %s not found or not in catalog",
+            photo_id,
+        )
         return [], "This photo is not in the search index. Run 'Analyze & Index' first."
     target_meta = (target_data.get("metadatas") or [None])[0] or {}
-    target_phash = _phash_to_int(target_meta.get("cull_phash") or target_meta.get("phash"))
+    target_phash = _phash_to_int(
+        target_meta.get("cull_phash") or target_meta.get("phash")
+    )
     if target_phash is None:
-        logger.warning("find_similar_to_photo: reference photo_id %s has no phash; run Analyze & Index first", photo_id)
+        logger.warning(
+            "find_similar_to_photo: reference photo_id %s has no phash; run Analyze & Index first",
+            photo_id,
+        )
         return [], "This photo has no perceptual hash. Run 'Analyze & Index' first."
 
     target_embedding = None
@@ -1337,12 +1546,18 @@ def find_similar_to_photo(
     )
 
     if scope_photo_ids is not None:
-        candidate_ids = [str(pid).strip() for pid in scope_photo_ids if pid and str(pid).strip() != photo_id]
+        candidate_ids = [
+            str(pid).strip()
+            for pid in scope_photo_ids
+            if pid and str(pid).strip() != photo_id
+        ]
     else:
         candidate_ids = get_all_image_ids(catalog_id=catalog_id)
         candidate_ids = [pid for pid in candidate_ids if pid != photo_id]
 
-    logger.info("find_similar_to_photo: %s candidate photo(s) to compare", len(candidate_ids))
+    logger.info(
+        "find_similar_to_photo: %s candidate photo(s) to compare", len(candidate_ids)
+    )
     if not candidate_ids:
         return [], None
 
@@ -1356,7 +1571,11 @@ def find_similar_to_photo(
         for idx, pid in enumerate(ids_list):
             meta = metas[idx] if idx < len(metas) else {}
             cand_phash = _phash_to_int(meta.get("cull_phash") or meta.get("phash"))
-            phash_dist = _phash_hamming_distance(target_phash, cand_phash) if cand_phash is not None else None
+            phash_dist = (
+                _phash_hamming_distance(target_phash, cand_phash)
+                if cand_phash is not None
+                else None
+            )
             if phash_dist is None or phash_dist > phash_max_hamming:
                 continue
             clip_dist = None
@@ -1364,19 +1583,32 @@ def find_similar_to_photo(
                 cand_emb = _embedding_to_array(embs[idx] if idx < len(embs) else None)
                 if cand_emb is not None:
                     clip_dist = _cosine_distance(target_embedding, cand_emb)
-            results.append({
-                "photo_id": pid,
-                "phash_distance": phash_dist,
-                "clip_distance": clip_dist,
-            })
+            results.append(
+                {
+                    "photo_id": pid,
+                    "phash_distance": phash_dist,
+                    "clip_distance": clip_dist,
+                }
+            )
 
-    results.sort(key=lambda r: (r["phash_distance"], r["clip_distance"] if r["clip_distance"] is not None else float("inf")))
+    results.sort(
+        key=lambda r: (
+            r["phash_distance"],
+            r["clip_distance"] if r["clip_distance"] is not None else float("inf"),
+        )
+    )
     out = results[:max_results]
-    logger.info("find_similar_to_photo: %s similar photo(s) found (phash_distance <= %s)", len(out), phash_max_hamming)
+    logger.info(
+        "find_similar_to_photo: %s similar photo(s) found (phash_distance <= %s)",
+        len(out),
+        phash_max_hamming,
+    )
     return out, None
 
 
-def find_similar_to_photo_by_clip(photo_id, scope_photo_ids=None, max_results=100, catalog_id=None):
+def find_similar_to_photo_by_clip(
+    photo_id, scope_photo_ids=None, max_results=100, catalog_id=None
+):
     """
     Find indexed photos semantically similar to the given photo by CLIP embedding (k-NN).
 
@@ -1396,19 +1628,32 @@ def find_similar_to_photo_by_clip(photo_id, scope_photo_ids=None, max_results=10
 
     target_data = get_image(photo_id, catalog_id=catalog_id)
     if not target_data or not target_data.get("ids"):
-        logger.warning("find_similar_to_photo_by_clip: reference photo_id %s not found or not in catalog", photo_id)
+        logger.warning(
+            "find_similar_to_photo_by_clip: reference photo_id %s not found or not in catalog",
+            photo_id,
+        )
         return [], "This photo is not in the search index. Run 'Analyze & Index' first."
     first_emb = _first_result_item(target_data.get("embeddings"))
     if first_emb is None:
-        logger.warning("find_similar_to_photo_by_clip: reference photo_id %s has no embedding; run Analyze & Index with embeddings", photo_id)
-        return [], "This photo has no image embedding. Run 'Analyze & Index' with embeddings enabled."
+        logger.warning(
+            "find_similar_to_photo_by_clip: reference photo_id %s has no embedding; run Analyze & Index with embeddings",
+            photo_id,
+        )
+        return (
+            [],
+            "This photo has no image embedding. Run 'Analyze & Index' with embeddings enabled.",
+        )
     query_embedding = _embedding_to_array(first_emb)
     if query_embedding is None:
         return [], None
 
     where_clause = None
     if scope_photo_ids is not None and len(scope_photo_ids) > 0:
-        ids_list = [str(pid).strip() for pid in scope_photo_ids if pid and str(pid).strip() != photo_id]
+        ids_list = [
+            str(pid).strip()
+            for pid in scope_photo_ids
+            if pid and str(pid).strip() != photo_id
+        ]
         if not ids_list:
             return [], None
         where_clause = {"photo_id": {"$in": ids_list}}
@@ -1431,16 +1676,23 @@ def find_similar_to_photo_by_clip(photo_id, scope_photo_ids=None, max_results=10
             continue
         d = dist0[i] if i < len(dist0) else None
         if d is not None:
-            out.append({"photo_id": pid, "phash_distance": None, "clip_distance": float(d)})
+            out.append(
+                {"photo_id": pid, "phash_distance": None, "clip_distance": float(d)}
+            )
         if len(out) >= max_results:
             break
-    logger.info("find_similar_to_photo_by_clip: %s similar photo(s) found by CLIP", len(out))
+    logger.info(
+        "find_similar_to_photo_by_clip: %s similar photo(s) found by CLIP", len(out)
+    )
     return out, None
 
 
 # --- Face embeddings collection API ---
 
-def add_face(face_id, embedding, photo_uuid, thumbnail_b64, person_id="", extra_metadata=None):
+
+def add_face(
+    face_id, embedding, photo_uuid, thumbnail_b64, person_id="", extra_metadata=None
+):
     """
     Add a single face to the face_embeddings collection.
 
@@ -1453,21 +1705,37 @@ def add_face(face_id, embedding, photo_uuid, thumbnail_b64, person_id="", extra_
     """
     _ensure_initialized()
     if face_collection is None:
-        raise DatabaseNotReadyError("Cannot add face: database not initialized (DB_PATH missing).")
-    metadata = {"photo_id": photo_uuid, "photo_uuid": photo_uuid, "thumbnail": thumbnail_b64, "person_id": person_id}
+        raise DatabaseNotReadyError(
+            "Cannot add face: database not initialized (DB_PATH missing)."
+        )
+    metadata = {
+        "photo_id": photo_uuid,
+        "photo_uuid": photo_uuid,
+        "thumbnail": thumbnail_b64,
+        "person_id": person_id,
+    }
     if extra_metadata:
         metadata.update(extra_metadata)
     face_collection.add(ids=[face_id], embeddings=[embedding], metadatas=[metadata])
 
 
-def add_faces_batch(face_ids, embeddings, photo_uuids, thumbnails_b64, person_ids=None, extra_metadatas=None):
+def add_faces_batch(
+    face_ids,
+    embeddings,
+    photo_uuids,
+    thumbnails_b64,
+    person_ids=None,
+    extra_metadatas=None,
+):
     """
     Add multiple faces in one call. All lists must have the same length.
     person_ids: optional list of person_id (default "" for each).
     """
     _ensure_initialized()
     if face_collection is None:
-        raise DatabaseNotReadyError("Cannot add faces batch: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot add faces batch: database not initialized (DB_PATH missing)."
+        )
     if not face_ids:
         return
     if person_ids is None:
@@ -1475,7 +1743,9 @@ def add_faces_batch(face_ids, embeddings, photo_uuids, thumbnails_b64, person_id
     if extra_metadatas is None:
         extra_metadatas = [{}] * len(face_ids)
     metadatas = []
-    for pu, tb, pid, extra_meta in zip(photo_uuids, thumbnails_b64, person_ids, extra_metadatas):
+    for pu, tb, pid, extra_meta in zip(
+        photo_uuids, thumbnails_b64, person_ids, extra_metadatas
+    ):
         metadata = {"photo_id": pu, "photo_uuid": pu, "thumbnail": tb, "person_id": pid}
         if extra_meta:
             metadata.update(extra_meta)
@@ -1533,7 +1803,9 @@ def update_face_metadatas(face_ids, metadatas):
     """
     _ensure_initialized()
     if face_collection is None:
-        raise DatabaseNotReadyError("Cannot update face metadatas: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot update face metadatas: database not initialized (DB_PATH missing)."
+        )
     if not face_ids or len(face_ids) != len(metadatas):
         return
     for i in range(0, len(face_ids), FACE_UPDATE_BATCH_SIZE):
@@ -1548,10 +1820,14 @@ def has_faces_for_photo(photo_uuid):
     if face_collection is None:
         return False
     try:
-        result = face_collection.get(where={"photo_id": photo_uuid}, include=[], limit=1)
+        result = face_collection.get(
+            where={"photo_id": photo_uuid}, include=[], limit=1
+        )
         if len(result.get("ids", [])) > 0:
             return True
-        legacy = face_collection.get(where={"photo_uuid": photo_uuid}, include=[], limit=1)
+        legacy = face_collection.get(
+            where={"photo_uuid": photo_uuid}, include=[], limit=1
+        )
         return len(legacy.get("ids", [])) > 0
     except Exception as e:
         logger.warning(f"Could not check faces for {photo_uuid}: {e}")
@@ -1567,10 +1843,10 @@ def faces_checked_for_photo(photo_uuid):
     if has_faces_for_photo(photo_uuid):
         return True
     try:
-        img = collection.get(ids=[photo_uuid], include=['metadatas'])
-        if img and img.get('metadatas') and img['metadatas']:
-            meta = img['metadatas'][0]
-            return meta.get('faces_checked', False)
+        img = collection.get(ids=[photo_uuid], include=["metadatas"])
+        if img and img.get("metadatas") and img["metadatas"]:
+            meta = img["metadatas"][0]
+            return meta.get("faces_checked", False)
     except Exception as e:
         logger.warning(f"Could not check faces_checked for {photo_uuid}: {e}")
     return False
@@ -1580,13 +1856,15 @@ def set_faces_checked(photo_uuid):
     """Mark that face detection was run for this photo (e.g. no faces found)."""
     _ensure_initialized()
     if collection is None:
-        raise DatabaseNotReadyError("Cannot set faces checked: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot set faces checked: database not initialized (DB_PATH missing)."
+        )
     try:
-        img = collection.get(ids=[photo_uuid], include=['metadatas'])
-        if not img or not img.get('ids'):
+        img = collection.get(ids=[photo_uuid], include=["metadatas"])
+        if not img or not img.get("ids"):
             return
-        meta = (img.get('metadatas') or [{}])[0].copy()
-        meta['faces_checked'] = True
+        meta = (img.get("metadatas") or [{}])[0].copy()
+        meta["faces_checked"] = True
         collection.update(ids=[photo_uuid], metadatas=[meta])
     except Exception as e:
         logger.warning(f"Could not set faces_checked for {photo_uuid}: {e}")
@@ -1596,7 +1874,9 @@ def delete_faces_by_photo_uuid(photo_uuid):
     """Remove all face entries that belong to the given photo UUID."""
     _ensure_initialized()
     if face_collection is None:
-        raise DatabaseNotReadyError("Cannot delete faces: database not initialized (DB_PATH missing).")
+        raise DatabaseNotReadyError(
+            "Cannot delete faces: database not initialized (DB_PATH missing)."
+        )
     try:
         face_collection.delete(where={"photo_id": photo_uuid})
     except Exception:
@@ -1608,7 +1888,14 @@ def delete_faces_by_photo_uuid(photo_uuid):
         logger.warning(f"Delete faces for photo_uuid={photo_uuid}: {e}")
 
 
-def migrate_photo_ids(id_mappings, *, update_faces=True, update_vertex=True, overwrite=False, dry_run=False):
+def migrate_photo_ids(
+    id_mappings,
+    *,
+    update_faces=True,
+    update_vertex=True,
+    overwrite=False,
+    dry_run=False,
+):
     """Migrate existing DB entries from old IDs (uuid) to new photo_id values.
 
     Args:
@@ -1666,31 +1953,49 @@ def migrate_photo_ids(id_mappings, *, update_faces=True, update_vertex=True, ove
                     elif dry_run:
                         summary["migrated"] += 1
                     else:
-                        old_metadata = _first_result_item(old_rec.get("metadatas"), {}) or {}
+                        old_metadata = (
+                            _first_result_item(old_rec.get("metadatas"), {}) or {}
+                        )
                         old_embedding = _first_result_item(old_rec.get("embeddings"))
                         merged_metadata = dict(old_metadata)
                         merged_metadata[LEGACY_UUID_FIELD] = old_id
                         merged_metadata[PHOTO_ID_FIELD] = new_id
 
                         if new_rec and new_rec.get("ids"):
-                            update_image(new_id, merged_metadata, embedding=old_embedding)
+                            update_image(
+                                new_id, merged_metadata, embedding=old_embedding
+                            )
                         else:
-                            add_image(new_id, old_embedding, merged_metadata, legacy_uuid=old_id)
+                            add_image(
+                                new_id,
+                                old_embedding,
+                                merged_metadata,
+                                legacy_uuid=old_id,
+                            )
                         delete_image(old_id)
 
                         if update_vertex:
                             old_v = get_vertex_image(old_id)
                             if old_v and old_v.get("ids"):
                                 old_v_emb = _first_result_item(old_v.get("embeddings"))
-                                old_v_meta = _first_result_item(old_v.get("metadatas"), {}) or {}
+                                old_v_meta = (
+                                    _first_result_item(old_v.get("metadatas"), {}) or {}
+                                )
                                 old_v_meta = _ensure_photo_metadata(new_id, old_v_meta)
                                 old_v_meta[LEGACY_UUID_FIELD] = old_id
                                 if old_v_emb is not None:
-                                    add_vertex_image(new_id, old_v_emb, old_v_meta, legacy_uuid=old_id)
+                                    add_vertex_image(
+                                        new_id,
+                                        old_v_emb,
+                                        old_v_meta,
+                                        legacy_uuid=old_id,
+                                    )
                                     delete_vertex_image(old_id)
 
                         if update_faces:
-                            face_data = face_collection.get(where={"photo_uuid": old_id}, include=["metadatas"])
+                            face_data = face_collection.get(
+                                where={"photo_uuid": old_id}, include=["metadatas"]
+                            )
                             face_ids = face_data.get("ids", []) or []
                             metas = face_data.get("metadatas", []) or []
                             if face_ids and metas:
@@ -1704,7 +2009,13 @@ def migrate_photo_ids(id_mappings, *, update_faces=True, update_vertex=True, ove
 
                         summary["migrated"] += 1
             except Exception as e:
-                logger.error("Failed to migrate photo ID %s -> %s: %s", old_id, new_id, e, exc_info=True)
+                logger.error(
+                    "Failed to migrate photo ID %s -> %s: %s",
+                    old_id,
+                    new_id,
+                    e,
+                    exc_info=True,
+                )
                 summary["errors"] += 1
 
         if idx == 1 or idx % progress_interval == 0 or idx == total_requested:
@@ -1738,4 +2049,3 @@ def query_faces(query_embedding, n_results, where_clause=None):
     except Exception as e:
         logger.error(f"Error querying face_embeddings: {e}", exc_info=True)
         return {"ids": [[]], "distances": [[]], "metadatas": [[]]}
-

--- a/server/src/service_clip.py
+++ b/server/src/service_clip.py
@@ -10,7 +10,7 @@ _download_status = {
     "progress": 0,
     "total": 0,
     "error": None,
-    "current_file": None
+    "current_file": None,
 }
 
 _download_lock = threading.Lock()
@@ -20,13 +20,14 @@ _download_thread = None
 
 class DownloadProgressTracker(tqdm.tqdm):
     """
-    Custom tqdm wrapper to capture byte-wise progress from hf_hub_download 
+    Custom tqdm wrapper to capture byte-wise progress from hf_hub_download
     and update the global status for the Lightroom UI.
     """
+
     def __init__(self, *args, **kwargs):
         # Mute standard output to avoid polluting logs/console
-        kwargs['file'] = open(os.devnull, 'w')
-        kwargs.pop('name', None)
+        kwargs["file"] = open(os.devnull, "w")
+        kwargs.pop("name", None)
         super().__init__(*args, **kwargs)
 
     def update(self, n=1):
@@ -34,9 +35,12 @@ class DownloadProgressTracker(tqdm.tqdm):
         if n > 0:
             with _download_lock:
                 _download_status["progress"] += n
-                
+
                 # Ensure progress doesn't exceed total due to tqdm behavior or imprecise total size
-                if _download_status["total"] > 0 and _download_status["progress"] > _download_status["total"]:
+                if (
+                    _download_status["total"] > 0
+                    and _download_status["progress"] > _download_status["total"]
+                ):
                     _download_status["progress"] = _download_status["total"]
 
 
@@ -51,7 +55,9 @@ def start_download_clip_model():
         if _download_thread and _download_thread.is_alive():
             logger.warning("Download thread is already running.")
             return
-        _download_thread = threading.Thread(target=_download_clip_model_thread, name="clip_model_downloader")
+        _download_thread = threading.Thread(
+            target=_download_clip_model_thread, name="clip_model_downloader"
+        )
         _download_thread.daemon = True
         _download_thread.start()
 
@@ -68,39 +74,43 @@ def _download_clip_model_thread():
     try:
         api = HfApi()
         model_info = api.model_info(IMAGE_MODEL_ID, files_metadata=True)
-        
+
         # Determine all files with actual sizes
         files_to_download = [f.rfilename for f in model_info.siblings if f.size]
         total_size = sum(f.size for f in model_info.siblings if f.size)
 
         with _download_lock:
-            _download_status.update({
-                "status": "downloading",
-                "progress": 0,
-                "total": total_size,
-                "error": None,
-                "current_file": None
-            })
+            _download_status.update(
+                {
+                    "status": "downloading",
+                    "progress": 0,
+                    "total": total_size,
+                    "error": None,
+                    "current_file": None,
+                }
+            )
 
         # Download files one by one to capture smooth byte-wise progress per file.
-        # Track bytes from completed files to handle cases where hf_hub_download 
+        # Track bytes from completed files to handle cases where hf_hub_download
         # skips a file (already cached) and doesn't trigger tqdm updates.
         bytes_from_completed_files = 0
-        
+
         for filename in files_to_download:
             # Find size from model_info
-            file_size = next((f.size for f in model_info.siblings if f.rfilename == filename), 0)
-            
+            file_size = next(
+                (f.size for f in model_info.siblings if f.rfilename == filename), 0
+            )
+
             with _download_lock:
                 _download_status["current_file"] = filename
-            
+
             logger.info(f"Downloading model file: {filename} ({file_size} bytes)")
             hf_hub_download(
                 repo_id=IMAGE_MODEL_ID,
                 filename=filename,
-                tqdm_class=DownloadProgressTracker
+                tqdm_class=DownloadProgressTracker,
             )
-            
+
             # After hf_hub_download returns, we ensure the progress for THIS file is fully counted
             bytes_from_completed_files += file_size
             with _download_lock:
@@ -115,7 +125,7 @@ def _download_clip_model_thread():
         with _download_lock:
             _download_status["status"] = "completed"
             _download_status["progress"] = total_size
-            
+
         logger.info(f"CLIP model download complete. Path: {path}")
     except Exception as e:
         logger.error(f"Error downloading CLIP model: {e}", exc_info=True)

--- a/server/src/service_db.py
+++ b/server/src/service_db.py
@@ -1,11 +1,13 @@
+import service_chroma as chroma_service
+import service_persons as persons_service
+from config import logger, DB_PATH
+
 import os
 import json
 import shutil
 import tempfile
 import zipfile
 from datetime import datetime
-
-from config import logger, DB_PATH
 
 # Ordner für serverseitig aufgehobene Backups: Docker /data/db/backups, Standalone <db-path>/backups
 def _get_backups_dir():
@@ -14,8 +16,6 @@ def _get_backups_dir():
         return None
     return os.path.join(DB_PATH, "backups")
 
-import service_chroma as chroma_service
-import service_persons as persons_service
 
 
 def get_database_stats(catalog_id=None) -> dict:

--- a/server/src/service_db.py
+++ b/server/src/service_db.py
@@ -9,13 +9,14 @@ import tempfile
 import zipfile
 from datetime import datetime
 
+
 # Ordner für serverseitig aufgehobene Backups: Docker /data/db/backups, Standalone <db-path>/backups
 def _get_backups_dir():
     from config import DB_PATH
+
     if not DB_PATH:
         return None
     return os.path.join(DB_PATH, "backups")
-
 
 
 def get_database_stats(catalog_id=None) -> dict:
@@ -44,18 +45,26 @@ def get_database_stats(catalog_id=None) -> dict:
 def build_backup_zip() -> tuple[str, str]:
     """Create a temporary ZIP containing all persistent DB files."""
     if not DB_PATH or not os.path.isdir(DB_PATH):
-        raise FileNotFoundError(f"Database path does not exist or is not a directory: {DB_PATH}")
+        raise FileNotFoundError(
+            f"Database path does not exist or is not a directory: {DB_PATH}"
+        )
 
-    backup_name = f"lrgeniusai-backend-backup-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.zip"
+    backup_name = (
+        f"lrgeniusai-backend-backup-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.zip"
+    )
     fd, zip_path = tempfile.mkstemp(prefix="lrgeniusai-backup-", suffix=".zip")
     os.close(fd)
 
     root_parent = os.path.dirname(DB_PATH)
     included_files = 0
-    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as archive:
+    with zipfile.ZipFile(
+        zip_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6
+    ) as archive:
         for current_root, dirs, files in os.walk(DB_PATH):
             # Do not include the backups directory in the backup (avoid self-embedding and runaway size)
-            dirs[:] = [d for d in dirs if not (current_root == DB_PATH and d == "backups")]
+            dirs[:] = [
+                d for d in dirs if not (current_root == DB_PATH and d == "backups")
+            ]
             files.sort()
             for filename in files:
                 full_path = os.path.join(current_root, filename)
@@ -65,7 +74,12 @@ def build_backup_zip() -> tuple[str, str]:
                 archive.write(full_path, arcname=archive_name)
                 included_files += 1
 
-    logger.info("Created DB backup zip at %s with %s files from %s", zip_path, included_files, DB_PATH)
+    logger.info(
+        "Created DB backup zip at %s with %s files from %s",
+        zip_path,
+        included_files,
+        DB_PATH,
+    )
 
     # Kopie serverseitig aufbewahren (Docker: /data/db/backups, Standalone: <db-path>/backups)
     backups_dir = _get_backups_dir()
@@ -125,7 +139,12 @@ def prune_old_backups(max_keep: int = 10) -> int:
         except Exception as e:
             logger.warning("Could not remove old backup %s: %s", path, e)
     if deleted > 0:
-        logger.info("Pruned %s old backups in %s, kept %s newest.", deleted, backups_dir, max_keep)
+        logger.info(
+            "Pruned %s old backups in %s, kept %s newest.",
+            deleted,
+            backups_dir,
+            max_keep,
+        )
     return deleted
 
 

--- a/server/src/service_face.py
+++ b/server/src/service_face.py
@@ -3,6 +3,7 @@ Face detection and embedding service using InsightFace.
 Provides face detection, 512-dim embeddings, thumbnails, and lightweight
 face-quality metadata for indexing and culling.
 """
+
 from __future__ import annotations
 
 import io
@@ -26,8 +27,11 @@ def _get_face_app():
         return _face_app
     try:
         from insightface.app import FaceAnalysis
+
         root = os.environ.get("INSIGHTFACE_ROOT", os.path.expanduser("~/.insightface"))
-        _face_app = FaceAnalysis(name="buffalo_l", root=root, providers=["CPUExecutionProvider"])
+        _face_app = FaceAnalysis(
+            name="buffalo_l", root=root, providers=["CPUExecutionProvider"]
+        )
         _face_app.prepare(ctx_id=0, det_size=(640, 640))
         logger.info("InsightFace FaceAnalysis (buffalo_l) loaded.")
         return _face_app
@@ -44,6 +48,7 @@ def unload_face_app():
     logger.info("Unloading InsightFace FaceAnalysis model...")
     _face_app = None
     import gc
+
     gc.collect()
     logger.info("Unloaded InsightFace model.")
 
@@ -71,7 +76,9 @@ def _compute_face_sharpness(crop_rgb: np.ndarray) -> float:
     return max(0.0, min(1.0, variance / (variance + denominator)))
 
 
-def _compute_eye_openness_proxy(crop_rgb: np.ndarray, bbox_list: List[int], keypoints) -> float:
+def _compute_eye_openness_proxy(
+    crop_rgb: np.ndarray, bbox_list: List[int], keypoints
+) -> float:
     """
     Lightweight proxy for eye openness using vertical gradient energy near eye landmarks.
     This is not a full landmark-based blink detector, but works as a cheap signal.
@@ -99,7 +106,9 @@ def _compute_eye_openness_proxy(crop_rgb: np.ndarray, bbox_list: List[int], keyp
     patch_ratio = CULLING_CONFIG["face_metrics"]["eye_patch_ratio"]
     patch_radius_min = CULLING_CONFIG["face_metrics"]["eye_patch_radius_min"]
     patch_radius_max = CULLING_CONFIG["face_metrics"]["eye_patch_radius_max"]
-    patch_radius = int(max(patch_radius_min, min(patch_radius_max, round(face_span * patch_ratio))))
+    patch_radius = int(
+        max(patch_radius_min, min(patch_radius_max, round(face_span * patch_ratio)))
+    )
     eye_scores = []
 
     # InsightFace 5-point format starts with left and right eye.
@@ -125,15 +134,21 @@ def _compute_eye_openness_proxy(crop_rgb: np.ndarray, bbox_list: List[int], keyp
     return float(sum(eye_scores) / len(eye_scores))
 
 
-def _compute_occlusion_proxy(det_score: float, center_proximity: float, eye_openness: float) -> float:
+def _compute_occlusion_proxy(
+    det_score: float, center_proximity: float, eye_openness: float
+) -> float:
     return max(
         0.0,
         min(
             1.0,
-            1.0 - (
-                CULLING_CONFIG["face_metrics"]["occlusion_det_weight"] * max(0.0, min(1.0, det_score))
-                + CULLING_CONFIG["face_metrics"]["occlusion_center_weight"] * max(0.0, min(1.0, center_proximity))
-                + CULLING_CONFIG["face_metrics"]["occlusion_eye_weight"] * max(0.0, min(1.0, eye_openness))
+            1.0
+            - (
+                CULLING_CONFIG["face_metrics"]["occlusion_det_weight"]
+                * max(0.0, min(1.0, det_score))
+                + CULLING_CONFIG["face_metrics"]["occlusion_center_weight"]
+                * max(0.0, min(1.0, center_proximity))
+                + CULLING_CONFIG["face_metrics"]["occlusion_eye_weight"]
+                * max(0.0, min(1.0, eye_openness))
             ),
         ),
     )
@@ -193,30 +208,42 @@ def detect_faces(image_bytes: bytes) -> List[Dict[str, Any]]:
                 bbox_list = [x1, y1, x2, y2]
                 area_ratio = max(0.0, min(1.0, ((x2 - x1) * (y2 - y1)) / image_area))
                 sharpness = _compute_face_sharpness(crop)
-                eye_openness = _compute_eye_openness_proxy(crop, bbox_list, getattr(face, "kps", None))
+                eye_openness = _compute_eye_openness_proxy(
+                    crop, bbox_list, getattr(face, "kps", None)
+                )
                 center_x = (x1 + x2) / 2.0
                 center_y = (y1 + y2) / 2.0
                 offset_x = abs((center_x / max(1.0, image_width)) - 0.5) * 2.0
                 offset_y = abs((center_y / max(1.0, image_height)) - 0.5) * 2.0
-                center_proximity = max(0.0, min(1.0, 1.0 - ((offset_x + offset_y) / 2.0)))
-                thumb = Image.fromarray(crop).resize((112, 112), Image.Resampling.LANCZOS)
+                center_proximity = max(
+                    0.0, min(1.0, 1.0 - ((offset_x + offset_y) / 2.0))
+                )
+                thumb = Image.fromarray(crop).resize(
+                    (112, 112), Image.Resampling.LANCZOS
+                )
                 buf = io.BytesIO()
                 thumb.save(buf, format="JPEG", quality=85)
-                thumbnail_b64 = base64.standard_b64encode(buf.getvalue()).decode("ascii")
+                thumbnail_b64 = base64.standard_b64encode(buf.getvalue()).decode(
+                    "ascii"
+                )
                 det_score = float(getattr(face, "det_score", 0.0) or 0.0)
-                occlusion = _compute_occlusion_proxy(det_score, center_proximity, eye_openness)
+                occlusion = _compute_occlusion_proxy(
+                    det_score, center_proximity, eye_openness
+                )
 
-        results.append({
-            "embedding": emb,
-            "thumbnail": thumbnail_b64,
-            "bbox": bbox_list,
-            "area_ratio": round(area_ratio, 4),
-            "sharpness": round(sharpness, 4),
-            "det_score": float(getattr(face, "det_score", 0.0) or 0.0),
-            "center_proximity": round(center_proximity, 4),
-            "eye_openness": round(eye_openness, 4),
-            "blink_penalty": round(max(0.0, min(1.0, 1.0 - eye_openness)), 4),
-            "occlusion": round(occlusion, 4),
-        })
+        results.append(
+            {
+                "embedding": emb,
+                "thumbnail": thumbnail_b64,
+                "bbox": bbox_list,
+                "area_ratio": round(area_ratio, 4),
+                "sharpness": round(sharpness, 4),
+                "det_score": float(getattr(face, "det_score", 0.0) or 0.0),
+                "center_proximity": round(center_proximity, 4),
+                "eye_openness": round(eye_openness, 4),
+                "blink_penalty": round(max(0.0, min(1.0, 1.0 - eye_openness)), 4),
+                "occlusion": round(occlusion, 4),
+            }
+        )
 
     return results

--- a/server/src/service_import.py
+++ b/server/src/service_import.py
@@ -4,7 +4,10 @@ import json
 from datetime import datetime as time
 from service_index import _flatten_keywords
 
-def import_metadata_task(metadata_items: list[dict], catalog_id=None) -> tuple[int, int]:
+
+def import_metadata_task(
+    metadata_items: list[dict], catalog_id=None
+) -> tuple[int, int]:
     """
     Process a batch of metadata imports.
 
@@ -22,7 +25,7 @@ def import_metadata_task(metadata_items: list[dict], catalog_id=None) -> tuple[i
     logger.info(f"Starting metadata import task for {total_items} items...")
 
     for item in metadata_items:
-        photo_id = item.get('photo_id') or item.get('uuid')
+        photo_id = item.get("photo_id") or item.get("uuid")
         if not photo_id:
             logger.warning("Skipping item due to missing photo_id.")
             failure_count += 1
@@ -33,44 +36,66 @@ def import_metadata_task(metadata_items: list[dict], catalog_id=None) -> tuple[i
             existing_record = chroma_service.get_image(photo_id)
 
             metadata_to_update = {}
-            if 'keywords' in item and item['keywords'] and item['keywords'] != []:
-                logger.debug(f"Importing keywords for photo_id {photo_id}: {item['keywords']}")
-                metadata_to_update['keywords'] = json.dumps(item['keywords'])
-                metadata_to_update['flattened_keywords'] = _flatten_keywords(item['keywords'])
-            if 'title' in item and item['title'] and item['title'] != '':
-                metadata_to_update['title'] = item['title']
-            if 'caption' in item and item['caption'] and item['caption'] != '':
-                metadata_to_update['caption'] = item['caption']
-            if 'alt_text' in item and item['alt_text'] and item['alt_text'] != '':
-                metadata_to_update['alt_text'] = item['alt_text']
-            
+            if "keywords" in item and item["keywords"] and item["keywords"] != []:
+                logger.debug(
+                    f"Importing keywords for photo_id {photo_id}: {item['keywords']}"
+                )
+                metadata_to_update["keywords"] = json.dumps(item["keywords"])
+                metadata_to_update["flattened_keywords"] = _flatten_keywords(
+                    item["keywords"]
+                )
+            if "title" in item and item["title"] and item["title"] != "":
+                metadata_to_update["title"] = item["title"]
+            if "caption" in item and item["caption"] and item["caption"] != "":
+                metadata_to_update["caption"] = item["caption"]
+            if "alt_text" in item and item["alt_text"] and item["alt_text"] != "":
+                metadata_to_update["alt_text"] = item["alt_text"]
+
             if not metadata_to_update:
-                logger.warning(f"No metadata provided to update for photo_id {photo_id}. Skipping.")
+                logger.warning(
+                    f"No metadata provided to update for photo_id {photo_id}. Skipping."
+                )
                 failure_count += 1
                 continue
 
             # If the record doesn't exist in the DB we will add a metadata-only
             # entry (no embedding). This makes it possible to import metadata
             # independently of embeddings.
-            if not existing_record or not existing_record['ids']:
-                metadata_to_update['run_date'] = time.now().strftime("%Y-%m-%d %H:%M:%S")
-                metadata_to_update['photo_id'] = photo_id
-                metadata_to_update['uuid'] = item.get('uuid', photo_id)
-                chroma_service.add_image(photo_id, None, metadata_to_update, legacy_uuid=item.get('uuid'), catalog_id=catalog_id)
+            if not existing_record or not existing_record["ids"]:
+                metadata_to_update["run_date"] = time.now().strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+                metadata_to_update["photo_id"] = photo_id
+                metadata_to_update["uuid"] = item.get("uuid", photo_id)
+                chroma_service.add_image(
+                    photo_id,
+                    None,
+                    metadata_to_update,
+                    legacy_uuid=item.get("uuid"),
+                    catalog_id=catalog_id,
+                )
                 logger.info(f"Created metadata-only entry for photo_id {photo_id}.")
                 success_count += 1
                 continue
 
-            metadata_to_update['run_date'] = time.now().strftime("%Y-%m-%d %H:%M:%S")
-            metadata_to_update['photo_id'] = photo_id
-            metadata_to_update['uuid'] = item.get('uuid', photo_id)
+            metadata_to_update["run_date"] = time.now().strftime("%Y-%m-%d %H:%M:%S")
+            metadata_to_update["photo_id"] = photo_id
+            metadata_to_update["uuid"] = item.get("uuid", photo_id)
 
-            chroma_service.update_image(photo_id, metadata_to_update, legacy_uuid=item.get('uuid'), catalog_id=catalog_id)
+            chroma_service.update_image(
+                photo_id,
+                metadata_to_update,
+                legacy_uuid=item.get("uuid"),
+                catalog_id=catalog_id,
+            )
             logger.info(f"Successfully imported metadata for photo_id {photo_id}.")
             success_count += 1
 
         except Exception as e:
-            logger.error(f"Error importing metadata for photo_id {photo_id}: {str(e)}", exc_info=True)
+            logger.error(
+                f"Error importing metadata for photo_id {photo_id}: {str(e)}",
+                exc_info=True,
+            )
             failure_count += 1
-            
+
     return success_count, failure_count

--- a/server/src/service_index.py
+++ b/server/src/service_index.py
@@ -12,28 +12,29 @@ from PIL import Image
 import io
 import numpy as np
 
+
 def _flatten_keywords(keywords):
     """
     Flatten keywords from various formats to a comma-separated string.
-    
+
     Handles:
     - Flat list: ["Keyword1", "Keyword2"] -> "Keyword1, Keyword2"
     - Nested dict: {"Category": ["Kw1", "Kw2"], ...} -> "Kw1, Kw2, ..."
     - Already a string: "Keyword1, Keyword2" -> "Keyword1, Keyword2"
-    
+
     Args:
         keywords: List, dict, or string of keywords
-        
+
     Returns:
         Comma-separated string of all keywords
     """
     if not keywords:
         return ""
-    
+
     if isinstance(keywords, str):
         # Already a string, return as-is
         return keywords
-    
+
     seen_keywords = set()
 
     def _append_unique(values, text):
@@ -68,12 +69,12 @@ def _flatten_keywords(keywords):
         flattened = []
         for kw in keywords:
             flattened.extend(_normalize_keyword_text(kw))
-        return ', '.join(flattened)
-    
+        return ", ".join(flattened)
+
     if isinstance(keywords, dict):
         # Nested dict - recursively collect all keywords
         all_keywords = []
-        
+
         def collect_keywords(d):
             for key, value in d.items():
                 if isinstance(value, list):
@@ -89,10 +90,10 @@ def _flatten_keywords(keywords):
                 else:
                     # Single keyword value
                     all_keywords.extend(_normalize_keyword_text(value))
-        
+
         collect_keywords(keywords)
-        return ', '.join(all_keywords)
-    
+        return ", ".join(all_keywords)
+
     return ""
 
 
@@ -130,7 +131,11 @@ def _compute_perceptual_hash(image_bytes: bytes) -> str:
     Returns empty string on failure.
     """
     try:
-        image = Image.open(io.BytesIO(image_bytes)).convert("L").resize((32, 32), Image.Resampling.LANCZOS)
+        image = (
+            Image.open(io.BytesIO(image_bytes))
+            .convert("L")
+            .resize((32, 32), Image.Resampling.LANCZOS)
+        )
         pixels = np.asarray(image, dtype=np.float32)
         dct_matrix = _build_dct_matrix(32)
         dct_transformed = dct_matrix @ pixels @ dct_matrix.T
@@ -175,31 +180,49 @@ def _compute_culling_metrics(image_bytes: bytes) -> dict:
         )
         sharpness_raw = float(np.var(laplacian))
         sharpness = _safe_unit_interval(
-            sharpness_raw / (sharpness_raw + CULLING_CONFIG["image_metrics"]["sharpness_denominator"])
+            sharpness_raw
+            / (sharpness_raw + CULLING_CONFIG["image_metrics"]["sharpness_denominator"])
         )
 
         luminance_mean = float(np.mean(gray))
-        highlight_clip = float(np.mean(gray >= CULLING_CONFIG["image_metrics"]["highlight_threshold"]))
-        shadow_clip = float(np.mean(gray <= CULLING_CONFIG["image_metrics"]["shadow_threshold"]))
+        highlight_clip = float(
+            np.mean(gray >= CULLING_CONFIG["image_metrics"]["highlight_threshold"])
+        )
+        shadow_clip = float(
+            np.mean(gray <= CULLING_CONFIG["image_metrics"]["shadow_threshold"])
+        )
         clipping_penalty = _safe_unit_interval(
             (highlight_clip * CULLING_CONFIG["image_metrics"]["highlight_clip_weight"])
             + (shadow_clip * CULLING_CONFIG["image_metrics"]["shadow_clip_weight"])
         )
         exposure_balance = _safe_unit_interval(
-            1.0 - (
+            1.0
+            - (
                 abs(luminance_mean - CULLING_CONFIG["image_metrics"]["exposure_target"])
                 / CULLING_CONFIG["image_metrics"]["exposure_tolerance"]
             )
         )
         exposure = _safe_unit_interval(
-            (CULLING_CONFIG["image_metrics"]["exposure_balance_weight"] * exposure_balance)
-            + (CULLING_CONFIG["image_metrics"]["exposure_clip_weight"] * (1.0 - clipping_penalty))
+            (
+                CULLING_CONFIG["image_metrics"]["exposure_balance_weight"]
+                * exposure_balance
+            )
+            + (
+                CULLING_CONFIG["image_metrics"]["exposure_clip_weight"]
+                * (1.0 - clipping_penalty)
+            )
         )
 
         blurred = (
-            gray[:-2, :-2] + gray[:-2, 1:-1] + gray[:-2, 2:]
-            + gray[1:-1, :-2] + gray[1:-1, 1:-1] + gray[1:-1, 2:]
-            + gray[2:, :-2] + gray[2:, 1:-1] + gray[2:, 2:]
+            gray[:-2, :-2]
+            + gray[:-2, 1:-1]
+            + gray[:-2, 2:]
+            + gray[1:-1, :-2]
+            + gray[1:-1, 1:-1]
+            + gray[1:-1, 2:]
+            + gray[2:, :-2]
+            + gray[2:, 1:-1]
+            + gray[2:, 2:]
         ) / 9.0
         reference = gray[1:-1, 1:-1]
         residual = np.abs(reference - blurred)
@@ -208,21 +231,31 @@ def _compute_culling_metrics(image_bytes: bytes) -> dict:
             noise_raw = float(np.mean(residual[midtone_mask]))
         else:
             noise_raw = float(np.mean(residual))
-        noise_penalty = _safe_unit_interval(noise_raw / CULLING_CONFIG["image_metrics"]["noise_denominator"])
+        noise_penalty = _safe_unit_interval(
+            noise_raw / CULLING_CONFIG["image_metrics"]["noise_denominator"]
+        )
 
         technical_score = _safe_unit_interval(
             (CULLING_CONFIG["image_metrics"]["technical_weight_sharpness"] * sharpness)
             + (CULLING_CONFIG["image_metrics"]["technical_weight_exposure"] * exposure)
-            + (CULLING_CONFIG["image_metrics"]["technical_weight_noise"] * (1.0 - noise_penalty))
+            + (
+                CULLING_CONFIG["image_metrics"]["technical_weight_noise"]
+                * (1.0 - noise_penalty)
+            )
         )
 
         contrast = _safe_unit_interval(float(np.std(gray)) / 0.25)
         rg = np.abs(rgb[:, :, 0] - rgb[:, :, 1])
         yb = np.abs(0.5 * (rgb[:, :, 0] + rgb[:, :, 1]) - rgb[:, :, 2])
-        colorfulness = _safe_unit_interval(float(np.mean(np.sqrt((rg * rg) + (yb * yb)))) / 0.35)
+        colorfulness = _safe_unit_interval(
+            float(np.mean(np.sqrt((rg * rg) + (yb * yb)))) / 0.35
+        )
         aesthetic_score = _safe_unit_interval(
             (CULLING_CONFIG["image_metrics"]["aesthetic_contrast_weight"] * contrast)
-            + (CULLING_CONFIG["image_metrics"]["aesthetic_colorfulness_weight"] * colorfulness)
+            + (
+                CULLING_CONFIG["image_metrics"]["aesthetic_colorfulness_weight"]
+                * colorfulness
+            )
             + (CULLING_CONFIG["image_metrics"]["aesthetic_exposure_weight"] * exposure)
         )
 
@@ -263,20 +296,35 @@ def _aggregate_face_culling_metrics(face_results: list[dict]) -> dict:
         }
 
     face_count = len(face_results)
-    sharpness_values = [_safe_unit_interval(face.get("sharpness", 0.0)) for face in face_results]
+    sharpness_values = [
+        _safe_unit_interval(face.get("sharpness", 0.0)) for face in face_results
+    ]
     prominence_values = [
-        _safe_unit_interval(face.get("area_ratio", 0.0) / CULLING_CONFIG["face_metrics"]["prominence_normalizer"])
+        _safe_unit_interval(
+            face.get("area_ratio", 0.0)
+            / CULLING_CONFIG["face_metrics"]["prominence_normalizer"]
+        )
         for face in face_results
     ]
     visibility_values = [
         _safe_unit_interval(
-            (CULLING_CONFIG["face_metrics"]["visibility_det_weight"] * _safe_unit_interval(face.get("det_score", 0.0)))
-            + (CULLING_CONFIG["face_metrics"]["visibility_center_weight"] * _safe_unit_interval(face.get("center_proximity", 0.0)))
+            (
+                CULLING_CONFIG["face_metrics"]["visibility_det_weight"]
+                * _safe_unit_interval(face.get("det_score", 0.0))
+            )
+            + (
+                CULLING_CONFIG["face_metrics"]["visibility_center_weight"]
+                * _safe_unit_interval(face.get("center_proximity", 0.0))
+            )
         )
         for face in face_results
     ]
-    eye_openness_values = [_safe_unit_interval(face.get("eye_openness", 0.0)) for face in face_results]
-    blink_penalties = [_safe_unit_interval(face.get("blink_penalty", 1.0)) for face in face_results]
+    eye_openness_values = [
+        _safe_unit_interval(face.get("eye_openness", 0.0)) for face in face_results
+    ]
+    blink_penalties = [
+        _safe_unit_interval(face.get("blink_penalty", 1.0)) for face in face_results
+    ]
     occlusion_values = []
     for face in face_results:
         if "occlusion" in face:
@@ -284,17 +332,29 @@ def _aggregate_face_culling_metrics(face_results: list[dict]) -> dict:
         else:
             occlusion_values.append(
                 _safe_unit_interval(
-                    1.0 - (
-                        (CULLING_CONFIG["face_metrics"]["occlusion_det_weight"] * _safe_unit_interval(face.get("det_score", 0.0)))
-                        + (CULLING_CONFIG["face_metrics"]["occlusion_center_weight"] * _safe_unit_interval(face.get("center_proximity", 0.0)))
-                        + (CULLING_CONFIG["face_metrics"]["occlusion_eye_weight"] * _safe_unit_interval(face.get("eye_openness", 0.0)))
+                    1.0
+                    - (
+                        (
+                            CULLING_CONFIG["face_metrics"]["occlusion_det_weight"]
+                            * _safe_unit_interval(face.get("det_score", 0.0))
+                        )
+                        + (
+                            CULLING_CONFIG["face_metrics"]["occlusion_center_weight"]
+                            * _safe_unit_interval(face.get("center_proximity", 0.0))
+                        )
+                        + (
+                            CULLING_CONFIG["face_metrics"]["occlusion_eye_weight"]
+                            * _safe_unit_interval(face.get("eye_openness", 0.0))
+                        )
                     )
                 )
             )
 
     face_sharpness = max(sharpness_values) if sharpness_values else 0.0
     face_prominence = max(prominence_values) if prominence_values else 0.0
-    face_visibility = sum(visibility_values) / len(visibility_values) if visibility_values else 0.0
+    face_visibility = (
+        sum(visibility_values) / len(visibility_values) if visibility_values else 0.0
+    )
     eye_openness = max(eye_openness_values) if eye_openness_values else 0.0
     blink_penalty = min(blink_penalties) if blink_penalties else 1.0
     occlusion_penalty = min(occlusion_values) if occlusion_values else 0.0
@@ -303,7 +363,10 @@ def _aggregate_face_culling_metrics(face_results: list[dict]) -> dict:
         + (CULLING_CONFIG["face_metrics"]["score_weight_prominence"] * face_prominence)
         + (CULLING_CONFIG["face_metrics"]["score_weight_visibility"] * face_visibility)
         + (CULLING_CONFIG["face_metrics"]["score_weight_eye_openness"] * eye_openness)
-        + (CULLING_CONFIG["face_metrics"]["score_weight_occlusion"] * (1.0 - occlusion_penalty))
+        + (
+            CULLING_CONFIG["face_metrics"]["score_weight_occlusion"]
+            * (1.0 - occlusion_penalty)
+        )
     )
     weight_total = (
         CULLING_CONFIG["face_metrics"]["score_weight_sharpness"]
@@ -332,13 +395,15 @@ def get_uuids_needing_processing(uuids: list[str], options: dict) -> list[str]:
     Returns UUIDs that need processing based on selected tasks and existing backend data.
     Mirrors the same logic as process_image_task for determining what's missing.
     """
-    regenerate_metadata = options.get('regenerate_metadata', True)
-    compute_embeddings = options.get('compute_embeddings', True)
-    compute_metadata = options.get('compute_metadata', False)
-    compute_faces = options.get('compute_faces', False)
-    compute_vertexai = options.get('compute_vertexai', False)
-    any_processing_task_enabled = compute_embeddings or compute_metadata or compute_faces or compute_vertexai
-    catalog_id = options.get('catalog_id')
+    regenerate_metadata = options.get("regenerate_metadata", True)
+    compute_embeddings = options.get("compute_embeddings", True)
+    compute_metadata = options.get("compute_metadata", False)
+    compute_faces = options.get("compute_faces", False)
+    compute_vertexai = options.get("compute_vertexai", False)
+    any_processing_task_enabled = (
+        compute_embeddings or compute_metadata or compute_faces or compute_vertexai
+    )
+    catalog_id = options.get("catalog_id")
 
     if not uuids:
         return []
@@ -347,21 +412,44 @@ def get_uuids_needing_processing(uuids: list[str], options: dict) -> list[str]:
     existing_records = {}
     for uuid in uuids:
         existing_record = chroma_service.get_image(uuid, catalog_id=catalog_id)
-        if existing_record and existing_record['ids']:
-            existing_records[uuid] = existing_record['metadatas'][0] if existing_record['metadatas'] else {}
+        if existing_record and existing_record["ids"]:
+            existing_records[uuid] = (
+                existing_record["metadatas"][0] if existing_record["metadatas"] else {}
+            )
 
     needing_processing = []
     for uuid in uuids:
         existing = existing_records.get(uuid, {})
 
-        needs_embedding = compute_embeddings and (regenerate_metadata or not existing.get('has_embedding', False))
-        has_any_metadata = existing.get('title') or existing.get('caption') or existing.get('alt_text') or existing.get('keywords')
-        needs_metadata = compute_metadata and (regenerate_metadata or not has_any_metadata)
-        needs_faces = compute_faces and (regenerate_metadata or not chroma_service.faces_checked_for_photo(uuid))
-        needs_vertexai = compute_vertexai and (regenerate_metadata or not chroma_service.has_vertex_embedding(uuid))
-        needs_cull_phash = any_processing_task_enabled and (regenerate_metadata or not existing.get('cull_phash'))
+        needs_embedding = compute_embeddings and (
+            regenerate_metadata or not existing.get("has_embedding", False)
+        )
+        has_any_metadata = (
+            existing.get("title")
+            or existing.get("caption")
+            or existing.get("alt_text")
+            or existing.get("keywords")
+        )
+        needs_metadata = compute_metadata and (
+            regenerate_metadata or not has_any_metadata
+        )
+        needs_faces = compute_faces and (
+            regenerate_metadata or not chroma_service.faces_checked_for_photo(uuid)
+        )
+        needs_vertexai = compute_vertexai and (
+            regenerate_metadata or not chroma_service.has_vertex_embedding(uuid)
+        )
+        needs_cull_phash = any_processing_task_enabled and (
+            regenerate_metadata or not existing.get("cull_phash")
+        )
 
-        if needs_embedding or needs_metadata or needs_faces or needs_vertexai or needs_cull_phash:
+        if (
+            needs_embedding
+            or needs_metadata
+            or needs_faces
+            or needs_vertexai
+            or needs_cull_phash
+        ):
             needing_processing.append(uuid)
 
     return needing_processing
@@ -373,16 +461,15 @@ def get_photo_ids_needing_processing(photo_ids: list[str], options: dict) -> lis
 
 
 def process_image_task(
-    image_triplets: list[tuple[bytes, str, str]], 
-    options: dict
+    image_triplets: list[tuple[bytes, str, str]], options: dict
 ) -> tuple[int, int, list[str]]:
     """
     Process a batch of images for indexing.
-    
+
     Args:
         image_triplets: List of (image_bytes, uuid, filename) tuples
         options: Dictionary with all processing options
-        
+
     Returns:
         Tuple of (success_count, failure_count, error_messages, warnings)
     """
@@ -393,86 +480,116 @@ def process_image_task(
     total_images = len(image_triplets)
 
     try:
-        provider = options.get('provider')
-        model_name = options.get('model')
-        replace_ss = options.get('replace_ss', False)
-        regenerate_metadata = options.get('regenerate_metadata', True)
-        compute_embeddings = options.get('compute_embeddings', True)
-        compute_metadata = options.get('compute_metadata', False)
-        compute_faces = options.get('compute_faces', False)
-        compute_vertexai = options.get('compute_vertexai', False)
-        vertex_project_id = options.get('vertex_project_id')
-        vertex_location = options.get('vertex_location')
+        provider = options.get("provider")
+        model_name = options.get("model")
+        replace_ss = options.get("replace_ss", False)
+        regenerate_metadata = options.get("regenerate_metadata", True)
+        compute_embeddings = options.get("compute_embeddings", True)
+        compute_metadata = options.get("compute_metadata", False)
+        compute_faces = options.get("compute_faces", False)
+        compute_vertexai = options.get("compute_vertexai", False)
+        vertex_project_id = options.get("vertex_project_id")
+        vertex_location = options.get("vertex_location")
 
         logger.info(f"Starting batch processing of {total_images} images...")
-        logger.info(f"regenerate_metadata={regenerate_metadata}, compute_embeddings={compute_embeddings}, "
-                   f"compute_metadata={compute_metadata}, compute_faces={compute_faces}, compute_vertexai={compute_vertexai}")
-        
+        logger.info(
+            f"regenerate_metadata={regenerate_metadata}, compute_embeddings={compute_embeddings}, "
+            f"compute_metadata={compute_metadata}, compute_faces={compute_faces}, compute_vertexai={compute_vertexai}"
+        )
+
         # Check existing records if regenerate_metadata is False
-        catalog_id = options.get('catalog_id')
+        catalog_id = options.get("catalog_id")
         existing_records = {}
         if not regenerate_metadata:
-            logger.info("Checking existing records to determine what needs generation...")
+            logger.info(
+                "Checking existing records to determine what needs generation..."
+            )
             for _, uuid, _ in image_triplets:
                 existing_record = chroma_service.get_image(uuid, catalog_id=catalog_id)
-                if existing_record and existing_record['ids']:
-                    existing_records[uuid] = existing_record['metadatas'][0] if existing_record['metadatas'] else {}
-        
+                if existing_record and existing_record["ids"]:
+                    existing_records[uuid] = (
+                        existing_record["metadatas"][0]
+                        if existing_record["metadatas"]
+                        else {}
+                    )
+
         # Determine what actually needs to be computed for each image
         images_needing_embeddings = []
         images_needing_metadata = []
         images_needing_faces = []
         images_needing_vertexai = []
         images_needing_cull_phash = []
-        
+
         for _, uuid, _ in image_triplets:
             existing = existing_records.get(uuid, {})
-            
+
             # Check if embedding is needed
-            needs_embedding = compute_embeddings and (regenerate_metadata or not existing.get('has_embedding', False))
+            needs_embedding = compute_embeddings and (
+                regenerate_metadata or not existing.get("has_embedding", False)
+            )
             if needs_embedding:
                 images_needing_embeddings.append(uuid)
 
             # Check if Vertex AI embedding is needed
-            if compute_vertexai and (regenerate_metadata or not chroma_service.has_vertex_embedding(uuid)):
+            if compute_vertexai and (
+                regenerate_metadata or not chroma_service.has_vertex_embedding(uuid)
+            ):
                 images_needing_vertexai.append(uuid)
 
             # Check if faces are needed
-            needs_faces = compute_faces and (regenerate_metadata or not chroma_service.faces_checked_for_photo(uuid))
+            needs_faces = compute_faces and (
+                regenerate_metadata or not chroma_service.faces_checked_for_photo(uuid)
+            )
             if needs_faces:
                 images_needing_faces.append(uuid)
-            
+
             # Check if metadata is needed
-            has_any_metadata = existing.get('title') or existing.get('caption') or existing.get('alt_text') or existing.get('keywords')
-            needs_metadata = compute_metadata and (regenerate_metadata or not has_any_metadata)
+            has_any_metadata = (
+                existing.get("title")
+                or existing.get("caption")
+                or existing.get("alt_text")
+                or existing.get("keywords")
+            )
+            needs_metadata = compute_metadata and (
+                regenerate_metadata or not has_any_metadata
+            )
             if existing and compute_metadata:
-                logger.info(f"UUID {uuid}: has_metadata={has_any_metadata}, regenerate={regenerate_metadata}, needs_metadata={needs_metadata}")
-                logger.info(f"  Existing fields: title={bool(existing.get('title'))}, caption={bool(existing.get('caption'))}, "
-                          f"alt_text={bool(existing.get('alt_text'))}, keywords={bool(existing.get('keywords'))}")
+                logger.info(
+                    f"UUID {uuid}: has_metadata={has_any_metadata}, regenerate={regenerate_metadata}, needs_metadata={needs_metadata}"
+                )
+                logger.info(
+                    f"  Existing fields: title={bool(existing.get('title'))}, caption={bool(existing.get('caption'))}, "
+                    f"alt_text={bool(existing.get('alt_text'))}, keywords={bool(existing.get('keywords'))}"
+                )
             if needs_metadata:
                 images_needing_metadata.append(uuid)
 
             # cull_phash is part of culling foundation and should be backfilled in delta mode.
-            if regenerate_metadata or not existing.get('cull_phash'):
+            if regenerate_metadata or not existing.get("cull_phash"):
                 images_needing_cull_phash.append(uuid)
-        
-        logger.info(f"Generation needed: {len(images_needing_embeddings)} embeddings, "
-                   f"{len(images_needing_metadata)} metadata, {len(images_needing_faces)} faces, {len(images_needing_vertexai)} vertexai")
+
+        logger.info(
+            f"Generation needed: {len(images_needing_embeddings)} embeddings, "
+            f"{len(images_needing_metadata)} metadata, {len(images_needing_faces)} faces, {len(images_needing_vertexai)} vertexai"
+        )
 
         # If nothing needs to be generated and we're not regenerating, skip work.
         # When regenerate_metadata is True we must not early-return: new images (no entry yet)
         # still need to be added to Chroma with at least minimal metadata.
         # Also do NOT early-return when compute_faces or compute_vertexai is True - we need to process images.
-        if (not regenerate_metadata
-                and not compute_faces
-                and not compute_vertexai
-                and len(images_needing_embeddings) == 0
-                and len(images_needing_metadata) == 0
-                and len(images_needing_cull_phash) == 0):
-            logger.info("No generation required (regenerate_metadata=False and all fields present). Returning success without changes.")
+        if (
+            not regenerate_metadata
+            and not compute_faces
+            and not compute_vertexai
+            and len(images_needing_embeddings) == 0
+            and len(images_needing_metadata) == 0
+            and len(images_needing_cull_phash) == 0
+        ):
+            logger.info(
+                "No generation required (regenerate_metadata=False and all fields present). Returning success without changes."
+            )
             return len(image_triplets), 0, [], []
 
-    
         analysis_service = get_analysis_service()
         siglip_model = None
         siglip_processor = None
@@ -483,8 +600,12 @@ def process_image_task(
         # Convert lists to sets for faster lookup in analyze_batch
         try:
             embeddings, metadata_results = analysis_service.analyze_batch(
-                image_triplets, options, siglip_model, siglip_processor,
-                set(images_needing_embeddings), set(images_needing_metadata)
+                image_triplets,
+                options,
+                siglip_model,
+                siglip_processor,
+                set(images_needing_embeddings),
+                set(images_needing_metadata),
             )
         except Exception as e:
             logger.error(f"Error in analyze_batch: {str(e)}", exc_info=True)
@@ -506,10 +627,14 @@ def process_image_task(
                         vertex_uuids.append(uuid)
                         vertex_bytes.append(image_bytes)
                 if vertex_bytes:
-                    logger.info(f"Generating Vertex AI embeddings for {len(vertex_bytes)} images...")
+                    logger.info(
+                        f"Generating Vertex AI embeddings for {len(vertex_bytes)} images..."
+                    )
                     try:
                         vertex_results = vertexai_service.get_image_embeddings(
-                            vertex_bytes, vertex_project_id=vertex_project_id, vertex_location=vertex_location
+                            vertex_bytes,
+                            vertex_project_id=vertex_project_id,
+                            vertex_location=vertex_location,
                         )
                         for uid, emb in zip(vertex_uuids, vertex_results):
                             if emb is not None:
@@ -519,15 +644,17 @@ def process_image_task(
                         error_messages.append(f"Vertex AI error: {e}")
             else:
                 logger.warning("Vertex AI requested but not available/configured.")
-                warnings.append("Vertex AI requested but not available or correctly configured (check Project ID and authentication).")
+                warnings.append(
+                    "Vertex AI requested but not available or correctly configured (check Project ID and authentication)."
+                )
 
         for i, (image_bytes, uuid, filename) in enumerate(image_triplets):
             try:
                 embedding = embeddings[i] if embeddings is not None else None
                 metadata_data = metadata_results[i] if metadata_results else None
-                
+
                 existing = existing_records.get(uuid, {})
-                
+
                 need_embedding = uuid in images_needing_embeddings
                 need_metadata = uuid in images_needing_metadata
                 need_cull_phash = uuid in images_needing_cull_phash
@@ -540,20 +667,30 @@ def process_image_task(
                     continue
 
                 if need_metadata and (not metadata_data or not metadata_data.success):
-                    error_txt = metadata_data.error if metadata_data and metadata_data.error else "Unknown error"
-                    logger.error(f"Metadata generation failed for {uuid}. Reason: {error_txt}")
+                    error_txt = (
+                        metadata_data.error
+                        if metadata_data and metadata_data.error
+                        else "Unknown error"
+                    )
+                    logger.error(
+                        f"Metadata generation failed for {uuid}. Reason: {error_txt}"
+                    )
                     error_messages.append(f"{filename}: {error_txt}")
                     failure_count += 1
                     continue
-                
+
                 if metadata_data and metadata_data.warning:
                     warnings.append(f"{filename}: {metadata_data.warning}")
 
                 # If nothing needed for this UUID (already complete) and no face processing, skip
                 # When compute_faces is True we must not skip - we need to reach face detection
-                if (not need_embedding and not need_metadata
-                        and not need_cull_phash
-                        and not regenerate_metadata and not compute_faces):
+                if (
+                    not need_embedding
+                    and not need_metadata
+                    and not need_cull_phash
+                    and not regenerate_metadata
+                    and not compute_faces
+                ):
                     logger.info(f"UUID {uuid}: already fully indexed; skipping update.")
                     success_count += 1
                     continue
@@ -578,15 +715,20 @@ def process_image_task(
                 # `date_time_unix` is a seconds-since-epoch float, `date_time` is
                 # an ISO/W3C string kept for backwards compatibility.
                 capture_time = None
-                catalog_time_unix = options.get('date_time_unix')
+                catalog_time_unix = options.get("date_time_unix")
                 if catalog_time_unix is not None:
                     try:
                         capture_time = float(catalog_time_unix)
                     except (TypeError, ValueError):
-                        logger.warning("Invalid date_time_unix value for %s: %r", uuid, catalog_time_unix)
-                elif options.get('date_time'):
+                        logger.warning(
+                            "Invalid date_time_unix value for %s: %r",
+                            uuid,
+                            catalog_time_unix,
+                        )
+                elif options.get("date_time"):
                     from datetime import datetime, timezone
-                    dt_str = options['date_time']
+
+                    dt_str = options["date_time"]
                     try:
                         # Normalize common W3C/ISO forms (e.g. trailing 'Z').
                         normalized = str(dt_str).strip()
@@ -597,7 +739,9 @@ def process_image_task(
                             dt_obj = dt_obj.replace(tzinfo=timezone.utc)
                         capture_time = float(dt_obj.timestamp())
                     except Exception as e:
-                        logger.warning("Could not parse date_time for %s: %r (%s)", uuid, dt_str, e)
+                        logger.warning(
+                            "Could not parse date_time for %s: %r (%s)", uuid, dt_str, e
+                        )
 
                 if capture_time is not None:
                     main_metadata["capture_time"] = capture_time
@@ -612,31 +756,33 @@ def process_image_task(
                 # Update metadata fields if newly generated
                 if metadata_data and metadata_data.success:
                     if metadata_data.title:
-                        main_metadata['title'] = metadata_data.title
+                        main_metadata["title"] = metadata_data.title
                     if metadata_data.caption:
-                        main_metadata['caption'] = metadata_data.caption
+                        main_metadata["caption"] = metadata_data.caption
                     if metadata_data.alt_text:
-                        main_metadata['alt_text'] = metadata_data.alt_text
+                        main_metadata["alt_text"] = metadata_data.alt_text
                     if metadata_data.keywords:
-                        main_metadata['keywords'] = json.dumps(metadata_data.keywords)
-                        #logger.debug(f"UUID {uuid}: keywords JSON data: {main_metadata['keywords']}")
-                        main_metadata['flattened_keywords'] = _flatten_keywords(metadata_data.keywords)
+                        main_metadata["keywords"] = json.dumps(metadata_data.keywords)
+                        # logger.debug(f"UUID {uuid}: keywords JSON data: {main_metadata['keywords']}")
+                        main_metadata["flattened_keywords"] = _flatten_keywords(
+                            metadata_data.keywords
+                        )
                     if not main_metadata.get("provider"):
                         main_metadata["provider"] = provider
                     if not main_metadata.get("model"):
                         main_metadata["model"] = model_name
-                
-                main_metadata['run_date'] = time.now().strftime("%Y-%m-%d %H:%M:%S")
-                
+
+                main_metadata["run_date"] = time.now().strftime("%Y-%m-%d %H:%M:%S")
+
                 # Update embedding status
                 if embedding is not None:
-                    main_metadata['has_embedding'] = True
-                elif existing and existing.get('has_embedding', False):
+                    main_metadata["has_embedding"] = True
+                elif existing and existing.get("has_embedding", False):
                     # Preserve existing embedding - we didn't generate a new one (e.g. only faces)
-                    main_metadata['has_embedding'] = True
+                    main_metadata["has_embedding"] = True
                 else:
-                    main_metadata['has_embedding'] = False
-                
+                    main_metadata["has_embedding"] = False
+
                 if replace_ss:
                     for key, value in main_metadata.items():
                         if isinstance(value, str):
@@ -645,27 +791,53 @@ def process_image_task(
                 # Determine if we need to update the embedding
                 # Only update embedding if we generated a new one
                 update_embedding = embedding if embedding is not None else None
-                
+
                 if existing and not regenerate_metadata:
-                    logger.info(f"UUID {uuid} already exists. Updating (embedding: {update_embedding is not None}).")
+                    logger.info(
+                        f"UUID {uuid} already exists. Updating (embedding: {update_embedding is not None})."
+                    )
                     try:
-                        chroma_service.update_image(uuid, main_metadata, embedding=update_embedding, catalog_id=catalog_id)
+                        chroma_service.update_image(
+                            uuid,
+                            main_metadata,
+                            embedding=update_embedding,
+                            catalog_id=catalog_id,
+                        )
                     except Exception as e:
-                        logger.error(f"Failed to update image {uuid} in ChromaDB: {e}", exc_info=True)
-                        error_messages.append(f"{filename}: Database update failed: {str(e)}")
+                        logger.error(
+                            f"Failed to update image {uuid} in ChromaDB: {e}",
+                            exc_info=True,
+                        )
+                        error_messages.append(
+                            f"{filename}: Database update failed: {str(e)}"
+                        )
                         failure_count += 1
                         continue
                 elif regenerate_metadata:
-                    logger.info(f"UUID {uuid} set to regenerate. Updating (embedding: {update_embedding is not None}).")
+                    logger.info(
+                        f"UUID {uuid} set to regenerate. Updating (embedding: {update_embedding is not None})."
+                    )
                     existing_in_chroma = chroma_service.get_image(uuid)
                     try:
                         if existing_in_chroma and existing_in_chroma.get("ids"):
-                            chroma_service.update_image(uuid, main_metadata, embedding=update_embedding, catalog_id=catalog_id)
+                            chroma_service.update_image(
+                                uuid,
+                                main_metadata,
+                                embedding=update_embedding,
+                                catalog_id=catalog_id,
+                            )
                         else:
-                            chroma_service.add_image(uuid, embedding, main_metadata, catalog_id=catalog_id)
+                            chroma_service.add_image(
+                                uuid, embedding, main_metadata, catalog_id=catalog_id
+                            )
                     except Exception as e:
-                        logger.error(f"Failed to regenerate image {uuid} in ChromaDB: {e}", exc_info=True)
-                        error_messages.append(f"{filename}: Database update failed: {str(e)}")
+                        logger.error(
+                            f"Failed to regenerate image {uuid} in ChromaDB: {e}",
+                            exc_info=True,
+                        )
+                        error_messages.append(
+                            f"{filename}: Database update failed: {str(e)}"
+                        )
                         failure_count += 1
                         continue
                 else:
@@ -673,60 +845,114 @@ def process_image_task(
                     if embedding is not None:
                         logger.info(f"UUID {uuid} is new. Indexing with embeddings.")
                     else:
-                        logger.info(f"UUID {uuid} is new. Indexing metadata-only entry (no embedding).")
+                        logger.info(
+                            f"UUID {uuid} is new. Indexing metadata-only entry (no embedding)."
+                        )
                     try:
-                        chroma_service.add_image(uuid, embedding, main_metadata, catalog_id=catalog_id)
+                        chroma_service.add_image(
+                            uuid, embedding, main_metadata, catalog_id=catalog_id
+                        )
                     except Exception as e:
-                        logger.error(f"Failed to add image {uuid} to ChromaDB: {e}", exc_info=True)
-                        error_messages.append(f"{filename}: Database indexing failed: {str(e)}")
+                        logger.error(
+                            f"Failed to add image {uuid} to ChromaDB: {e}",
+                            exc_info=True,
+                        )
+                        error_messages.append(
+                            f"{filename}: Database indexing failed: {str(e)}"
+                        )
                         failure_count += 1
                         continue
 
                 # Face detection and indexing (second Chroma collection)
                 if compute_faces and image_bytes:
                     # Without regenerate_metadata: skip if already checked (has faces or marked as checked, no faces)
-                    if not regenerate_metadata and chroma_service.faces_checked_for_photo(uuid):
-                        logger.debug(f"UUID {uuid}: faces already checked, skipping (regenerate_metadata=False).")
+                    if (
+                        not regenerate_metadata
+                        and chroma_service.faces_checked_for_photo(uuid)
+                    ):
+                        logger.debug(
+                            f"UUID {uuid}: faces already checked, skipping (regenerate_metadata=False)."
+                        )
                     else:
                         try:
                             chroma_service.delete_faces_by_photo_uuid(uuid)
                             face_results = face_service.detect_faces(image_bytes)
                             if face_results:
-                                face_ids = [f"{uuid}_{i}" for i in range(len(face_results))]
-                                embeddings_f = [face["embedding"] for face in face_results]
-                                thumbnails_b64 = [face.get("thumbnail", "") for face in face_results]
+                                face_ids = [
+                                    f"{uuid}_{i}" for i in range(len(face_results))
+                                ]
+                                embeddings_f = [
+                                    face["embedding"] for face in face_results
+                                ]
+                                thumbnails_b64 = [
+                                    face.get("thumbnail", "") for face in face_results
+                                ]
                                 face_extra_metadatas = [
                                     {
                                         "bbox": json.dumps(face.get("bbox") or []),
                                         "face_area_ratio": face.get("area_ratio", 0.0),
                                         "face_sharpness": face.get("sharpness", 0.0),
                                         "face_det_score": face.get("det_score", 0.0),
-                                        "face_center_proximity": face.get("center_proximity", 0.0),
-                                        "face_eye_openness": face.get("eye_openness", 0.0),
-                                        "face_blink_penalty": face.get("blink_penalty", 1.0),
+                                        "face_center_proximity": face.get(
+                                            "center_proximity", 0.0
+                                        ),
+                                        "face_eye_openness": face.get(
+                                            "eye_openness", 0.0
+                                        ),
+                                        "face_blink_penalty": face.get(
+                                            "blink_penalty", 1.0
+                                        ),
                                         "face_occlusion": face.get("occlusion", 0.0),
                                     }
                                     for face in face_results
                                 ]
                                 chroma_service.add_faces_batch(
-                                    face_ids, embeddings_f, [uuid] * len(face_results), thumbnails_b64,
-                                    extra_metadatas=face_extra_metadatas
+                                    face_ids,
+                                    embeddings_f,
+                                    [uuid] * len(face_results),
+                                    thumbnails_b64,
+                                    extra_metadatas=face_extra_metadatas,
                                 )
-                                main_metadata.update(_aggregate_face_culling_metrics(face_results))
-                                chroma_service.update_image(uuid, main_metadata, embedding=update_embedding, catalog_id=catalog_id)
-                                logger.info(f"UUID {uuid}: indexed {len(face_results)} face(s).")
+                                main_metadata.update(
+                                    _aggregate_face_culling_metrics(face_results)
+                                )
+                                chroma_service.update_image(
+                                    uuid,
+                                    main_metadata,
+                                    embedding=update_embedding,
+                                    catalog_id=catalog_id,
+                                )
+                                logger.info(
+                                    f"UUID {uuid}: indexed {len(face_results)} face(s)."
+                                )
                             else:
-                                main_metadata.update(_aggregate_face_culling_metrics([]))
-                                chroma_service.update_image(uuid, main_metadata, embedding=update_embedding, catalog_id=catalog_id)
+                                main_metadata.update(
+                                    _aggregate_face_culling_metrics([])
+                                )
+                                chroma_service.update_image(
+                                    uuid,
+                                    main_metadata,
+                                    embedding=update_embedding,
+                                    catalog_id=catalog_id,
+                                )
                                 chroma_service.set_faces_checked(uuid)
-                                logger.debug(f"UUID {uuid}: no faces detected (marked as checked).")
+                                logger.debug(
+                                    f"UUID {uuid}: no faces detected (marked as checked)."
+                                )
                         except Exception as e:
-                            logger.warning(f"Face detection/indexing failed for {uuid}: {e}", exc_info=True)
+                            logger.warning(
+                                f"Face detection/indexing failed for {uuid}: {e}",
+                                exc_info=True,
+                            )
                             error_messages.append(f"{filename} faces: {e}")
 
                 # Vertex AI embeddings (optional, separate Chroma collection)
                 if uuid in vertex_embeddings_by_uuid:
-                    chroma_service.add_vertex_image(uuid, vertex_embeddings_by_uuid[uuid], {"photo_id": uuid, "uuid": uuid})
+                    chroma_service.add_vertex_image(
+                        uuid,
+                        vertex_embeddings_by_uuid[uuid],
+                        {"photo_id": uuid, "uuid": uuid},
+                    )
                     logger.debug(f"UUID {uuid}: Vertex AI embedding stored.")
 
                 success_count += 1

--- a/server/src/service_metadata.py
+++ b/server/src/service_metadata.py
@@ -3,12 +3,13 @@ Service layer for metadata generation across different LLM providers.
 Handles provider selection, initialization, and orchestration.
 Uses lazy loading - providers are only initialized when needed.
 """
+
 from typing import Dict, List, Optional, Any
 from llm_provider_base import (
-    LLMProviderBase, 
+    LLMProviderBase,
     EditGenerationRequest,
     EditGenerationResponse,
-    MetadataGenerationRequest, 
+    MetadataGenerationRequest,
     MetadataGenerationResponse,
 )
 from llm_provider_ollama import OllamaProvider
@@ -24,17 +25,18 @@ import torch
 import torch.nn.functional as F
 from config import TORCH_DEVICE
 
+
 class AnalysisService:
     """
     Central service for managing metadata generation across multiple LLM providers.
     Handles provider initialization, selection, and fallback logic.
     Uses lazy loading - providers are created but models loaded only on first use.
     """
-    
+
     def __init__(self, lazy_load=True):
         """
         Initialize the metadata service with all available providers.
-        
+
         Args:
             lazy_load: If True, only check availability. Models are loaded on first use.
         """
@@ -43,88 +45,107 @@ class AnalysisService:
         self.provider_errors: Dict[str, str] = {}
         self.lazy_load = lazy_load
         self._initialize_providers()
-    
+
     def _initialize_providers(self):
         """
         Initialize all configured providers with lazy loading.
         Providers are created but heavy models are only loaded on first use.
-        
+
         Note: Ollama and LM Studio availability is NOT checked here - they will be
         dynamically checked when listing models, allowing them to be started after server startup.
         """
         logger.info("Checking available LLM providers (lazy loading enabled)...")
-        
+
         # Ollama (local) - Always register, availability checked dynamically
         try:
             ollama = OllamaProvider({})
-            self.providers['ollama'] = ollama
+            self.providers["ollama"] = ollama
             if ollama.is_available():
-                self.provider_status['ollama'] = 'available'
+                self.provider_status["ollama"] = "available"
                 logger.info("[OK] Ollama provider available")
             else:
-                self.provider_status['ollama'] = 'registered'
-                logger.info("[INFO] Ollama provider registered (server not running, can be started later)")
+                self.provider_status["ollama"] = "registered"
+                logger.info(
+                    "[INFO] Ollama provider registered (server not running, can be started later)"
+                )
         except Exception as e:
-            self.provider_status['ollama'] = 'failed'
-            self.provider_errors['ollama'] = str(e)
+            self.provider_status["ollama"] = "failed"
+            self.provider_errors["ollama"] = str(e)
             logger.error(f"[FAIL] Failed to initialize Ollama provider: {e}")
-        
+
         # LM Studio (local) - Always register, availability checked dynamically
         try:
             lmstudio = LMStudioProvider({})
-            self.providers['lmstudio'] = lmstudio
+            self.providers["lmstudio"] = lmstudio
             if lmstudio.is_available():
-                self.provider_status['lmstudio'] = 'available'
+                self.provider_status["lmstudio"] = "available"
                 logger.info("[OK] LM Studio provider initialized")
             else:
-                self.provider_status['lmstudio'] = 'registered'
-                logger.info("[INFO] LM Studio provider registered (server not running, can be started later)")
+                self.provider_status["lmstudio"] = "registered"
+                logger.info(
+                    "[INFO] LM Studio provider registered (server not running, can be started later)"
+                )
         except Exception as e:
-            self.provider_status['lmstudio'] = 'failed'
-            self.provider_errors['lmstudio'] = str(e)
+            self.provider_status["lmstudio"] = "failed"
+            self.provider_errors["lmstudio"] = str(e)
             logger.error(f"[FAIL] Failed to initialize LM Studio provider: {e}")
-        
+
         # ChatGPT (cloud) - Always add to providers, API key can be provided later
         try:
             chatgpt = ChatGPTProvider({})
-            self.providers['chatgpt'] = chatgpt
+            self.providers["chatgpt"] = chatgpt
             if chatgpt.is_available():
-                self.provider_status['chatgpt'] = 'available'
+                self.provider_status["chatgpt"] = "available"
                 logger.info("[OK] ChatGPT provider initialized")
             else:
-                self.provider_status['chatgpt'] = 'registered'
-                logger.info("[INFO] ChatGPT provider registered (API key not configured, can be provided later)")
+                self.provider_status["chatgpt"] = "registered"
+                logger.info(
+                    "[INFO] ChatGPT provider registered (API key not configured, can be provided later)"
+                )
         except Exception as e:
-            self.provider_status['chatgpt'] = 'failed'
-            self.provider_errors['chatgpt'] = str(e)
+            self.provider_status["chatgpt"] = "failed"
+            self.provider_errors["chatgpt"] = str(e)
             logger.error(f"[FAIL] Failed to initialize ChatGPT provider: {e}")
-        
+
         # Gemini (cloud) - Always add to providers, API key can be provided later
         try:
             gemini = GeminiProvider({})
-            self.providers['gemini'] = gemini
+            self.providers["gemini"] = gemini
             if gemini.is_available():
-                self.provider_status['gemini'] = 'available'
+                self.provider_status["gemini"] = "available"
                 logger.info("[OK] Gemini provider initialized")
             else:
-                self.provider_status['gemini'] = 'registered'
-                logger.info("[INFO] Gemini provider registered (API key not configured, can be provided later)")
+                self.provider_status["gemini"] = "registered"
+                logger.info(
+                    "[INFO] Gemini provider registered (API key not configured, can be provided later)"
+                )
         except Exception as e:
-            self.provider_status['gemini'] = 'failed'
-            self.provider_errors['gemini'] = str(e)
+            self.provider_status["gemini"] = "failed"
+            self.provider_errors["gemini"] = str(e)
             logger.error(f"[FAIL] Failed to initialize Gemini provider: {e}")
-        
+
         if not self.providers:
-            logger.error("[WARN] No LLM providers available! Metadata generation will not work.")
+            logger.error(
+                "[WARN] No LLM providers available! Metadata generation will not work."
+            )
         else:
-            logger.info(f"Metadata service ready with {len(self.providers)} provider(s): {', '.join(self.providers.keys())}")
-    
+            logger.info(
+                f"Metadata service ready with {len(self.providers)} provider(s): {', '.join(self.providers.keys())}"
+            )
+
     def get_available_providers(self) -> List[str]:
         """Get list of available provider names"""
         return list(self.providers.keys())
 
-    def analyze_batch(self, image_triplets: list[tuple[bytes, str, str]], options: dict, image_model, image_processor,
-                     uuids_needing_embeddings=None, uuids_needing_metadata=None):
+    def analyze_batch(
+        self,
+        image_triplets: list[tuple[bytes, str, str]],
+        options: dict,
+        image_model,
+        image_processor,
+        uuids_needing_embeddings=None,
+        uuids_needing_metadata=None,
+    ):
         """
         Analyzes a batch of images, generating embeddings and metadata.
         Only generates data for UUIDs in the corresponding needing_* lists.
@@ -135,37 +156,59 @@ class AnalysisService:
 
         # If no specific UUIDs lists provided, generate for all (backward compatibility)
         if uuids_needing_embeddings is None:
-            uuids_needing_embeddings = uuids if options.get('compute_embeddings', True) else []
+            uuids_needing_embeddings = (
+                uuids if options.get("compute_embeddings", True) else []
+            )
         if uuids_needing_metadata is None:
-            uuids_needing_metadata = uuids if options.get('compute_metadata', False) else []
+            uuids_needing_metadata = (
+                uuids if options.get("compute_metadata", False) else []
+            )
 
         embeddings = None
         if len(uuids_needing_embeddings) > 0:
-            logger.debug(f"Generating embeddings for {len(uuids_needing_embeddings)} images...")
+            logger.debug(
+                f"Generating embeddings for {len(uuids_needing_embeddings)} images..."
+            )
             embeddings = []
             for i, uuid in enumerate(uuids):
                 if uuid in uuids_needing_embeddings:
-                    emb = self._generate_image_embeddings([images[i]], image_model, image_processor)
+                    emb = self._generate_image_embeddings(
+                        [images[i]], image_model, image_processor
+                    )
                     embeddings.append(emb[0] if emb else None)
                 else:
-                    embeddings.append(None)  # Placeholder for images not needing embeddings
+                    embeddings.append(
+                        None
+                    )  # Placeholder for images not needing embeddings
 
         metadata_results = None
         if len(uuids_needing_metadata) > 0:
-            logger.info(f"Generating metadata for {len(uuids_needing_metadata)} images out of {len(uuids)} total")
+            logger.info(
+                f"Generating metadata for {len(uuids_needing_metadata)} images out of {len(uuids)} total"
+            )
             logger.info(f"UUIDs needing metadata: {uuids_needing_metadata}")
             # Filter to only process images that need metadata
-            filtered_triplets = [(image_data[i], uuids[i], '') for i, uuid in enumerate(uuids) if uuid in uuids_needing_metadata]
-            logger.info(f"Filtered to {len(filtered_triplets)} triplets for metadata generation")
-            partial_results = self._generate_metadata_batch([t[1] for t in filtered_triplets], 
-                                                           [t[0] for t in filtered_triplets], 
-                                                           options)
+            filtered_triplets = [
+                (image_data[i], uuids[i], "")
+                for i, uuid in enumerate(uuids)
+                if uuid in uuids_needing_metadata
+            ]
+            logger.info(
+                f"Filtered to {len(filtered_triplets)} triplets for metadata generation"
+            )
+            partial_results = self._generate_metadata_batch(
+                [t[1] for t in filtered_triplets],
+                [t[0] for t in filtered_triplets],
+                options,
+            )
             # Reconstruct full results array with None for images that didn't need metadata
             metadata_results = []
             partial_idx = 0
             for uuid in uuids:
                 if uuid in uuids_needing_metadata:
-                    metadata_results.append(partial_results[partial_idx] if partial_results else None)
+                    metadata_results.append(
+                        partial_results[partial_idx] if partial_results else None
+                    )
                     partial_idx += 1
                 else:
                     metadata_results.append(None)
@@ -175,7 +218,9 @@ class AnalysisService:
         # service_index.process_image_task.
         return embeddings, metadata_results
 
-    def _generate_image_embeddings(self, images: List[Image.Image], image_model, image_processor) -> List[Optional[List[float]]]:
+    def _generate_image_embeddings(
+        self, images: List[Image.Image], image_model, image_processor
+    ) -> List[Optional[List[float]]]:
         """
         Generates embeddings for all images in the batch.
         Errors are handled per image.
@@ -183,7 +228,7 @@ class AnalysisService:
         if not image_model:
             logger.error("Vision model not initialized.")
             return [None] * len(images)
-        
+
         embeddings = []
 
         for i, image in enumerate(images):
@@ -196,14 +241,19 @@ class AnalysisService:
                     image_features = image_model.encode_image(image_tensor)
                     normalized_embeddings = F.normalize(image_features, p=2, dim=1)
                     embeddings.append(normalized_embeddings.cpu().numpy()[0])
-            
+
             except Exception as e:
-                logger.error(f"Failed to generate image embedding for image at index {i}: {e}", exc_info=True)
+                logger.error(
+                    f"Failed to generate image embedding for image at index {i}: {e}",
+                    exc_info=True,
+                )
                 embeddings.append(None)
-        
+
         return embeddings
 
-    def _generate_metadata_batch(self, uuids: List[str], image_data: List[bytes], options: dict) -> List[Optional[MetadataGenerationResponse]]:
+    def _generate_metadata_batch(
+        self, uuids: List[str], image_data: List[bytes], options: dict
+    ) -> List[Optional[MetadataGenerationResponse]]:
         """
         Generates metadata for all images in the batch.
         """
@@ -214,56 +264,57 @@ class AnalysisService:
         return results
 
     def generate_metadata_single(
-        self,
-        uuid: str,
-        image_data: bytes,
-        options: dict
+        self, uuid: str, image_data: bytes, options: dict
     ) -> MetadataGenerationResponse:
         """
         Generate metadata for a single image.
         """
-        provider = options.get('provider') or DEFAULT_METADATA_PROVIDER
-        
+        provider = options.get("provider") or DEFAULT_METADATA_PROVIDER
+
         if provider not in self.providers:
             if not self.providers:
-                return MetadataGenerationResponse(uuid=uuid, success=False, error="No LLM providers available")
+                return MetadataGenerationResponse(
+                    uuid=uuid, success=False, error="No LLM providers available"
+                )
             provider = list(self.providers.keys())[0]
-            warning_msg = f"Requested provider not available, using fallback: {provider}"
+            warning_msg = (
+                f"Requested provider not available, using fallback: {provider}"
+            )
             logger.warning(warning_msg)
-        
+
         selected_provider = self.providers[provider]
         logger.info(f"Generating metadata for {uuid} using {provider}")
-        
+
         request = MetadataGenerationRequest(
             image_data=image_data,
             uuid=uuid,
             provider=provider,
-            model=options['model'],
-            api_key=options.get('api_key'),
-            generate_keywords=options['generate_keywords'],
-            generate_caption=options['generate_caption'],
-            generate_title=options['generate_title'],
-            generate_alt_text=options['generate_alt_text'],
-            language=options['language'],
-            temperature=options['temperature'],
-            max_tokens=options.get('max_tokens'),
-            user_prompt=options.get('user_prompt'),
-            submit_gps=options['submit_gps'],
-            submit_keywords=options['submit_keywords'],
-            submit_folder_names=options['submit_folder_names'],
-            existing_keywords=options.get('existing_keywords'),
-            gps_coordinates=options.get('gps_coordinates'),
-            folder_names=options.get('folder_names'),
-            user_context=options.get('user_context'),
-            keyword_categories=options.get('keyword_categories'),
-            bilingual_keywords=options.get('bilingual_keywords', False),
-            keyword_secondary_language=options.get('keyword_secondary_language'),
-            system_prompt=options.get('prompt'),
-            date_time=options.get('date_time'),
-            ollama_base_url=options.get('ollama_base_url'),
-            lmstudio_base_url=options.get('lmstudio_base_url'),
+            model=options["model"],
+            api_key=options.get("api_key"),
+            generate_keywords=options["generate_keywords"],
+            generate_caption=options["generate_caption"],
+            generate_title=options["generate_title"],
+            generate_alt_text=options["generate_alt_text"],
+            language=options["language"],
+            temperature=options["temperature"],
+            max_tokens=options.get("max_tokens"),
+            user_prompt=options.get("user_prompt"),
+            submit_gps=options["submit_gps"],
+            submit_keywords=options["submit_keywords"],
+            submit_folder_names=options["submit_folder_names"],
+            existing_keywords=options.get("existing_keywords"),
+            gps_coordinates=options.get("gps_coordinates"),
+            folder_names=options.get("folder_names"),
+            user_context=options.get("user_context"),
+            keyword_categories=options.get("keyword_categories"),
+            bilingual_keywords=options.get("bilingual_keywords", False),
+            keyword_secondary_language=options.get("keyword_secondary_language"),
+            system_prompt=options.get("prompt"),
+            date_time=options.get("date_time"),
+            ollama_base_url=options.get("ollama_base_url"),
+            lmstudio_base_url=options.get("lmstudio_base_url"),
         )
-        
+
         # Diagnostic logging for prompt context
         ctx_summary = []
         if request.existing_keywords:
@@ -282,25 +333,29 @@ class AnalysisService:
         try:
             response = selected_provider.generate_metadata(request)
             if not response.success:
-                logger.error(f"[FAIL] Failed to generate metadata for {uuid}: {response.error}")
-            if 'warning_msg' in locals():
+                logger.error(
+                    f"[FAIL] Failed to generate metadata for {uuid}: {response.error}"
+                )
+            if "warning_msg" in locals():
                 response.warning = warning_msg
             return response
         except Exception as e:
-            logger.error(f"Unexpected error during metadata generation for {uuid}: {e}", exc_info=True)
+            logger.error(
+                f"Unexpected error during metadata generation for {uuid}: {e}",
+                exc_info=True,
+            )
             return MetadataGenerationResponse(uuid=uuid, success=False, error=str(e))
 
     def generate_edit_recipe_single(
-        self,
-        uuid: str,
-        image_data: bytes,
-        options: dict
+        self, uuid: str, image_data: bytes, options: dict
     ) -> EditGenerationResponse:
-        provider = options.get('provider') or DEFAULT_METADATA_PROVIDER
+        provider = options.get("provider") or DEFAULT_METADATA_PROVIDER
 
         if provider not in self.providers:
             if not self.providers:
-                return EditGenerationResponse(uuid=uuid, success=False, error="No LLM providers available")
+                return EditGenerationResponse(
+                    uuid=uuid, success=False, error="No LLM providers available"
+                )
             provider = list(self.providers.keys())[0]
             warning_msg = f"Requested provider '{provider}' not available, using fallback: {provider}"
             logger.warning(warning_msg)
@@ -312,60 +367,64 @@ class AnalysisService:
             image_data=image_data,
             uuid=uuid,
             provider=provider,
-            model=options['model'],
-            api_key=options.get('api_key'),
-            language=options.get('language', DEFAULT_METADATA_LANGUAGE),
-            temperature=options.get('temperature', 0.2),
-            max_tokens=options.get('max_tokens'),
-            user_prompt=options.get('user_prompt'),
-            submit_gps=options.get('submit_gps', False),
-            submit_keywords=options.get('submit_keywords', False),
-            submit_folder_names=options.get('submit_folder_names', False),
-            existing_keywords=options.get('existing_keywords'),
-            gps_coordinates=options.get('gps_coordinates'),
-            folder_names=options.get('folder_names'),
-            user_context=options.get('user_context'),
-            system_prompt=options.get('prompt'),
-            date_time=options.get('date_time'),
-            edit_intent=options.get('edit_intent'),
-            style_strength=options.get('style_strength', 0.5),
-            include_masks=options.get('include_masks', True),
-            adjust_white_balance=options.get('adjust_white_balance', True),
-            adjust_basic_tone=options.get('adjust_basic_tone', True),
-            adjust_presence=options.get('adjust_presence', True),
-            adjust_color_mix=options.get('adjust_color_mix', True),
-            do_color_grading=options.get('do_color_grading', True),
-            use_tone_curve=options.get('use_tone_curve', True),
-            use_point_curve=options.get('use_point_curve', True),
-            adjust_detail=options.get('adjust_detail', True),
-            adjust_effects=options.get('adjust_effects', True),
-            adjust_lens_corrections=options.get('adjust_lens_corrections', True),
-            allow_auto_crop=options.get('allow_auto_crop', True),
-            composition_mode=options.get('composition_mode', 'subtle'),
-            ollama_base_url=options.get('ollama_base_url'),
-            lmstudio_base_url=options.get('lmstudio_base_url'),
+            model=options["model"],
+            api_key=options.get("api_key"),
+            language=options.get("language", DEFAULT_METADATA_LANGUAGE),
+            temperature=options.get("temperature", 0.2),
+            max_tokens=options.get("max_tokens"),
+            user_prompt=options.get("user_prompt"),
+            submit_gps=options.get("submit_gps", False),
+            submit_keywords=options.get("submit_keywords", False),
+            submit_folder_names=options.get("submit_folder_names", False),
+            existing_keywords=options.get("existing_keywords"),
+            gps_coordinates=options.get("gps_coordinates"),
+            folder_names=options.get("folder_names"),
+            user_context=options.get("user_context"),
+            system_prompt=options.get("prompt"),
+            date_time=options.get("date_time"),
+            edit_intent=options.get("edit_intent"),
+            style_strength=options.get("style_strength", 0.5),
+            include_masks=options.get("include_masks", True),
+            adjust_white_balance=options.get("adjust_white_balance", True),
+            adjust_basic_tone=options.get("adjust_basic_tone", True),
+            adjust_presence=options.get("adjust_presence", True),
+            adjust_color_mix=options.get("adjust_color_mix", True),
+            do_color_grading=options.get("do_color_grading", True),
+            use_tone_curve=options.get("use_tone_curve", True),
+            use_point_curve=options.get("use_point_curve", True),
+            adjust_detail=options.get("adjust_detail", True),
+            adjust_effects=options.get("adjust_effects", True),
+            adjust_lens_corrections=options.get("adjust_lens_corrections", True),
+            allow_auto_crop=options.get("allow_auto_crop", True),
+            composition_mode=options.get("composition_mode", "subtle"),
+            ollama_base_url=options.get("ollama_base_url"),
+            lmstudio_base_url=options.get("lmstudio_base_url"),
         )
 
         # Query similar training examples for few-shot style injection.
         training_examples = None
-        use_training = options.get('use_training_style', True)
+        use_training = options.get("use_training_style", True)
         if use_training:
             try:
                 # Re-use the CLIP embedding of the current photo from the main collection
                 # (best-effort: skip if not available).
                 import service_chroma as chroma_service
+
                 existing = chroma_service.get_image(uuid)
                 embedding = None
                 if existing and existing.get("ids") and existing.get("embeddings"):
                     raw_emb = existing["embeddings"][0]
                     if raw_emb is not None:
                         import numpy as np
+
                         emb_arr = np.asarray(raw_emb, dtype=np.float32)
                         if emb_arr.size > 0 and not np.allclose(emb_arr, 0.0):
                             embedding = emb_arr.tolist()
                 if embedding is not None:
-                    training_examples = training_service.query_similar_training_examples(
-                        embedding, n_results=3
+                    training_examples = (
+                        training_service.query_similar_training_examples(
+                            embedding, n_results=3
+                        )
                     )
                     if training_examples:
                         logger.info(
@@ -374,7 +433,9 @@ class AnalysisService:
                             uuid,
                         )
             except Exception as exc:
-                training_warning = f"Could not retrieve training examples for uuid={uuid}: {exc}"
+                training_warning = (
+                    f"Could not retrieve training examples for uuid={uuid}: {exc}"
+                )
                 logger.warning(training_warning)
 
         request.training_examples = training_examples or []
@@ -401,20 +462,25 @@ class AnalysisService:
                     },
                 )
             if not response.success:
-                logger.error(f"[FAIL] Failed to generate edit recipe for {uuid}: {response.error}")
-            
+                logger.error(
+                    f"[FAIL] Failed to generate edit recipe for {uuid}: {response.error}"
+                )
+
             # Aggregate warnings
             warnings = []
-            if 'warning_msg' in locals():
+            if "warning_msg" in locals():
                 warnings.append(warning_msg)
-            if 'training_warning' in locals():
+            if "training_warning" in locals():
                 warnings.append(training_warning)
             if warnings:
                 response.warning = " | ".join(warnings)
-                
+
             return response
         except Exception as e:
-            logger.error(f"Unexpected error during edit generation for {uuid}: {e}", exc_info=True)
+            logger.error(
+                f"Unexpected error during edit generation for {uuid}: {e}",
+                exc_info=True,
+            )
             return EditGenerationResponse(uuid=uuid, success=False, error=str(e))
 
     def get_available_models(
@@ -430,25 +496,31 @@ class AnalysisService:
         result: Dict[str, List[str]] = {}
         for provider_name, provider_instance in self.providers.items():
             try:
-                if provider_name == 'chatgpt' and openai_apikey:
+                if provider_name == "chatgpt" and openai_apikey:
                     provider_instance.api_key = openai_apikey
-                if provider_name == 'gemini' and gemini_apikey:
+                if provider_name == "gemini" and gemini_apikey:
                     provider_instance.api_key = gemini_apikey
-                
-                if provider_name == 'ollama' and ollama_base_url:
-                    provider_instance = OllamaProvider({'base_url': ollama_base_url})
-                if provider_name == 'lmstudio' and lmstudio_base_url:
+
+                if provider_name == "ollama" and ollama_base_url:
+                    provider_instance = OllamaProvider({"base_url": ollama_base_url})
+                if provider_name == "lmstudio" and lmstudio_base_url:
                     # Reuse existing provider instance but point it to a different host
                     provider_instance.host = lmstudio_base_url
 
-                if provider_name in ['ollama', 'lmstudio'] and not provider_instance.is_available():
+                if (
+                    provider_name in ["ollama", "lmstudio"]
+                    and not provider_instance.is_available()
+                ):
                     result[provider_name] = []
                     continue
 
                 models = provider_instance.list_available_models()
                 result[provider_name] = models
             except Exception as e:
-                logger.error(f"Error listing models for provider {provider_name}: {e}", exc_info=True)
+                logger.error(
+                    f"Error listing models for provider {provider_name}: {e}",
+                    exc_info=True,
+                )
                 result[provider_name] = []
         return result
 
@@ -456,11 +528,13 @@ class AnalysisService:
         """Return health status of LLM providers."""
         return {
             "llm_providers": self.provider_status,
-            "llm_errors": self.provider_errors
+            "llm_errors": self.provider_errors,
         }
+
 
 # Global service instance
 _analysis_service: Optional[AnalysisService] = None
+
 
 def get_analysis_service() -> AnalysisService:
     """

--- a/server/src/service_metadata.py
+++ b/server/src/service_metadata.py
@@ -266,10 +266,14 @@ class AnalysisService:
         
         # Diagnostic logging for prompt context
         ctx_summary = []
-        if request.existing_keywords: ctx_summary.append(f"{len(request.existing_keywords)} keywords")
-        if request.folder_names: ctx_summary.append(f"{len(request.folder_names)} folders")
-        if request.user_context: ctx_summary.append(f"context ({len(str(request.user_context))} chars)")
-        if request.gps_coordinates: ctx_summary.append("GPS")
+        if request.existing_keywords:
+            ctx_summary.append(f"{len(request.existing_keywords)} keywords")
+        if request.folder_names:
+            ctx_summary.append(f"{len(request.folder_names)} folders")
+        if request.user_context:
+            ctx_summary.append(f"context ({len(str(request.user_context))} chars)")
+        if request.gps_coordinates:
+            ctx_summary.append("GPS")
         if ctx_summary:
             logger.info(f"Context for {uuid}: {', '.join(ctx_summary)}")
         else:

--- a/server/src/service_persons.py
+++ b/server/src/service_persons.py
@@ -6,6 +6,7 @@ Distance scale: API accepts cosine distance (1 - cosine_similarity), same as Imm
 - Immich default 0.7, typical range 0.4–0.8 (higher = merge more).
 - Converted to L2 for sklearn: L2 = sqrt(2 * cosine_distance) for unit vectors.
 """
+
 from __future__ import annotations
 
 import json
@@ -107,12 +108,12 @@ def run_clustering(
     # Cosine distance -> L2 for unit vectors: L2 = sqrt(2 * cos_dist)
     l2_threshold = math.sqrt(2.0 * float(distance_threshold))
     agg_linkage = "complete" if linkage != "average" else "average"
-    
+
     data = chroma_service.get_all_faces(include_embeddings=True)
     if not data or not data.get("ids"):
         logger.info("No faces to cluster (or service not initialized).")
         return {"person_count": 0, "face_count": 0, "updated": 0, "unassigned": 0}
-        
+
     ids = data.get("ids", [])
     embeddings = data.get("embeddings", [])
     metadatas = data.get("metadatas", [])
@@ -125,7 +126,9 @@ def run_clustering(
     n = len(ids)
 
     if n == 1:
-        labels = [0] if min_faces_per_person is None or min_faces_per_person <= 1 else [-1]
+        labels = (
+            [0] if min_faces_per_person is None or min_faces_per_person <= 1 else [-1]
+        )
     else:
         if min_faces_per_person is not None and min_faces_per_person >= 2:
             clustering = DBSCAN(
@@ -196,12 +199,14 @@ def run_clustering(
         else:
             person_id = label_to_person.get(lb, f"person_{next_new_idx}")
         new_meta = dict(meta or {})
-        new_meta.update({
-            "photo_id": meta.get("photo_id", meta.get("photo_uuid", "")),
-            "photo_uuid": meta.get("photo_uuid", meta.get("photo_id", "")),
-            "thumbnail": meta.get("thumbnail", ""),
-            "person_id": person_id,
-        })
+        new_meta.update(
+            {
+                "photo_id": meta.get("photo_id", meta.get("photo_uuid", "")),
+                "photo_uuid": meta.get("photo_uuid", meta.get("photo_id", "")),
+                "thumbnail": meta.get("thumbnail", ""),
+                "person_id": person_id,
+            }
+        )
         new_metadatas.append(new_meta)
 
     chroma_service.update_face_metadatas(ids, new_metadatas)
@@ -226,7 +231,7 @@ def list_persons() -> List[Dict[str, Any]]:
     data = chroma_service.get_all_faces(include_embeddings=False)
     if not data or not data.get("ids"):
         return []
-        
+
     ids = data.get("ids", [])
     metadatas = data.get("metadatas", [])
 
@@ -239,25 +244,35 @@ def list_persons() -> List[Dict[str, Any]]:
         if pid == "":
             pid = "_unassigned"
         if pid not in by_person:
-            by_person[pid] = {"person_id": pid if pid != "_unassigned" else "", "face_ids": [], "photo_ids": set()}
+            by_person[pid] = {
+                "person_id": pid if pid != "_unassigned" else "",
+                "face_ids": [],
+                "photo_ids": set(),
+            }
         by_person[pid]["face_ids"].append(ids[i] if i < len(ids) else "")
-        by_person[pid]["photo_ids"].add(meta.get("photo_id", meta.get("photo_uuid", "")))
+        by_person[pid]["photo_ids"].add(
+            meta.get("photo_id", meta.get("photo_uuid", ""))
+        )
 
     result = []
+
     def _sort_key(item):
         pid, info = item[0], item[1]
         photo_count = len(info["photo_ids"])
         if pid == "_unassigned" or pid == "person_unassigned":
             return (1, 0, pid)  # unassigned at end
         return (0, -photo_count, pid)  # most photos first
+
     for pid, info in sorted(by_person.items(), key=_sort_key):
         person_id = info["person_id"]
-        result.append({
-            "person_id": person_id,
-            "name": names.get(person_id, "") if person_id else "",
-            "face_count": len(info["face_ids"]),
-            "photo_count": len(info["photo_ids"]),
-        })
+        result.append(
+            {
+                "person_id": person_id,
+                "name": names.get(person_id, "") if person_id else "",
+                "face_count": len(info["face_ids"]),
+                "photo_count": len(info["photo_ids"]),
+            }
+        )
     return result
 
 
@@ -271,7 +286,7 @@ def get_photo_ids_for_person(person_id: str) -> List[str]:
     data = chroma_service.get_all_faces(include_embeddings=False)
     if not data or not data.get("ids"):
         return []
-        
+
     metadatas = data.get("metadatas", [])
     photo_ids = set()
     for meta in metadatas or []:

--- a/server/src/service_search.py
+++ b/server/src/service_search.py
@@ -1,4 +1,3 @@
-
 import service_chroma as chroma_service
 import service_vertexai as vertexai_service
 from config import logger, TORCH_DEVICE
@@ -26,35 +25,48 @@ def _merge_semantic_results(siglip_results, vertex_results):
 
 def _transform_and_sort_results(results, quality_sort):
     """Transforms ChromaDB results and sorts them based on quality or distance."""
-    if not results or not results['ids'][0]:
+    if not results or not results["ids"][0]:
         return []
 
-    ids, distances, metadatas = results['ids'][0], results['distances'][0], results['metadatas'][0]
+    ids, distances, metadatas = (
+        results["ids"][0],
+        results["distances"][0],
+        results["metadatas"][0],
+    )
 
     transformed_results = []
     for i in range(len(ids)):
         # Skip metadata-only entries (with dummy embeddings) from semantic search
         metadata = metadatas[i] if i < len(metadatas) else {}
-        if metadata and not metadata.get('has_embedding', True):
+        if metadata and not metadata.get("has_embedding", True):
             continue
-            
-        transformed_results.append({
-            "photo_id": ids[i],
-            "uuid": ids[i],  # backward compatibility for older plugin responses
-            "distance": float(round(distances[i], 4)),
-        })
 
-    transformed_results.sort(key=lambda x: x['distance'])
+        transformed_results.append(
+            {
+                "photo_id": ids[i],
+                "uuid": ids[i],  # backward compatibility for older plugin responses
+                "distance": float(round(distances[i], 4)),
+            }
+        )
+
+    transformed_results.sort(key=lambda x: x["distance"])
     return transformed_results
 
 
 def _transform_vertex_results(vertex_results):
     """Transform Vertex Chroma query result to list of {photo_id, distance} sorted by distance."""
-    if not vertex_results or not vertex_results.get('ids') or not vertex_results['ids'][0]:
+    if (
+        not vertex_results
+        or not vertex_results.get("ids")
+        or not vertex_results["ids"][0]
+    ):
         return []
-    ids, distances = vertex_results['ids'][0], vertex_results['distances'][0]
-    out = [{"photo_id": uid, "uuid": uid, "distance": float(round(d, 4))} for uid, d in zip(ids, distances)]
-    out.sort(key=lambda x: x['distance'])
+    ids, distances = vertex_results["ids"][0], vertex_results["distances"][0]
+    out = [
+        {"photo_id": uid, "uuid": uid, "distance": float(round(d, 4))}
+        for uid, d in zip(ids, distances)
+    ]
+    out.sort(key=lambda x: x["distance"])
     return out
 
 
@@ -91,9 +103,20 @@ def _normalize_search_sources(search_sources):
     return out
 
 
-def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, *, vertex_project_id=None, vertex_location=None, catalog_id=None):
+def search_images(
+    term,
+    quality_sort,
+    photo_ids_to_search,
+    search_sources=None,
+    *,
+    vertex_project_id=None,
+    vertex_location=None,
+    catalog_id=None,
+):
     sources = _normalize_search_sources(search_sources)
-    logger.info(f"Searching for '{term}' (quality_sort: {quality_sort}, scoped: {photo_ids_to_search is not None}, catalog_id: {bool(catalog_id)}, sources: {sources})")
+    logger.info(
+        f"Searching for '{term}' (quality_sort: {quality_sort}, scoped: {photo_ids_to_search is not None}, catalog_id: {bool(catalog_id)}, sources: {sources})"
+    )
 
     sorted_semantic_results = []
     semantic_photo_ids = set()
@@ -107,15 +130,21 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
             with torch.no_grad():
                 model = server_lifecycle.get_model()
                 text_features = model.encode_text(text_tokens)
-                normalized_embeddings = F.normalize(text_features, p=2, dim=1).cpu().numpy()[0]
+                normalized_embeddings = (
+                    F.normalize(text_features, p=2, dim=1).cpu().numpy()[0]
+                )
 
             db_results = chroma_service.query_images(
                 query_embedding=normalized_embeddings,
                 n_results=300,
-                where_clause={"photo_id": {"$in": photo_ids_to_search}} if photo_ids_to_search else None,
+                where_clause={"photo_id": {"$in": photo_ids_to_search}}
+                if photo_ids_to_search
+                else None,
                 catalog_id=catalog_id,
             )
-            if photo_ids_to_search and (not db_results or not db_results.get("ids") or not db_results["ids"][0]):
+            if photo_ids_to_search and (
+                not db_results or not db_results.get("ids") or not db_results["ids"][0]
+            ):
                 # Legacy fallback for unmigrated metadata
                 db_results = chroma_service.query_images(
                     query_embedding=normalized_embeddings,
@@ -125,16 +154,26 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
                 )
 
             relevant_results = _filter_by_relevance(db_results)
-            sorted_semantic_results = _transform_and_sort_results(relevant_results, quality_sort)
-            semantic_photo_ids = {res['photo_id'] for res in sorted_semantic_results}
+            sorted_semantic_results = _transform_and_sort_results(
+                relevant_results, quality_sort
+            )
+            semantic_photo_ids = {res["photo_id"] for res in sorted_semantic_results}
         else:
             warning = "SigLIP model not loaded. Semantic search results will be missing. Download the model in the plugin manager."
             logger.info(warning)
 
     # 1b. Vertex AI semantic search (use vertex_project_id/vertex_location from request so plugin prefs are used)
     vertex_semantic_results = []
-    if sources["semantic_vertex"] and vertexai_service.is_available(vertex_project_id, vertex_location) and term.strip():
-        vertex_where = {"photo_id": {"$in": list(photo_ids_to_search)}} if photo_ids_to_search else None
+    if (
+        sources["semantic_vertex"]
+        and vertexai_service.is_available(vertex_project_id, vertex_location)
+        and term.strip()
+    ):
+        vertex_where = (
+            {"photo_id": {"$in": list(photo_ids_to_search)}}
+            if photo_ids_to_search
+            else None
+        )
         try:
             vertex_ids = chroma_service.get_all_vertex_image_ids()
             if photo_ids_to_search:
@@ -142,7 +181,9 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
             else:
                 scope_vertex = set(vertex_ids)
             if scope_vertex:
-                query_emb = vertexai_service.get_text_embedding(term, vertex_project_id, vertex_location)
+                query_emb = vertexai_service.get_text_embedding(
+                    term, vertex_project_id, vertex_location
+                )
                 if query_emb:
                     vertex_results = chroma_service.query_vertex_images(
                         query_embedding=query_emb,
@@ -150,7 +191,11 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
                         where_clause=vertex_where,
                         catalog_id=catalog_id,
                     )
-                    if photo_ids_to_search and (not vertex_results or not vertex_results.get("ids") or not vertex_results["ids"][0]):
+                    if photo_ids_to_search and (
+                        not vertex_results
+                        or not vertex_results.get("ids")
+                        or not vertex_results["ids"][0]
+                    ):
                         vertex_results = chroma_service.query_vertex_images(
                             query_embedding=query_emb,
                             n_results=300,
@@ -158,7 +203,9 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
                             catalog_id=catalog_id,
                         )
                     vertex_semantic_results = _transform_vertex_results(vertex_results)
-                    logger.info(f"Vertex AI semantic search returned {len(vertex_semantic_results)} results.")
+                    logger.info(
+                        f"Vertex AI semantic search returned {len(vertex_semantic_results)} results."
+                    )
         except Exception as e:
             msg = f"Vertex AI search failed: {str(e)}"
             logger.warning(msg, exc_info=True)
@@ -167,8 +214,10 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
             else:
                 warning += f" | {msg}"
     if vertex_semantic_results:
-        sorted_semantic_results = _merge_semantic_results(sorted_semantic_results, vertex_semantic_results)
-        semantic_photo_ids = {res['photo_id'] for res in sorted_semantic_results}
+        sorted_semantic_results = _merge_semantic_results(
+            sorted_semantic_results, vertex_semantic_results
+        )
+        semantic_photo_ids = {res["photo_id"] for res in sorted_semantic_results}
 
     # 2. Metadata Search (in-memory)
     metadata_only_results = []
@@ -178,18 +227,24 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
 
         if photo_ids_to_search:
             target_ids = list(photo_ids_to_search)
-            all_metadata_raw = chroma_service.collection.get(ids=target_ids, include=["metadatas"])
+            all_metadata_raw = chroma_service.collection.get(
+                ids=target_ids, include=["metadatas"]
+            )
         elif catalog_id:
             target_ids = chroma_service.get_all_image_ids(catalog_id=catalog_id)
-            all_metadata_raw = chroma_service.collection.get(ids=target_ids, include=["metadatas"]) if target_ids else {"ids": [], "metadatas": []}
+            all_metadata_raw = (
+                chroma_service.collection.get(ids=target_ids, include=["metadatas"])
+                if target_ids
+                else {"ids": [], "metadatas": []}
+            )
         else:
             all_metadata_raw = chroma_service.collection.get(include=["metadatas"])
 
         metadata_ids = set()
         term_lower = term.lower()
 
-        for i, photo_id in enumerate(all_metadata_raw['ids']):
-            metadata = all_metadata_raw['metadatas'][i]
+        for i, photo_id in enumerate(all_metadata_raw["ids"]):
+            metadata = all_metadata_raw["metadatas"][i]
             if not metadata:
                 continue
 
@@ -200,18 +255,25 @@ def search_images(term, quality_sort, photo_ids_to_search, search_sources=None, 
                         break
 
         metadata_only_ids = metadata_ids - semantic_photo_ids
-        metadata_only_results = [{"photo_id": pid, "uuid": pid, "distance": None} for pid in metadata_only_ids]
+        metadata_only_results = [
+            {"photo_id": pid, "uuid": pid, "distance": None}
+            for pid in metadata_only_ids
+        ]
 
     # 3. Combine results
 
     final_results = sorted_semantic_results + metadata_only_results
-    
-    logger.info(f"Total results: {len(final_results)} ({len(sorted_semantic_results)} semantic, {len(metadata_only_results)} metadata-only)")
-    
+
+    logger.info(
+        f"Total results: {len(final_results)} ({len(sorted_semantic_results)} semantic, {len(metadata_only_results)} metadata-only)"
+    )
+
     return final_results, warning
 
-    
-def group_similar_images(photo_ids, phash_threshold, clip_threshold, time_delta, culling_preset="default"):
+
+def group_similar_images(
+    photo_ids, phash_threshold, clip_threshold, time_delta, culling_preset="default"
+):
     """Groups a list of images by similarity and sorts them by quality."""
     logger.info(
         "Grouping %s photo IDs with phash_threshold='%s', clip_threshold='%s', time_delta='%ss', culling_preset='%s'.",
@@ -241,7 +303,9 @@ def group_similar_images(photo_ids, phash_threshold, clip_threshold, time_delta,
         raise e
 
 
-def cull_images(photo_ids, phash_threshold, clip_threshold, time_delta, culling_preset="default"):
+def cull_images(
+    photo_ids, phash_threshold, clip_threshold, time_delta, culling_preset="default"
+):
     """
     High-level culling wrapper around grouping/ranking.
     Returns grouped results plus a compact summary for UI/reporting.

--- a/server/src/service_style_engine.py
+++ b/server/src/service_style_engine.py
@@ -20,6 +20,7 @@ When confidence is below the threshold and LLM fallback is enabled, the
 caller should fall back to the usual LLM path with training examples as
 few-shot context.
 """
+
 from __future__ import annotations
 
 import json
@@ -32,14 +33,14 @@ import service_training as training_service
 # Tunable weights (can be made user-configurable later via config / prefs)
 # ---------------------------------------------------------------------------
 
-WEIGHT_CLIP = 0.50       # CLIP visual similarity
-WEIGHT_EXPOSURE = 0.25   # Exposure state proximity
-WEIGHT_SCENE = 0.15      # Scene-type tag overlap
+WEIGHT_CLIP = 0.50  # CLIP visual similarity
+WEIGHT_EXPOSURE = 0.25  # Exposure state proximity
+WEIGHT_SCENE = 0.15  # Scene-type tag overlap
 WEIGHT_TIME_OF_DAY = 0.10  # Time-of-day / lighting cue
 
 # Confidence thresholds
-CONFIDENCE_GOOD = 0.70    # ≥ this → style engine output direct, no warning
-CONFIDENCE_LOW = 0.45     # < this → LLM fallback recommended
+CONFIDENCE_GOOD = 0.70  # ≥ this → style engine output direct, no warning
+CONFIDENCE_LOW = 0.45  # < this → LLM fallback recommended
 
 # Interpolation: number of top examples to blend
 TOP_K_BLEND = 3
@@ -54,6 +55,7 @@ MIN_TRAINING_EXAMPLES = 5
 # Distance → similarity conversion
 # ---------------------------------------------------------------------------
 
+
 def _clip_distance_to_similarity(distance: float) -> float:
     """Convert ChromaDB L2 distance (squared) to cosine similarity proxy.
 
@@ -66,6 +68,7 @@ def _clip_distance_to_similarity(distance: float) -> float:
 # ---------------------------------------------------------------------------
 # Exposure proximity scoring
 # ---------------------------------------------------------------------------
+
 
 def _exposure_proximity(
     query: Dict[str, float],
@@ -95,6 +98,7 @@ def _exposure_proximity(
 # Scene-type tag overlap scoring
 # ---------------------------------------------------------------------------
 
+
 def _scene_overlap(
     query_tags: List[str],
     candidate_tags: List[str],
@@ -120,6 +124,7 @@ def _scene_overlap(
 
 _TOD_ORDER = ["dawn", "morning", "afternoon", "evening", "night", "unknown"]
 
+
 def _tod_proximity(query_tod: str, candidate_tod: str) -> float:
     """Score proximity of time-of-day buckets.  Adjacent buckets score 0.5, same = 1.0."""
     if query_tod == "unknown" or candidate_tod == "unknown":
@@ -141,6 +146,7 @@ def _tod_proximity(query_tod: str, candidate_tod: str) -> float:
 # Composite scoring
 # ---------------------------------------------------------------------------
 
+
 def calculate_composite_score(
     clip_sim: float,
     query_exposure: Dict[str, float],
@@ -151,12 +157,19 @@ def calculate_composite_score(
     """Compute weighted composite match score for one candidate."""
     exp_score = _exposure_proximity(
         query_exposure,
-        {k: candidate.get(k, 0.0) for k in (
-            "exp_luminance_mean", "exp_contrast", "exp_warmth_proxy",
-        )},
+        {
+            k: candidate.get(k, 0.0)
+            for k in (
+                "exp_luminance_mean",
+                "exp_contrast",
+                "exp_warmth_proxy",
+            )
+        },
     )
     scene_score = _scene_overlap(query_scene_tags, candidate.get("scene_tags", []))
-    tod_score = _tod_proximity(query_tod, candidate.get("time_of_day_bucket", "unknown"))
+    tod_score = _tod_proximity(
+        query_tod, candidate.get("time_of_day_bucket", "unknown")
+    )
 
     return (
         WEIGHT_CLIP * clip_sim
@@ -169,6 +182,7 @@ def calculate_composite_score(
 # ---------------------------------------------------------------------------
 # Recipe interpolation
 # ---------------------------------------------------------------------------
+
 
 def interpolate_recipes(
     winners: List[Tuple[Dict[str, Any], float]],
@@ -206,6 +220,7 @@ def interpolate_recipes(
 # RAW-adaptive exposure compensation
 # ---------------------------------------------------------------------------
 
+
 def adaptive_compensation(
     recipe: Dict[str, Any],
     query_exposure: Dict[str, float],
@@ -229,8 +244,7 @@ def adaptive_compensation(
         for ex, score in winners
     )
     avg_train_contrast = sum(
-        ex.get("exp_contrast", 0.5) * (score / total_weight)
-        for ex, score in winners
+        ex.get("exp_contrast", 0.5) * (score / total_weight) for ex, score in winners
     )
 
     query_lum = query_exposure.get("exp_luminance_mean", 0.5)
@@ -239,7 +253,9 @@ def adaptive_compensation(
     # Luminance delta → small exposure correction
     lum_delta = query_lum - avg_train_lum
     # Scale: 0.1 luminance unit ≈ 0.5 EV
-    exposure_correction = -lum_delta * 5.0  # subtract because brighter photo needs less exposure push
+    exposure_correction = (
+        -lum_delta * 5.0
+    )  # subtract because brighter photo needs less exposure push
     exposure_correction = max(-1.5, min(1.5, exposure_correction))
 
     # Contrast delta → small contrast correction
@@ -304,7 +320,9 @@ _TONE_CURVE_KEYS = {
 }
 
 
-def _canonical_to_edit_recipe(canonical: Dict[str, Any], summary: str = "") -> Dict[str, Any]:
+def _canonical_to_edit_recipe(
+    canonical: Dict[str, Any], summary: str = ""
+) -> Dict[str, Any]:
     """Convert canonical key/value dict to the edit recipe format used by the plugin."""
     global_settings: Dict[str, Any] = {}
 
@@ -332,8 +350,10 @@ def _canonical_to_edit_recipe(canonical: Dict[str, Any], summary: str = "") -> D
 # Main entry point
 # ---------------------------------------------------------------------------
 
+
 class StyleEngineResult:
     """Result from the style engine."""
+
     def __init__(
         self,
         recipe: Dict[str, Any],
@@ -449,7 +469,7 @@ def generate_style_edit(
     # -----------------------------------------------------------------------
     # Step 4: Compute confidence from best candidate scores
     # -----------------------------------------------------------------------
-    #top_scores = [s for _, s in scored[:TOP_K_BLEND]]
+    # top_scores = [s for _, s in scored[:TOP_K_BLEND]]
 
     best_score = scored[0][1] if scored else 0.0
     confidence = round(best_score, 3)
@@ -473,14 +493,19 @@ def generate_style_edit(
     # -----------------------------------------------------------------------
     # Step 7: Build summary from top example labels
     # -----------------------------------------------------------------------
-    labels = list(set(
-        ex.get("label") or ex.get("summary") or ""
-        for ex, _ in winners if (ex.get("label") or ex.get("summary"))
-    ))
+    labels = list(
+        set(
+            ex.get("label") or ex.get("summary") or ""
+            for ex, _ in winners
+            if (ex.get("label") or ex.get("summary"))
+        )
+    )
     summary_parts = []
     if labels:
         summary_parts.append("Style: " + " / ".join(labels[:2]))
-    summary_parts.append(f"Matched {len(winners)} of {training_count} examples (confidence {confidence:.0%})")
+    summary_parts.append(
+        f"Matched {len(winners)} of {training_count} examples (confidence {confidence:.0%})"
+    )
     summary = " — ".join(summary_parts)
 
     recipe = _canonical_to_edit_recipe(blended, summary=summary)

--- a/server/src/service_style_engine.py
+++ b/server/src/service_style_engine.py
@@ -449,7 +449,8 @@ def generate_style_edit(
     # -----------------------------------------------------------------------
     # Step 4: Compute confidence from best candidate scores
     # -----------------------------------------------------------------------
-    top_scores = [s for _, s in scored[:TOP_K_BLEND]]
+    #top_scores = [s for _, s in scored[:TOP_K_BLEND]]
+
     best_score = scored[0][1] if scored else 0.0
     confidence = round(best_score, 3)
 

--- a/server/src/service_training.py
+++ b/server/src/service_training.py
@@ -12,6 +12,7 @@ Enhanced with multi-criteria features:
   - EXIF-based categorical fields (focal-length bucket, time-of-day, camera)
   - Statistics endpoint for the style-profile UI
 """
+
 from __future__ import annotations
 
 import json
@@ -27,7 +28,9 @@ _chroma_client = None
 _training_collection = None
 
 COLLECTION_NAME = "edit_training"
-EMBEDDING_DIM = 1152  # CLIP ViT-L/14 dimension used by the main image_embeddings collection
+EMBEDDING_DIM = (
+    1152  # CLIP ViT-L/14 dimension used by the main image_embeddings collection
+)
 
 # ---------------------------------------------------------------------------
 # Scene-type probe texts for CLIP zero-shot classification
@@ -54,12 +57,14 @@ _SCENE_THRESHOLD = 0.22  # cosine similarity threshold for a tag to be "present"
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+
 def _ensure_initialized() -> None:
     global _chroma_client, _training_collection
     if _training_collection is not None:
         return
 
     import config
+
     if not config.DB_PATH:
         logger.debug("edit_training initialization skipped: DB_PATH not set yet.")
         return
@@ -67,7 +72,9 @@ def _ensure_initialized() -> None:
     import chromadb
     from chromadb.config import Settings
 
-    logger.info("Initializing edit_training ChromaDB collection (lazy at %s)...", config.DB_PATH)
+    logger.info(
+        "Initializing edit_training ChromaDB collection (lazy at %s)...", config.DB_PATH
+    )
     _chroma_client = chromadb.PersistentClient(
         path=config.DB_PATH,
         settings=Settings(anonymized_telemetry=False),
@@ -91,6 +98,7 @@ def _safe_unit(value: float) -> float:
 # ---------------------------------------------------------------------------
 # Exposure metrics (computed from JPEG preview bytes)
 # ---------------------------------------------------------------------------
+
 
 def compute_exposure_metrics(image_bytes: bytes) -> Dict[str, float]:
     """Compute proxy RAW exposure characteristics from an image.
@@ -172,6 +180,7 @@ def compute_exposure_metrics(image_bytes: bytes) -> Dict[str, float]:
 # Scene-type tagging via CLIP zero-shot probing
 # ---------------------------------------------------------------------------
 
+
 def compute_scene_tags(image_embedding: Optional[List[float]]) -> List[str]:
     """Return list of scene-type tag strings present in the image.
 
@@ -193,7 +202,11 @@ def compute_scene_tags(image_embedding: Optional[List[float]]) -> List[str]:
         if clip_model is None or clip_processor is None:
             return []
 
-        img_vec = torch.tensor(image_embedding, dtype=torch.float32).unsqueeze(0).to(TORCH_DEVICE)
+        img_vec = (
+            torch.tensor(image_embedding, dtype=torch.float32)
+            .unsqueeze(0)
+            .to(TORCH_DEVICE)
+        )
         img_vec = F.normalize(img_vec, p=2, dim=1)
 
         tags: List[str] = []
@@ -224,10 +237,12 @@ def _get_clip_tokenize():
     """Retrieve open_clip tokenizer (lazy import)."""
     try:
         import open_clip
+
         return open_clip.get_tokenizer("ViT-L-14")
     except Exception:
         try:
             import clip
+
             return clip.tokenize
         except Exception:
             return None
@@ -236,6 +251,7 @@ def _get_clip_tokenize():
 # ---------------------------------------------------------------------------
 # EXIF / catalog field bucketing
 # ---------------------------------------------------------------------------
+
 
 def focal_length_bucket(focal_length_mm: Optional[float]) -> str:
     """Map focal length in mm to a categorical bucket."""
@@ -308,7 +324,9 @@ _LR_TO_CANONICAL: Dict[str, str] = {
 }
 
 
-def normalize_develop_settings_for_style(develop_settings: Dict[str, Any]) -> Dict[str, float]:
+def normalize_develop_settings_for_style(
+    develop_settings: Dict[str, Any],
+) -> Dict[str, float]:
     """Convert raw LR develop settings dict to canonical float form for interpolation."""
     canonical: Dict[str, float] = {}
     for lr_key, canon_key in _LR_TO_CANONICAL.items():
@@ -321,6 +339,7 @@ def normalize_develop_settings_for_style(develop_settings: Dict[str, Any]) -> Di
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def add_training_example(
     photo_id: str,
@@ -360,7 +379,9 @@ def add_training_example(
     """
     _ensure_initialized()
     if _training_collection is None:
-        logger.warning("add_training_example skipped: service not initialized (DB_PATH missing).")
+        logger.warning(
+            "add_training_example skipped: service not initialized (DB_PATH missing)."
+        )
         return
     if not photo_id:
         raise ValueError("photo_id is required")
@@ -409,11 +430,17 @@ def add_training_example(
     # Upsert: update if already present, add otherwise.
     existing = _training_collection.get(ids=[photo_id], include=[])
     if existing and existing.get("ids"):
-        _training_collection.update(ids=[photo_id], embeddings=[emb], metadatas=[metadata])
-        logger.info("Updated training example photo_id=%s scene_tags=%s", photo_id, scene_tags)
+        _training_collection.update(
+            ids=[photo_id], embeddings=[emb], metadatas=[metadata]
+        )
+        logger.info(
+            "Updated training example photo_id=%s scene_tags=%s", photo_id, scene_tags
+        )
     else:
         _training_collection.add(ids=[photo_id], embeddings=[emb], metadatas=[metadata])
-        logger.info("Added training example photo_id=%s scene_tags=%s", photo_id, scene_tags)
+        logger.info(
+            "Added training example photo_id=%s scene_tags=%s", photo_id, scene_tags
+        )
 
 
 def delete_training_example(photo_id: str) -> bool:
@@ -454,17 +481,19 @@ def list_training_examples() -> List[Dict[str, Any]]:
     examples = []
     for i, pid in enumerate(ids):
         meta = dict(metadatas[i]) if i < len(metadatas) else {}
-        examples.append({
-            "photo_id": pid,
-            "filename": meta.get("filename", ""),
-            "label": meta.get("label", ""),
-            "summary": meta.get("summary", ""),
-            "captured_at": meta.get("captured_at", ""),
-            "has_embedding": bool(meta.get("has_embedding", False)),
-            "focal_length_bucket": meta.get("focal_length_bucket", "unknown"),
-            "time_of_day_bucket": meta.get("time_of_day_bucket", "unknown"),
-            "scene_tags": _safe_json_list(meta.get("scene_tags", "[]")),
-        })
+        examples.append(
+            {
+                "photo_id": pid,
+                "filename": meta.get("filename", ""),
+                "label": meta.get("label", ""),
+                "summary": meta.get("summary", ""),
+                "captured_at": meta.get("captured_at", ""),
+                "has_embedding": bool(meta.get("has_embedding", False)),
+                "focal_length_bucket": meta.get("focal_length_bucket", "unknown"),
+                "time_of_day_bucket": meta.get("time_of_day_bucket", "unknown"),
+                "scene_tags": _safe_json_list(meta.get("scene_tags", "[]")),
+            }
+        )
     examples.sort(key=lambda x: x["captured_at"], reverse=True)
     return examples
 
@@ -544,9 +573,13 @@ def get_training_stats() -> Dict[str, Any]:
     if exp_means:
         exposure_stats["mean_luminance"] = round(sum(exp_means) / len(exp_means), 3)
     if exp_contrasts:
-        exposure_stats["mean_contrast"] = round(sum(exp_contrasts) / len(exp_contrasts), 3)
+        exposure_stats["mean_contrast"] = round(
+            sum(exp_contrasts) / len(exp_contrasts), 3
+        )
     if exp_colorfulness:
-        exposure_stats["mean_colorfulness"] = round(sum(exp_colorfulness) / len(exp_colorfulness), 3)
+        exposure_stats["mean_colorfulness"] = round(
+            sum(exp_colorfulness) / len(exp_colorfulness), 3
+        )
 
     return {
         "count": count,
@@ -611,24 +644,26 @@ def query_similar_training_examples(
         except (ValueError, TypeError):
             canonical_settings = {}
 
-        examples.append({
-            "photo_id": pid,
-            "develop_settings": dev_settings,
-            "canonical_settings": canonical_settings,
-            "label": meta.get("label", ""),
-            "filename": meta.get("filename", ""),
-            "summary": meta.get("summary", ""),
-            "distance": float(distances[i]) if i < len(distances) else 1.0,
-            "scene_tags": _safe_json_list(meta.get("scene_tags", "[]")),
-            "exp_luminance_mean": float(meta.get("exp_luminance_mean", 0.5)),
-            "exp_contrast": float(meta.get("exp_contrast", 0.0)),
-            "exp_colorfulness": float(meta.get("exp_colorfulness", 0.0)),
-            "exp_warmth_proxy": float(meta.get("exp_warmth_proxy", 0.5)),
-            "exp_highlight_ratio": float(meta.get("exp_highlight_ratio", 0.0)),
-            "exp_shadow_ratio": float(meta.get("exp_shadow_ratio", 0.0)),
-            "focal_length_bucket": meta.get("focal_length_bucket", "unknown"),
-            "time_of_day_bucket": meta.get("time_of_day_bucket", "unknown"),
-        })
+        examples.append(
+            {
+                "photo_id": pid,
+                "develop_settings": dev_settings,
+                "canonical_settings": canonical_settings,
+                "label": meta.get("label", ""),
+                "filename": meta.get("filename", ""),
+                "summary": meta.get("summary", ""),
+                "distance": float(distances[i]) if i < len(distances) else 1.0,
+                "scene_tags": _safe_json_list(meta.get("scene_tags", "[]")),
+                "exp_luminance_mean": float(meta.get("exp_luminance_mean", 0.5)),
+                "exp_contrast": float(meta.get("exp_contrast", 0.0)),
+                "exp_colorfulness": float(meta.get("exp_colorfulness", 0.0)),
+                "exp_warmth_proxy": float(meta.get("exp_warmth_proxy", 0.5)),
+                "exp_highlight_ratio": float(meta.get("exp_highlight_ratio", 0.0)),
+                "exp_shadow_ratio": float(meta.get("exp_shadow_ratio", 0.0)),
+                "focal_length_bucket": meta.get("focal_length_bucket", "unknown"),
+                "time_of_day_bucket": meta.get("time_of_day_bucket", "unknown"),
+            }
+        )
     return examples
 
 
@@ -649,6 +684,7 @@ def clear_all_training_examples() -> int:
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
 
 def _safe_json_list(value: Any) -> List[str]:
     """Safely decode a JSON string to a list, returning [] on failure."""

--- a/server/src/service_version.py
+++ b/server/src/service_version.py
@@ -11,7 +11,11 @@ def get_backend_version_info() -> dict:
     }
 
 
-def check_plugin_backend_version(plugin_version: str | None, plugin_build: int | None = None, plugin_release_tag: str | None = None) -> dict:
+def check_plugin_backend_version(
+    plugin_version: str | None,
+    plugin_build: int | None = None,
+    plugin_release_tag: str | None = None,
+) -> dict:
     backend = get_backend_version_info()
     normalized_backend = _normalize_version(backend["backend_version"])
     normalized_plugin = _normalize_version(plugin_version)
@@ -29,7 +33,9 @@ def check_plugin_backend_version(plugin_version: str | None, plugin_build: int |
     # Dev fallback:
     # Local development uses placeholder versions in Info.lua and backend defaults.
     # Allow this combination so development setups are not blocked.
-    if _is_dev_backend(backend["backend_version"], backend["backend_release_tag"]) and _is_default_dev_plugin(normalized_plugin):
+    if _is_dev_backend(
+        backend["backend_version"], backend["backend_release_tag"]
+    ) and _is_default_dev_plugin(normalized_plugin):
         return {
             **backend,
             "plugin_version": plugin_version,
@@ -40,7 +46,9 @@ def check_plugin_backend_version(plugin_version: str | None, plugin_build: int |
         }
 
     compatible = normalized_plugin == normalized_backend
-    reason = "exact version match" if compatible else "plugin and backend version differ"
+    reason = (
+        "exact version match" if compatible else "plugin and backend version differ"
+    )
 
     return {
         **backend,

--- a/server/src/service_vertexai.py
+++ b/server/src/service_vertexai.py
@@ -3,6 +3,7 @@ Google Vertex AI Multimodal Embeddings for images and text.
 Used optionally in parallel to SigLIP2 embeddings; stored in a separate ChromaDB collection.
 Config: vertex_project_id and vertex_location from Lightroom plugin or env vars.
 """
+
 import base64
 import os
 from typing import List, Optional
@@ -29,8 +30,14 @@ def _detect_mime_type(image_bytes: bytes) -> str:
 
 def _resolve_config(vertex_project_id=None, vertex_location=None):
     """Resolve project and location from options or environment."""
-    project = (vertex_project_id or "").strip() or os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("VERTEX_PROJECT_ID")
-    location = (vertex_location or "").strip() or os.environ.get("VERTEX_LOCATION", "us-central1")
+    project = (
+        (vertex_project_id or "").strip()
+        or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        or os.environ.get("VERTEX_PROJECT_ID")
+    )
+    location = (vertex_location or "").strip() or os.environ.get(
+        "VERTEX_LOCATION", "us-central1"
+    )
     return project, location
 
 
@@ -41,7 +48,9 @@ def _get_vertex_client_and_endpoint(vertex_project_id=None, vertex_location=None
     if not project and _last_vertex_config:
         project, location = _last_vertex_config
     if not project:
-        logger.warning("Vertex AI: Project ID not set (plugin preferences or GOOGLE_CLOUD_PROJECT); Vertex embeddings disabled.")
+        logger.warning(
+            "Vertex AI: Project ID not set (plugin preferences or GOOGLE_CLOUD_PROJECT); Vertex embeddings disabled."
+        )
         return None
     key = (project, location)
     if key in _vertex_client_cache:
@@ -95,7 +104,9 @@ def _to_plain_python(value):
             if kind == "bool_value":
                 return bool(value.bool_value)
             if kind == "struct_value":
-                return {k: _to_plain_python(v) for k, v in value.struct_value.fields.items()}
+                return {
+                    k: _to_plain_python(v) for k, v in value.struct_value.fields.items()
+                }
             if kind == "list_value":
                 return [_to_plain_python(v) for v in value.list_value.values]
         except Exception:
@@ -105,6 +116,7 @@ def _to_plain_python(value):
     if hasattr(value, "DESCRIPTOR"):
         try:
             from google.protobuf import json_format
+
             return json_format.MessageToDict(value)
         except Exception:
             pass
@@ -140,15 +152,21 @@ def _extract_embedding(prediction_value, field_name: str) -> Optional[List[float
 
 def is_available(vertex_project_id=None, vertex_location=None) -> bool:
     """Return True if Vertex AI embeddings can be used (project configured and model loadable)."""
-    return _get_vertex_client_and_endpoint(vertex_project_id, vertex_location) is not None
+    return (
+        _get_vertex_client_and_endpoint(vertex_project_id, vertex_location) is not None
+    )
 
 
-def get_image_embeddings(image_bytes_list: List[bytes], vertex_project_id=None, vertex_location=None) -> List[Optional[List[float]]]:
+def get_image_embeddings(
+    image_bytes_list: List[bytes], vertex_project_id=None, vertex_location=None
+) -> List[Optional[List[float]]]:
     """
     Generate Vertex AI image embeddings for a list of images.
     One request per image (API limit). Returns one embedding per input; None on failure.
     """
-    client_and_endpoint = _get_vertex_client_and_endpoint(vertex_project_id, vertex_location)
+    client_and_endpoint = _get_vertex_client_and_endpoint(
+        vertex_project_id, vertex_location
+    )
     if client_and_endpoint is None:
         return [None] * len(image_bytes_list)
     client, endpoint = client_and_endpoint
@@ -162,19 +180,31 @@ def get_image_embeddings(image_bytes_list: List[bytes], vertex_project_id=None, 
                 "mimeType": _detect_mime_type(img_bytes),
             }
             instance = struct_pb2.Value(
-                struct_value=struct_pb2.Struct(fields={
-                    "image": struct_pb2.Value(
-                        struct_value=struct_pb2.Struct(fields={
-                            "bytesBase64Encoded": struct_pb2.Value(string_value=image_obj["bytesBase64Encoded"]),
-                            "mimeType": struct_pb2.Value(string_value=image_obj["mimeType"]),
-                        })
-                    )
-                })
+                struct_value=struct_pb2.Struct(
+                    fields={
+                        "image": struct_pb2.Value(
+                            struct_value=struct_pb2.Struct(
+                                fields={
+                                    "bytesBase64Encoded": struct_pb2.Value(
+                                        string_value=image_obj["bytesBase64Encoded"]
+                                    ),
+                                    "mimeType": struct_pb2.Value(
+                                        string_value=image_obj["mimeType"]
+                                    ),
+                                }
+                            )
+                        )
+                    }
+                )
             )
             parameters = struct_pb2.Value(
-                struct_value=struct_pb2.Struct(fields={
-                    "dimension": struct_pb2.Value(number_value=float(VERTEX_EMBEDDING_DIM))
-                })
+                struct_value=struct_pb2.Struct(
+                    fields={
+                        "dimension": struct_pb2.Value(
+                            number_value=float(VERTEX_EMBEDDING_DIM)
+                        )
+                    }
+                )
             )
 
             response = client.predict(
@@ -183,13 +213,16 @@ def get_image_embeddings(image_bytes_list: List[bytes], vertex_project_id=None, 
                 parameters=parameters,
             )
             if response.predictions:
-                image_embedding = _extract_embedding(response.predictions[0], "imageEmbedding")
+                image_embedding = _extract_embedding(
+                    response.predictions[0], "imageEmbedding"
+                )
             else:
                 image_embedding = None
 
             if image_embedding:
                 # Normalize for cosine similarity (Chroma uses L2 distance)
                 import numpy as np
+
                 vec = np.array(image_embedding, dtype=np.float32)
                 norm = np.linalg.norm(vec)
                 if norm > 1e-6:
@@ -198,31 +231,42 @@ def get_image_embeddings(image_bytes_list: List[bytes], vertex_project_id=None, 
             else:
                 results.append(None)
         except Exception as e:
-            logger.warning("Vertex embedding failed for image %s: %s", i, e, exc_info=True)
+            logger.warning(
+                "Vertex embedding failed for image %s: %s", i, e, exc_info=True
+            )
             results.append(None)
     return results
 
 
-def get_text_embedding(text: str, vertex_project_id=None, vertex_location=None) -> Optional[List[float]]:
+def get_text_embedding(
+    text: str, vertex_project_id=None, vertex_location=None
+) -> Optional[List[float]]:
     """
     Generate Vertex AI text embedding for a search query.
     Used when searching with the Vertex collection.
     """
-    client_and_endpoint = _get_vertex_client_and_endpoint(vertex_project_id, vertex_location)
+    client_and_endpoint = _get_vertex_client_and_endpoint(
+        vertex_project_id, vertex_location
+    )
     if client_and_endpoint is None or not text or not text.strip():
         return None
     client, endpoint = client_and_endpoint
     from google.protobuf import struct_pb2
+
     try:
         instance = struct_pb2.Value(
-            struct_value=struct_pb2.Struct(fields={
-                "text": struct_pb2.Value(string_value=text.strip())
-            })
+            struct_value=struct_pb2.Struct(
+                fields={"text": struct_pb2.Value(string_value=text.strip())}
+            )
         )
         parameters = struct_pb2.Value(
-            struct_value=struct_pb2.Struct(fields={
-                "dimension": struct_pb2.Value(number_value=float(VERTEX_EMBEDDING_DIM))
-            })
+            struct_value=struct_pb2.Struct(
+                fields={
+                    "dimension": struct_pb2.Value(
+                        number_value=float(VERTEX_EMBEDDING_DIM)
+                    )
+                }
+            )
         )
         response = client.predict(
             endpoint=endpoint,
@@ -230,11 +274,14 @@ def get_text_embedding(text: str, vertex_project_id=None, vertex_location=None) 
             parameters=parameters,
         )
         if response.predictions:
-            text_embedding = _extract_embedding(response.predictions[0], "textEmbedding")
+            text_embedding = _extract_embedding(
+                response.predictions[0], "textEmbedding"
+            )
         else:
             text_embedding = None
         if text_embedding:
             import numpy as np
+
             vec = np.array(text_embedding, dtype=np.float32)
             norm = np.linalg.norm(vec)
             if norm > 1e-6:

--- a/server/test/api_test_client.py
+++ b/server/test/api_test_client.py
@@ -132,14 +132,22 @@ def run_load_probe(base_url: str, timeout: float, iterations: int) -> None:
         status, body = call_api(base_url, "/db/stats", timeout=timeout)
         assert_status(status, 200, f"GET /db/stats load iteration {i + 1}")
         if not isinstance(parse_json(body), dict):
-            raise AssertionError(f"GET /db/stats load iteration {i + 1}: malformed JSON")
+            raise AssertionError(
+                f"GET /db/stats load iteration {i + 1}: malformed JSON"
+            )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run backend API smoke/load checks.")
-    parser.add_argument("--base-url", default="http://127.0.0.1:19819", help="Backend base URL")
-    parser.add_argument("--timeout", type=float, default=5.0, help="HTTP timeout in seconds")
-    parser.add_argument("--iterations", type=int, default=120, help="Number of repeated load requests")
+    parser.add_argument(
+        "--base-url", default="http://127.0.0.1:19819", help="Backend base URL"
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=5.0, help="HTTP timeout in seconds"
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=120, help="Number of repeated load requests"
+    )
     args = parser.parse_args()
 
     start = time.time()

--- a/server/test/dump_photo_metadata.py
+++ b/server/test/dump_photo_metadata.py
@@ -82,4 +82,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/server/test/test_api_endpoints.py
+++ b/server/test/test_api_endpoints.py
@@ -4,88 +4,102 @@ import json
 from unittest.mock import MagicMock
 
 
-
 from geniusai_server import app
+
 
 @pytest.fixture
 def client():
-    app.config['TESTING'] = True
+    app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
 
+
 # --- Admin / Diagnostic Endpoints ---
 
+
 def test_ping(client):
-    response = client.get('/ping')
+    response = client.get("/ping")
     assert response.status_code == 200
-    assert response.data.decode('utf-8').strip() == "pong"
+    assert response.data.decode("utf-8").strip() == "pong"
+
 
 def test_version(client):
-    response = client.get('/version')
+    response = client.get("/version")
     assert response.status_code == 200
     data = response.get_json()
     assert "backend_version" in data
 
+
 def test_version_check(client):
-    response = client.post('/version/check', json={
-        "plugin_version": "1.0.0",
-        "plugin_release_tag": "v1.0.0",
-        "plugin_build": 12345
-    })
+    response = client.post(
+        "/version/check",
+        json={
+            "plugin_version": "1.0.0",
+            "plugin_release_tag": "v1.0.0",
+            "plugin_build": 12345,
+        },
+    )
     assert response.status_code == 200
+
 
 # --- Database Endpoints ---
 
+
 def test_db_stats(client, mocker):
-    mocker.patch('routes_db.service_db.get_database_stats', return_value={"total": 0})
-    response = client.get('/db/stats')
+    mocker.patch("routes_db.service_db.get_database_stats", return_value={"total": 0})
+    response = client.get("/db/stats")
     assert response.status_code == 200
     assert response.get_json() == {"total": 0}
 
+
 def test_get_ids(client, mocker):
-    mocker.patch('routes_index.chroma_service.get_all_image_ids', return_value=["id1", "id2"])
-    response = client.get('/get/ids')
+    mocker.patch(
+        "routes_index.chroma_service.get_all_image_ids", return_value=["id1", "id2"]
+    )
+    response = client.get("/get/ids")
     assert response.status_code == 200
     assert response.get_json() == ["id1", "id2"]
 
 
 # --- Search / Cull Endpoints ---
 
+
 def test_search(client, mocker):
-    mocker.patch('routes_search.service_search.search_images', return_value=([], None))
-    response = client.post('/search', json={
-        "term": "test search",
-        "max_results": 5
-    })
+    mocker.patch("routes_search.service_search.search_images", return_value=([], None))
+    response = client.post("/search", json={"term": "test search", "max_results": 5})
     assert response.status_code == 200
     assert response.get_json() == {"results": []}
+
 
 def test_find_similar(client, mocker):
-    mocker.patch('routes_search.service_search.find_similar_images', return_value=([], None))
-    response = client.post('/find_similar', json={
-        "photo_id": "test_id",
-        "max_results": 5
-    })
+    mocker.patch(
+        "routes_search.service_search.find_similar_images", return_value=([], None)
+    )
+    response = client.post(
+        "/find_similar", json={"photo_id": "test_id", "max_results": 5}
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"results": []}
 
+
 def test_group_similar(client, mocker):
-    mocker.patch('routes_search.service_search.group_similar_images', return_value=([], None))
-    response = client.post('/group_similar', json={
-        "photo_ids": ["id1", "id2"]
-    })
+    mocker.patch(
+        "routes_search.service_search.group_similar_images", return_value=([], None)
+    )
+    response = client.post("/group_similar", json={"photo_ids": ["id1", "id2"]})
     assert response.status_code == 200
 
+
 def test_cull(client, mocker):
-    mocker.patch('service_search.cull_images', return_value={"groups": []})
-    response = client.post('/cull', json={
-        "photo_ids": ["id1", "id2"]
-    })
+    mocker.patch("service_search.cull_images", return_value={"groups": []})
+    response = client.post("/cull", json={"photo_ids": ["id1", "id2"]})
     assert response.status_code == 200
     assert response.get_json() == {"groups": []}
 
+
 # --- AI Edit Endpoints ---
+
 
 def test_edit(client, mocker):
     mock_service = MagicMock()
@@ -97,19 +111,18 @@ def test_edit(client, mocker):
     mock_service.generate_edit_recipe_single.return_value = mock_response
     mock_response.warning = None
     mock_response.error = None
-    mocker.patch('routes_edit.get_analysis_service', return_value=mock_service)
-    mocker.patch('routes_edit.chroma_service.get_image', return_value=None)
-    mocker.patch('routes_edit.chroma_service.add_image')
+    mocker.patch("routes_edit.get_analysis_service", return_value=mock_service)
+    mocker.patch("routes_edit.chroma_service.get_image", return_value=None)
+    mocker.patch("routes_edit.chroma_service.add_image")
 
-    data = {
-        'photo_id': ['id1'],
-        'options': '{}'
-    }
-    response = client.post('/edit', data={
-        **data,
-        'image': (io.BytesIO(b"fake data"), 'test.jpg')
-    }, content_type='multipart/form-data')
+    data = {"photo_id": ["id1"], "options": "{}"}
+    response = client.post(
+        "/edit",
+        data={**data, "image": (io.BytesIO(b"fake data"), "test.jpg")},
+        content_type="multipart/form-data",
+    )
     assert response.status_code == 200
+
 
 def test_edit_base64(client, mocker):
     mock_service = MagicMock()
@@ -121,152 +134,198 @@ def test_edit_base64(client, mocker):
     mock_service.generate_edit_recipe_single.return_value = mock_response
     mock_response.warning = None
     mock_response.error = None
-    mocker.patch('routes_edit.get_analysis_service', return_value=mock_service)
-    mocker.patch('routes_edit.chroma_service.get_image', return_value=None)
-    mocker.patch('routes_edit.chroma_service.add_image')
+    mocker.patch("routes_edit.get_analysis_service", return_value=mock_service)
+    mocker.patch("routes_edit.chroma_service.get_image", return_value=None)
+    mocker.patch("routes_edit.chroma_service.add_image")
 
-    response = client.post('/edit_base64', json={
-        "image": "ZmFrZSBkYXRh", # "fake data" in base64
-        "photo_id": "test_id",
-        "filename": "test.jpg"
-    })
+    response = client.post(
+        "/edit_base64",
+        json={
+            "image": "ZmFrZSBkYXRh",  # "fake data" in base64
+            "photo_id": "test_id",
+            "filename": "test.jpg",
+        },
+    )
     assert response.status_code == 200
+
 
 # --- Indexing Endpoints ---
 
+
 def test_index_unprocessed(client, mocker):
-    mocker.patch('routes_index.get_photo_ids_needing_processing', return_value=["id2"])
-    response = client.post('/index/check-unprocessed', json={
-        "photo_ids": ["id1", "id2"]
-    })
+    mocker.patch("routes_index.get_photo_ids_needing_processing", return_value=["id2"])
+    response = client.post(
+        "/index/check-unprocessed", json={"photo_ids": ["id1", "id2"]}
+    )
     assert response.status_code == 200
     assert "photo_ids" in response.get_json()
     assert response.get_json()["photo_ids"] == ["id2"]
 
+
 def test_remove(client, mocker):
-    mocker.patch('routes_index.chroma_service.delete_image', return_value=True)
-    mocker.patch('routes_index.chroma_service.delete_faces_by_photo_uuid', return_value=True)
-    response = client.post('/remove', json={
-        "photo_id": "id1"
-    })
+    mocker.patch("routes_index.chroma_service.delete_image", return_value=True)
+    mocker.patch(
+        "routes_index.chroma_service.delete_faces_by_photo_uuid", return_value=True
+    )
+    response = client.post("/remove", json={"photo_id": "id1"})
     assert response.status_code == 200
+
 
 # --- Faces Endpoints ---
 
+
 def test_faces_query(client, mocker):
-    mocker.patch('routes_faces.face_service.detect_faces', return_value=[{"embedding": [0.1, 0.2]}])
+    mocker.patch(
+        "routes_faces.face_service.detect_faces",
+        return_value=[{"embedding": [0.1, 0.2]}],
+    )
     # Based on routes_faces implementation
-    mocker.patch('routes_faces.chroma_service.query_faces', return_value={"ids": [["f1"]], "distances": [[0.5]], "metadatas": [[{"photo_id": "p1"}]]})
-    
-    response = client.post('/faces/query', json={
-        "image": "fakebase64",
-        "n_results": 10
-    })
-    assert response.status_code in [200, 400] # Usually 200 if base64 is bypassed or 400 if decode fails
+    mocker.patch(
+        "routes_faces.chroma_service.query_faces",
+        return_value={
+            "ids": [["f1"]],
+            "distances": [[0.5]],
+            "metadatas": [[{"photo_id": "p1"}]],
+        },
+    )
+
+    response = client.post(
+        "/faces/query", json={"image": "fakebase64", "n_results": 10}
+    )
+    assert response.status_code in [
+        200,
+        400,
+    ]  # Usually 200 if base64 is bypassed or 400 if decode fails
+
 
 def test_faces_cluster(client, mocker):
-    mocker.patch('routes_faces.persons_service.run_clustering', return_value={"summary": "ok"})
-    response = client.post('/faces/cluster')
+    mocker.patch(
+        "routes_faces.persons_service.run_clustering", return_value={"summary": "ok"}
+    )
+    response = client.post("/faces/cluster")
     assert response.status_code == 200
 
+
 def test_list_persons(client, mocker):
-    mocker.patch('routes_faces.persons_service.list_persons', return_value=[])
-    response = client.get('/faces/persons')
+    mocker.patch("routes_faces.persons_service.list_persons", return_value=[])
+    response = client.get("/faces/persons")
     assert response.status_code == 200
 
 
 # --- Training Endpoints ---
 
+
 def test_training_add(client, mocker):
-    mocker.patch('routes_training.training_service.add_training_example')
-    mocker.patch('routes_training.training_service.get_training_count', return_value=1)
+    mocker.patch("routes_training.training_service.add_training_example")
+    mocker.patch("routes_training.training_service.get_training_count", return_value=1)
     # Bypass CLIP embedding for simplicity in smoke test
-    mocker.patch('routes_training._compute_clip_embedding', return_value=None)
-    
-    response = client.post('/training/add', data={
-        "photo_id": "test_id",
-        "develop_settings": json.dumps({"Exposure": 1.0})
-    })
+    mocker.patch("routes_training._compute_clip_embedding", return_value=None)
+
+    response = client.post(
+        "/training/add",
+        data={"photo_id": "test_id", "develop_settings": json.dumps({"Exposure": 1.0})},
+    )
     assert response.status_code == 200
     assert response.get_json()["status"] == "ok"
 
+
 def test_training_list(client, mocker):
-    mocker.patch('routes_training.training_service.list_training_examples', return_value=[])
-    response = client.get('/training/list')
+    mocker.patch(
+        "routes_training.training_service.list_training_examples", return_value=[]
+    )
+    response = client.get("/training/list")
     assert response.status_code == 200
     assert "examples" in response.get_json()
 
+
 def test_training_count(client, mocker):
-    mocker.patch('routes_training.training_service.get_training_count', return_value=5)
-    response = client.get('/training/count')
+    mocker.patch("routes_training.training_service.get_training_count", return_value=5)
+    response = client.get("/training/count")
     assert response.status_code == 200
     assert response.get_json()["count"] == 5
 
+
 def test_training_delete(client, mocker):
-    mocker.patch('routes_training.training_service.delete_training_example', return_value=True)
-    mocker.patch('routes_training.training_service.get_training_count', return_value=4)
-    response = client.delete('/training/test_id')
+    mocker.patch(
+        "routes_training.training_service.delete_training_example", return_value=True
+    )
+    mocker.patch("routes_training.training_service.get_training_count", return_value=4)
+    response = client.delete("/training/test_id")
     assert response.status_code == 200
 
 
 # --- DB Maintenance Endpoints ---
 
+
 def test_db_backup(client, mocker):
-    mocker.patch('routes_db.service_db.build_backup_zip', return_value=('fake_path.zip', 'backup.zip'))
+    mocker.patch(
+        "routes_db.service_db.build_backup_zip",
+        return_value=("fake_path.zip", "backup.zip"),
+    )
     # Mock send_file to avoid FileNotFoundError in test environment
-    mocker.patch('routes_db.send_file', return_value=app.response_class("fake content", mimetype="application/zip"))
+    mocker.patch(
+        "routes_db.send_file",
+        return_value=app.response_class("fake content", mimetype="application/zip"),
+    )
     # Mock os.remove to avoid errors when the after_this_request handler runs
-    mocker.patch('routes_db.os.remove')
-    response = client.get('/db/backup')
+    mocker.patch("routes_db.os.remove")
+    response = client.get("/db/backup")
     assert response.status_code == 200
-    assert response.headers['Content-Type'] == 'application/zip'
+    assert response.headers["Content-Type"] == "application/zip"
+
 
 def test_db_migrate_photo_ids(client, mocker):
-    mocker.patch('routes_db.service_db.migrate_photo_ids', return_value={"updated": 1})
-    response = client.post('/db/migrate-photo-ids', json={"test": "mapping"})
+    mocker.patch("routes_db.service_db.migrate_photo_ids", return_value={"updated": 1})
+    response = client.post("/db/migrate-photo-ids", json={"test": "mapping"})
     assert response.status_code == 200
 
 
 # --- CLIP Endpoints ---
 
+
 def test_clip_status(client, mocker):
-    mocker.patch('routes_clip.is_model_cached', return_value=True)
-    response = client.get('/clip/status')
+    mocker.patch("routes_clip.is_model_cached", return_value=True)
+    response = client.get("/clip/status")
     assert response.status_code == 200
     assert response.get_json()["clip"] == "ready"
 
+
 # --- Import Endpoints ---
 
+
 def test_import_metadata(client, mocker):
-    mocker.patch('routes_import.import_service.import_metadata_task', return_value=(1, 0))
-    response = client.post('/import/metadata', json={
-        "metadata_items": [{"photo_id": "p1"}]
-    })
+    mocker.patch(
+        "routes_import.import_service.import_metadata_task", return_value=(1, 0)
+    )
+    response = client.post(
+        "/import/metadata", json={"metadata_items": [{"photo_id": "p1"}]}
+    )
     assert response.status_code == 200
     assert response.get_json()["success_count"] == 1
 
 
 # --- Server Health and Models ---
 
+
 def test_health(client, mocker):
-    mocker.patch('server_lifecycle.get_health_status', return_value={"clip": "ok"})
+    mocker.patch("server_lifecycle.get_health_status", return_value={"clip": "ok"})
     mock_service = MagicMock()
     mock_service.get_health_status.return_value = {"llm": "ok"}
-    mocker.patch('routes_server.get_analysis_service', return_value=mock_service)
-    mocker.patch('service_face._get_face_app')
-    
-    response = client.get('/health')
+    mocker.patch("routes_server.get_analysis_service", return_value=mock_service)
+    mocker.patch("service_face._get_face_app")
+
+    response = client.get("/health")
     assert response.status_code == 200
     data = response.get_json()
     assert "clip" in data
     assert "llm" in data
 
+
 def test_models(client, mocker):
     mock_service = MagicMock()
     mock_service.get_available_models.return_value = {"chatgpt": ["gpt-4"]}
-    mocker.patch('routes_server.get_analysis_service', return_value=mock_service)
-    
-    response = client.get('/models')
+    mocker.patch("routes_server.get_analysis_service", return_value=mock_service)
+
+    response = client.get("/models")
     assert response.status_code == 200
     assert "models" in response.get_json()
-

--- a/server/test/test_config.py
+++ b/server/test/test_config.py
@@ -1,33 +1,37 @@
 from src.config import _deep_merge_dict, get_culling_config, BASE_CULLING_CONFIG
 
+
 def test_deep_merge_dict():
     base = {"a": 1, "b": {"c": 2, "d": 3}}
     override = {"b": {"c": 4, "e": 5}, "f": 6}
     merged = _deep_merge_dict(base, override)
-    
+
     assert merged["a"] == 1
     assert merged["b"]["c"] == 4
     assert merged["b"]["d"] == 3
     assert merged["b"]["e"] == 5
     assert merged["f"] == 6
 
+
 def test_get_culling_config_default():
     config = get_culling_config()
     assert config == BASE_CULLING_CONFIG
-    
+
     config_explicit = get_culling_config("default")
     assert config_explicit == BASE_CULLING_CONFIG
 
+
 def test_get_culling_config_portrait():
     config = get_culling_config("portrait")
-    
+
     # Check that it merged overrides
     assert config["ranking"]["face_group_weight_technical"] == 0.34
     assert config["ranking"]["face_group_weight_face"] == 0.66
-    
+
     # Check that base keys are still present
     assert "face_metrics" in config
     assert config["face_metrics"]["eye_patch_ratio"] == 0.08
+
 
 def test_get_culling_config_invalid_preset():
     # Invalid presets should fallback to default

--- a/server/test/test_edit_recipe.py
+++ b/server/test/test_edit_recipe.py
@@ -10,62 +10,64 @@ from edit_recipe import normalize_edit_recipe, filter_edit_recipe_by_controls
 
 class NormalizeEditRecipeTests(unittest.TestCase):
     def test_clamps_global_values_and_discards_invalid_mask(self):
-        recipe = normalize_edit_recipe({
-            "summary": "  Brighten portrait  ",
-            "global": {
-                "exposure": 9,
-                "contrast": -120,
-                "temperature": "5600",
-                "white_balance": {
-                    "temperature": 6200,
-                    "tint": 13,
-                },
-                "crop": {
-                    "left": -0.1,
-                    "right": 1.2,
-                    "top": 0.05,
-                    "bottom": 0.95,
-                    "angle": 60,
-                },
-                "vignette": -40,
-                "vignette_feather": 120,
-                "sharpen_radius": 4.0,
-                "noise_reduction_detail": 85,
-                "grain_size": 33,
-                "tone_curve": {
-                    "highlights": 30,
-                    "shadow_split": -5,
-                    "midtone_split": 50,
-                    "highlight_split": 150,
-                    "point_curve": {
-                        "master": [0, 0, 64, 56, 128, 136, 255, 255],
-                        "red": [{"x": 0, "y": 0}, {"x": 255, "y": 250}],
-                        "green": [[0, 3], [255, 255]],
-                        "blue": [0, 0, 255],  # odd length should be trimmed/invalid
+        recipe = normalize_edit_recipe(
+            {
+                "summary": "  Brighten portrait  ",
+                "global": {
+                    "exposure": 9,
+                    "contrast": -120,
+                    "temperature": "5600",
+                    "white_balance": {
+                        "temperature": 6200,
+                        "tint": 13,
                     },
-                    "extended_point_curve": {
-                        "master": [0, 0, 84, 68, 130, 147, 183, 193, 448, 448],
-                        "red": [{"x": 0, "y": 0}, {"x": 512, "y": 490}],
+                    "crop": {
+                        "left": -0.1,
+                        "right": 1.2,
+                        "top": 0.05,
+                        "bottom": 0.95,
+                        "angle": 60,
                     },
-                },
-            },
-            "masks": [
-                {
-                    "kind": "subject",
-                    "adjustments": {
-                        "exposure": 2.3,
-                        "clarity": -150,
+                    "vignette": -40,
+                    "vignette_feather": 120,
+                    "sharpen_radius": 4.0,
+                    "noise_reduction_detail": 85,
+                    "grain_size": 33,
+                    "tone_curve": {
+                        "highlights": 30,
+                        "shadow_split": -5,
+                        "midtone_split": 50,
+                        "highlight_split": 150,
+                        "point_curve": {
+                            "master": [0, 0, 64, 56, 128, 136, 255, 255],
+                            "red": [{"x": 0, "y": 0}, {"x": 255, "y": 250}],
+                            "green": [[0, 3], [255, 255]],
+                            "blue": [0, 0, 255],  # odd length should be trimmed/invalid
+                        },
+                        "extended_point_curve": {
+                            "master": [0, 0, 84, 68, 130, 147, 183, 193, 448, 448],
+                            "red": [{"x": 0, "y": 0}, {"x": 512, "y": 490}],
+                        },
                     },
                 },
-                {
-                    "kind": "person",
-                    "adjustments": {
-                        "exposure": 1,
+                "masks": [
+                    {
+                        "kind": "subject",
+                        "adjustments": {
+                            "exposure": 2.3,
+                            "clarity": -150,
+                        },
                     },
-                },
-            ],
-            "warnings": ["  keep skin natural  "],
-        })
+                    {
+                        "kind": "person",
+                        "adjustments": {
+                            "exposure": 1,
+                        },
+                    },
+                ],
+                "warnings": ["  keep skin natural  "],
+            }
+        )
 
         self.assertEqual(recipe["summary"], "Brighten portrait")
         self.assertEqual(recipe["global"]["exposure"], 5.0)
@@ -85,12 +87,25 @@ class NormalizeEditRecipeTests(unittest.TestCase):
         self.assertEqual(recipe["global"]["tone_curve"]["shadow_split"], 0.0)
         self.assertEqual(recipe["global"]["tone_curve"]["midtone_split"], 50.0)
         self.assertEqual(recipe["global"]["tone_curve"]["highlight_split"], 100.0)
-        self.assertEqual(recipe["global"]["tone_curve"]["point_curve"]["master"], [0, 0, 64, 56, 128, 136, 255, 255])
-        self.assertEqual(recipe["global"]["tone_curve"]["point_curve"]["red"], [0, 0, 255, 250])
-        self.assertEqual(recipe["global"]["tone_curve"]["point_curve"]["green"], [0, 3, 255, 255])
+        self.assertEqual(
+            recipe["global"]["tone_curve"]["point_curve"]["master"],
+            [0, 0, 64, 56, 128, 136, 255, 255],
+        )
+        self.assertEqual(
+            recipe["global"]["tone_curve"]["point_curve"]["red"], [0, 0, 255, 250]
+        )
+        self.assertEqual(
+            recipe["global"]["tone_curve"]["point_curve"]["green"], [0, 3, 255, 255]
+        )
         self.assertNotIn("blue", recipe["global"]["tone_curve"]["point_curve"])
-        self.assertEqual(recipe["global"]["tone_curve"]["extended_point_curve"]["master"], [0, 0, 84, 68, 130, 147, 183, 193, 448, 448])
-        self.assertEqual(recipe["global"]["tone_curve"]["extended_point_curve"]["red"], [0, 0, 512, 490])
+        self.assertEqual(
+            recipe["global"]["tone_curve"]["extended_point_curve"]["master"],
+            [0, 0, 84, 68, 130, 147, 183, 193, 448, 448],
+        )
+        self.assertEqual(
+            recipe["global"]["tone_curve"]["extended_point_curve"]["red"],
+            [0, 0, 512, 490],
+        )
         # Top-level keys take precedence over white_balance object.
         self.assertEqual(recipe["global"]["temperature"], 5600.0)
         self.assertNotIn("white_balance", recipe["global"])
@@ -98,7 +113,9 @@ class NormalizeEditRecipeTests(unittest.TestCase):
         self.assertEqual(recipe["masks"][0]["kind"], "subject")
         self.assertEqual(recipe["masks"][0]["adjustments"]["clarity"], -100.0)
         self.assertIn("keep skin natural", recipe["warnings"])
-        self.assertTrue(any("unsupported kind" in warning for warning in recipe["warnings"]))
+        self.assertTrue(
+            any("unsupported kind" in warning for warning in recipe["warnings"])
+        )
 
     def test_handles_invalid_payload(self):
         recipe = normalize_edit_recipe("invalid")
@@ -107,43 +124,54 @@ class NormalizeEditRecipeTests(unittest.TestCase):
         self.assertTrue(recipe["warnings"])
 
     def test_white_balance_object_maps_to_temperature_and_tint(self):
-        recipe = normalize_edit_recipe({
-            "summary": "WB tweak",
-            "global": {
-                "white_balance": {
-                    "temperature": 70000,
-                    "tint": -200,
+        recipe = normalize_edit_recipe(
+            {
+                "summary": "WB tweak",
+                "global": {
+                    "white_balance": {
+                        "temperature": 70000,
+                        "tint": -200,
+                    },
                 },
-            },
-            "masks": [],
-            "warnings": [],
-        })
+                "masks": [],
+                "warnings": [],
+            }
+        )
         self.assertEqual(recipe["global"]["temperature"], 50000.0)
         self.assertEqual(recipe["global"]["tint"], -150.0)
 
     def test_filter_recipe_by_category_controls(self):
-        recipe = normalize_edit_recipe({
-            "summary": "Category control test",
-            "global": {
-                "exposure": 0.5,
-                "temperature": 5600,
-                "clarity": 20,
-                "vibrance": 15,
-                "color_grading": {"shadows": {"hue": 220, "saturation": 20}},
-                "tone_curve": {
-                    "highlights": 25,
-                    "point_curve": {"master": [0, 0, 128, 140, 255, 255]},
+        recipe = normalize_edit_recipe(
+            {
+                "summary": "Category control test",
+                "global": {
+                    "exposure": 0.5,
+                    "temperature": 5600,
+                    "clarity": 20,
+                    "vibrance": 15,
+                    "color_grading": {"shadows": {"hue": 220, "saturation": 20}},
+                    "tone_curve": {
+                        "highlights": 25,
+                        "point_curve": {"master": [0, 0, 128, 140, 255, 255]},
+                    },
+                    "crop": {"left": 0.02, "right": 0.98, "top": 0.03, "bottom": 0.97},
+                    "sharpening": 40,
+                    "vignette": -25,
+                    "lens_corrections": {"enable_profile_corrections": True},
                 },
-                "crop": {"left": 0.02, "right": 0.98, "top": 0.03, "bottom": 0.97},
-                "sharpening": 40,
-                "vignette": -25,
-                "lens_corrections": {"enable_profile_corrections": True},
-            },
-            "masks": [
-                {"kind": "subject", "adjustments": {"exposure": 0.3, "clarity": 10, "sharpness": 25}},
-            ],
-            "warnings": [],
-        })
+                "masks": [
+                    {
+                        "kind": "subject",
+                        "adjustments": {
+                            "exposure": 0.3,
+                            "clarity": 10,
+                            "sharpness": 25,
+                        },
+                    },
+                ],
+                "warnings": [],
+            }
+        )
 
         filtered = filter_edit_recipe_by_controls(
             recipe,
@@ -182,20 +210,22 @@ class NormalizeEditRecipeTests(unittest.TestCase):
         self.assertNotIn("sharpness", filtered["masks"][0]["adjustments"])
 
     def test_crop_xywh_shape_is_normalized(self):
-        recipe = normalize_edit_recipe({
-            "summary": "xywh crop",
-            "global": {
-                "crop": {
-                    "x": 0.1,
-                    "y": 0.2,
-                    "width": 0.7,
-                    "height": 0.6,
-                    "rotation": 12,
+        recipe = normalize_edit_recipe(
+            {
+                "summary": "xywh crop",
+                "global": {
+                    "crop": {
+                        "x": 0.1,
+                        "y": 0.2,
+                        "width": 0.7,
+                        "height": 0.6,
+                        "rotation": 12,
+                    },
                 },
-            },
-            "masks": [],
-            "warnings": [],
-        })
+                "masks": [],
+                "warnings": [],
+            }
+        )
 
         self.assertIn("crop", recipe["global"])
         self.assertEqual(recipe["global"]["crop"]["left"], 0.1)
@@ -205,20 +235,25 @@ class NormalizeEditRecipeTests(unittest.TestCase):
         self.assertEqual(recipe["global"]["crop"]["angle"], 12.0)
 
     def test_invalid_crop_shape_adds_warning(self):
-        recipe = normalize_edit_recipe({
-            "summary": "bad crop",
-            "global": {
-                "crop": {
-                    "x": 0.3,
-                    "width": 0.4,
+        recipe = normalize_edit_recipe(
+            {
+                "summary": "bad crop",
+                "global": {
+                    "crop": {
+                        "x": 0.3,
+                        "width": 0.4,
+                    },
                 },
-            },
-            "masks": [],
-            "warnings": [],
-        })
+                "masks": [],
+                "warnings": [],
+            }
+        )
 
         self.assertNotIn("crop", recipe["global"])
-        self.assertTrue(any("Ignored crop" in warning for warning in recipe["warnings"]))
+        self.assertTrue(
+            any("Ignored crop" in warning for warning in recipe["warnings"])
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/test/test_style_engine.py
+++ b/server/test/test_style_engine.py
@@ -6,11 +6,12 @@ from unittest.mock import patch
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from service_style_engine import (
-    calculate_composite_score, 
-    interpolate_recipes, 
+    calculate_composite_score,
+    interpolate_recipes,
     generate_style_edit,
-    StyleEngineResult
+    StyleEngineResult,
 )
+
 
 def test_calculate_composite_score():
     query_exposure = {"exp_luminance_mean": 0.5, "exp_contrast": 0.5}
@@ -18,59 +19,58 @@ def test_calculate_composite_score():
         "exp_luminance_mean": 0.52,
         "exp_contrast": 0.48,
         "scene_tags": ["scene_outdoor", "scene_landscape"],
-        "time_of_day_bucket": "afternoon"
+        "time_of_day_bucket": "afternoon",
     }
     query_scene_tags = ["scene_outdoor", "scene_landscape"]
     query_tod = "afternoon"
     clip_sim = 0.95
-    
+
     score = calculate_composite_score(
         clip_sim=clip_sim,
         query_exposure=query_exposure,
         candidate=candidate,
         query_scene_tags=query_scene_tags,
-        query_tod=query_tod
+        query_tod=query_tod,
     )
-    
+
     assert score > 0.8
-    
+
     # Test lower score with mismatch
     score_mismatch = calculate_composite_score(
-        clip_sim=0.2, # low sim
+        clip_sim=0.2,  # low sim
         query_exposure=query_exposure,
         candidate=candidate,
-        query_scene_tags=["scene_indoor"], # mismatch
-        query_tod="night" # mismatch
+        query_scene_tags=["scene_indoor"],  # mismatch
+        query_tod="night",  # mismatch
     )
-    
+
     assert score > score_mismatch
+
 
 def test_interpolate_recipes():
     # Example 1: Exposure +1
     ex1 = {"canonical_settings": {"exposure": 1.0, "contrast": 10}}
     # Example 2: Exposure -1
     ex2 = {"canonical_settings": {"exposure": -1.0, "contrast": 50}}
-    
-    winners = [
-        (ex1, 0.5),
-        (ex2, 0.5)
-    ]
-    
+
+    winners = [(ex1, 0.5), (ex2, 0.5)]
+
     interpolated = interpolate_recipes(winners)
-    
+
     # (1.0*0.5) + (-1.0*0.5) = 0
     assert interpolated.get("exposure") == 0.0
     # (10*0.5) + (50*0.5) = 30
     assert interpolated.get("contrast") == 30
 
+
 @patch("service_style_engine.training_service")
 def test_generate_style_edit_adaptive(mock_training):
     # If training photo was dark (0.2) and target is bright (0.8)
     # The engine should suggest LOWERING exposure relative to what was done to the dark photo
-    
+
     # Mock training service stats
     mock_training.get_training_count.return_value = 20
-    
+
     # Mock query_similar_training_examples
     # ex1 was a dark photo (0.2) and we gave it +0.5 exposure
     mock_ex = {
@@ -79,49 +79,45 @@ def test_generate_style_edit_adaptive(mock_training):
         "exp_luminance_mean": 0.2,
         "exp_contrast": 0.5,
         "canonical_settings": {"exposure": 0.5, "contrast": 20},
-        "distance": 0.05, # high sim
+        "distance": 0.05,  # high sim
         "scene_tags": [],
-        "time_of_day_bucket": "unknown"
+        "time_of_day_bucket": "unknown",
     }
     mock_training.query_similar_training_examples.return_value = [mock_ex]
-    
+
     # Mock compute_exposure_metrics (target is bright: 0.8)
     mock_training.compute_exposure_metrics.return_value = {
         "exp_luminance_mean": 0.8,
-        "exp_contrast": 0.5
+        "exp_contrast": 0.5,
     }
     mock_training.compute_scene_tags.return_value = []
     mock_training.time_of_day_bucket.return_value = "unknown"
     mock_training.focal_length_bucket.return_value = "unknown"
-    
+
     # Run the engine
     result = generate_style_edit(
-        photo_id="target1",
-        image_bytes=b"fake",
-        clip_embedding=[0.1]*512
+        photo_id="target1", image_bytes=b"fake", clip_embedding=[0.1] * 512
     )
-    
+
     assert isinstance(result, StyleEngineResult)
     assert result.engine == "style"
-    
-    # target (0.8) - training (0.2) = 0.6 difference. 
+
+    # target (0.8) - training (0.2) = 0.6 difference.
     # Current logic: exposure_correction = -lum_delta * 5.0
     # -0.6 * 5.0 = -3.0 (clamped to -1.5)
     # Base exposure was 0.5. Result should be 0.5 - 1.5 = -1.0
-    
+
     final_exposure = result.recipe["global"].get("exposure")
-    assert final_exposure < 0.5 # Should have been lowered
-    assert final_exposure == -1.0 # 0.5 + (-1.5)
+    assert final_exposure < 0.5  # Should have been lowered
+    assert final_exposure == -1.0  # 0.5 + (-1.5)
+
 
 @patch("service_style_engine.training_service")
 def test_generate_style_edit_not_enough_training(mock_training):
     mock_training.get_training_count.return_value = 2
-    
-    result = generate_style_edit(
-        photo_id="target1",
-        image_bytes=b"fake"
-    )
-    
+
+    result = generate_style_edit(photo_id="target1", image_bytes=b"fake")
+
     assert result.engine == "none"
     assert "inactive" in result.warning
     assert "2" in result.warning

--- a/server/test/test_version_info.py
+++ b/server/test/test_version_info.py
@@ -1,11 +1,12 @@
-
 from src.version_info import BACKEND_VERSION, BACKEND_RELEASE_TAG, BACKEND_BUILD
+
 
 def test_version_info_types():
     assert isinstance(BACKEND_VERSION, str)
     assert isinstance(BACKEND_RELEASE_TAG, str)
     assert isinstance(BACKEND_BUILD, int)
-    
+
+
 def test_version_info_structure():
     assert BACKEND_VERSION != ""
     assert BACKEND_BUILD >= 0

--- a/server/test/verify_style_engine.py
+++ b/server/test/verify_style_engine.py
@@ -7,55 +7,56 @@ from unittest.mock import patch
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from service_style_engine import (
-    calculate_composite_score, 
-    interpolate_recipes, 
-    generate_style_edit
+    calculate_composite_score,
+    interpolate_recipes,
+    generate_style_edit,
 )
 
+
 class TestStyleEngineLogic(unittest.TestCase):
-    
     def test_composite_score(self):
         print("\nTesting composite score...")
         query_exposure = {"exp_luminance_mean": 0.5, "exp_contrast": 0.5}
         query_scene_tags = ["scene_outdoor"]
         query_tod = "afternoon"
-        
+
         # ex1 matches everything
         ex1 = {
             "exp_luminance_mean": 0.5,
             "exp_contrast": 0.5,
             "scene_tags": ["scene_outdoor"],
-            "time_of_day_bucket": "afternoon"
+            "time_of_day_bucket": "afternoon",
         }
-        
+
         # ex2 matches nothing well
         ex2 = {
             "exp_luminance_mean": 0.1,
             "exp_contrast": 0.2,
             "scene_tags": ["scene_dark"],
-            "time_of_day_bucket": "night"
+            "time_of_day_bucket": "night",
         }
-        
-        score1 = calculate_composite_score(1.0, query_exposure, ex1, query_scene_tags, query_tod)
-        score2 = calculate_composite_score(0.0, query_exposure, ex2, query_scene_tags, query_tod)
-        
+
+        score1 = calculate_composite_score(
+            1.0, query_exposure, ex1, query_scene_tags, query_tod
+        )
+        score2 = calculate_composite_score(
+            0.0, query_exposure, ex2, query_scene_tags, query_tod
+        )
+
         print(f"  Example 1 Score: {score1}")
         print(f"  Example 2 Score: {score2}")
-        
+
         self.assertGreater(score1, score2)
 
     def test_interpolation(self):
         print("Testing recipe interpolation...")
         ex1 = {"canonical_settings": {"exposure": 1.0, "contrast": 0}}
         ex2 = {"canonical_settings": {"exposure": 0.0, "contrast": 40}}
-        
-        weighted = [
-            (ex1, 0.75),
-            (ex2, 0.25)
-        ]
-        
+
+        weighted = [(ex1, 0.75), (ex2, 0.25)]
+
         interp = interpolate_recipes(weighted)
-        
+
         # 1.0 * 0.75 + 0.0 * 0.25 = 0.75
         self.assertEqual(interp.get("exposure"), 0.75)
         # 0 * 0.75 + 40 * 0.25 = 10
@@ -65,16 +66,16 @@ class TestStyleEngineLogic(unittest.TestCase):
     def test_adaptive_compensation(self, mock_training):
         print("Testing adaptive RAW compensation...")
         # Training was high key (0.8), Target is low key (0.3).
-        
+
         mock_training.get_training_count.return_value = 10
         mock_training.compute_exposure_metrics.return_value = {
-            "exp_luminance_mean": 0.3, # Darker target
-            "exp_contrast": 0.5
+            "exp_luminance_mean": 0.3,  # Darker target
+            "exp_contrast": 0.5,
         }
         mock_training.compute_scene_tags.return_value = []
         mock_training.time_of_day_bucket.return_value = "unknown"
         mock_training.focal_length_bucket.return_value = "unknown"
-        
+
         # ex1 was a bright photo (0.8) and we did nothing to it (exposure 0.0)
         mock_ex = {
             "photo_id": "ex1",
@@ -84,20 +85,21 @@ class TestStyleEngineLogic(unittest.TestCase):
             "canonical_settings": {"exposure": 0.0},
             "distance": 0.05,
             "scene_tags": [],
-            "time_of_day_bucket": "unknown"
+            "time_of_day_bucket": "unknown",
         }
         mock_training.query_similar_training_examples.return_value = [mock_ex]
-        
-        result = generate_style_edit("target1", b"fake", clip_embedding=[0.1]*512)
-        
+
+        result = generate_style_edit("target1", b"fake", clip_embedding=[0.1] * 512)
+
         final_exp = result.recipe["global"].get("exposure")
         print(f"  Final Exposure: {final_exp}")
-        
-        # Target (0.3) is darker than training (0.8). 
+
+        # Target (0.3) is darker than training (0.8).
         # lum_delta = 0.3 - 0.8 = -0.5
         # exposure_correction = -(-0.5) * 5.0 = 2.5 (clamped to 1.5)
         self.assertGreater(final_exp, 0)
         self.assertEqual(final_exp, 1.5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

  Establishes a shared Python formatting/linting baseline for the `server/` backend using
  [ruff](https://docs.astral.sh/ruff/), wires it into CI, documents the expectation in `.agents/rules/`,
   and applies an initial format pass across the existing codebase.

  ## Changes

  - **CI check** (`.github/workflows/lint-format.yml`)  runs `ruff check --ignore E741` and `ruff
  format --check --diff` against `./server/` on every push and PR via `astral-sh/ruff-action@v3`.
  - **Local check script** (`server/scripts/lint_format.sh`)  same `ruff check` + `ruff format --check`
   invocations contributors can run locally before pushing.
  - **Agent rules update** (`.agents/rules/general-rules.md`) adds a Code Style line pointing
  contributors (and coding agents) at `uv run ruff format` and the local check script.
  - **Initial format pass** (`0d94959`)  mechanical `ruff format` run across `server/src/` and
  `server/test/`. pure whitespace/line-break/quote-style normalization. 

## Test plan

  - [ ] CI passes on this PR (both lint and format check steps).
  - [ ] Running `bash server/scripts/lint_format.sh` locally exits 0.
  - [ ] Backend still boots and responds to `/ping`, `/version`, and a sample `/index_base64` call