### PR TITLE
refactor: pin lmstudio version 

### DIFF
--- a/server/requirements-desktop.txt
+++ b/server/requirements-desktop.txt
@@ -12,7 +12,7 @@ transformers>=4.46
 tokenizers>=0.22.0
 rich
 ollama
-lmstudio
+lmstudio>=1.5.0
 pillow
 google-genai
 google-cloud-aiplatform

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,7 +11,7 @@ transformers>=4.46
 tokenizers>=0.22.0
 pillow
 ollama
-lmstudio
+lmstudio>=1.5.0
 google-genai
 google-cloud-aiplatform
 openai

--- a/server/src/llm_provider_lmstudio.py
+++ b/server/src/llm_provider_lmstudio.py
@@ -28,17 +28,10 @@ class LMStudioProvider(LLMProviderBase):
         # lmstudio-python's synchronous API defaults to timing out after ~60s of
         # inactivity when waiting for a response/stream event. Wire our configured
         # timeout through so metadata generation can run longer (e.g. 720s).
-        #
         # Note: this timeout is global to the lmstudio-python sync API.
         try:
-            set_sync_timeout = getattr(lms, "set_sync_api_timeout", None)
-            if callable(set_sync_timeout):
-                set_sync_timeout(self.timeout)
-                logger.info(f"LM Studio sync API timeout set to {self.timeout}s")
-            else:
-                logger.debug(
-                    "lmstudio-python set_sync_api_timeout not available; using SDK default timeout"
-                )
+            lms.set_sync_api_timeout(self.timeout)
+            logger.info(f"LM Studio sync API timeout set to {self.timeout}s")
         except Exception as e:
             logger.warning(
                 f"Failed to set lmstudio-python sync API timeout: {e}", exc_info=True


### PR DESCRIPTION
and remove unneccessary getattr check since `set_sync_api_timeout` will always exist in versions `>=1.5.0`