### PR TITLE
test: cover pure-function helpers and provider response parsing

### DIFF
--- a/server/test/test_flatten_keywords.py
+++ b/server/test/test_flatten_keywords.py
@@ -1,0 +1,96 @@
+import unittest
+
+from service_index import _flatten_keywords
+
+
+class FlattenKeywordsTests(unittest.TestCase):
+    def test_empty_inputs_return_empty_string(self):
+        self.assertEqual(_flatten_keywords(None), "")
+        self.assertEqual(_flatten_keywords(""), "")
+        self.assertEqual(_flatten_keywords([]), "")
+        self.assertEqual(_flatten_keywords({}), "")
+
+    def test_string_input_returned_as_is(self):
+        self.assertEqual(_flatten_keywords("Keyword1, Keyword2"), "Keyword1, Keyword2")
+
+    def test_flat_list_of_strings(self):
+        self.assertEqual(
+            _flatten_keywords(["Alpha", "Beta", "Gamma"]), "Alpha, Beta, Gamma"
+        )
+
+    def test_list_strips_whitespace_and_drops_empty(self):
+        self.assertEqual(
+            _flatten_keywords(["  Alpha  ", "", "   ", "Beta"]), "Alpha, Beta"
+        )
+
+    def test_list_dedupes_case_insensitively(self):
+        self.assertEqual(
+            _flatten_keywords(["Alpha", "alpha", "ALPHA", "Beta"]), "Alpha, Beta"
+        )
+
+    def test_structured_keyword_objects(self):
+        keywords = [
+            {"name": "Mountain", "synonyms": ["Peak", "Summit"]},
+            {"name": "Lake"},
+        ]
+        result = _flatten_keywords(keywords)
+        self.assertEqual(result, "Mountain, Peak, Summit, Lake")
+
+    def test_synonyms_dedupe_against_name_case_insensitive(self):
+        keywords = [{"name": "Mountain", "synonyms": ["mountain", "Peak"]}]
+        self.assertEqual(_flatten_keywords(keywords), "Mountain, Peak")
+
+    def test_nested_dict_recurses(self):
+        keywords = {
+            "Nature": {
+                "Landscape": ["Mountain", "Lake"],
+                "Wildlife": ["Bear"],
+            },
+            "People": ["Family"],
+        }
+        result = _flatten_keywords(keywords)
+        # Order follows dict insertion order (Python 3.7+)
+        self.assertEqual(result, "Mountain, Lake, Bear, Family")
+
+    def test_nested_dict_with_structured_leaf_object(self):
+        keywords = {
+            "Nature": {"name": "Mountain", "synonyms": ["Peak"]},
+        }
+        self.assertEqual(_flatten_keywords(keywords), "Mountain, Peak")
+
+    def test_nested_dict_with_scalar_value(self):
+        keywords = {"Category": "DirectKeyword"}
+        self.assertEqual(_flatten_keywords(keywords), "DirectKeyword")
+
+    def test_dedup_across_categories(self):
+        keywords = {
+            "Nature": ["Mountain"],
+            "Travel": ["Mountain", "Hiking"],
+        }
+        self.assertEqual(_flatten_keywords(keywords), "Mountain, Hiking")
+
+    def test_malformed_dict_entries_skipped(self):
+        keywords = [
+            {"name": None},
+            {"name": 42},
+            {"name": "Valid"},
+        ]
+        self.assertEqual(_flatten_keywords(keywords), "Valid")
+
+    def test_synonyms_without_name_still_emitted(self):
+        # Pins current behavior: a dict missing `name` still contributes its
+        # synonyms. Surprising, but downstream code expects this today.
+        keywords = [{"synonyms": ["orphan"]}, {"name": "Valid"}]
+        self.assertEqual(_flatten_keywords(keywords), "orphan, Valid")
+
+    def test_synonyms_non_list_ignored(self):
+        keywords = [{"name": "Mountain", "synonyms": "Peak"}]
+        self.assertEqual(_flatten_keywords(keywords), "Mountain")
+
+    def test_unknown_input_type_returns_empty_string(self):
+        self.assertEqual(_flatten_keywords(42), "")
+        self.assertEqual(_flatten_keywords(3.14), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test/test_image_to_base64.py
+++ b/server/test/test_image_to_base64.py
@@ -1,0 +1,83 @@
+import base64
+import io
+import unittest
+
+from PIL import Image
+
+from llm_provider_base import LLMProviderBase
+
+
+class _StubProvider(LLMProviderBase):
+    def generate_metadata(self, request):
+        raise NotImplementedError
+
+    def is_available(self):
+        return True
+
+    def generate_edit_recipe(self, request):
+        raise NotImplementedError
+
+    def list_available_models(self):
+        return []
+
+
+def _make_jpeg_bytes(color=(255, 0, 0)):
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="JPEG", quality=80)
+    return buf.getvalue()
+
+
+def _make_png_bytes(color=(0, 255, 0)):
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class ImageToBase64Tests(unittest.TestCase):
+    def setUp(self):
+        self.provider = _StubProvider({})
+
+    def test_jpeg_input_skips_re_encode(self):
+        jpeg_bytes = _make_jpeg_bytes()
+        result = self.provider._image_to_base64(jpeg_bytes)
+        # Fast path: returned base64 must decode back to the exact original bytes
+        self.assertEqual(base64.b64decode(result), jpeg_bytes)
+
+    def test_jpeg_magic_number_detected(self):
+        jpeg_bytes = _make_jpeg_bytes()
+        self.assertTrue(jpeg_bytes.startswith(b"\xff\xd8\xff"))
+
+    def test_png_re_encoded_to_jpeg(self):
+        png_bytes = _make_png_bytes()
+        result = self.provider._image_to_base64(png_bytes)
+        decoded = base64.b64decode(result)
+        # Should now be a JPEG, not the original PNG bytes
+        self.assertNotEqual(decoded, png_bytes)
+        self.assertTrue(decoded.startswith(b"\xff\xd8\xff"))
+        # And should still decode back to a valid image
+        Image.open(io.BytesIO(decoded)).verify()
+
+    def test_returns_valid_base64(self):
+        result = self.provider._image_to_base64(_make_jpeg_bytes())
+        self.assertIsInstance(result, str)
+        # No exception means valid base64
+        base64.b64decode(result, validate=True)
+
+    def test_non_image_bytes_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.provider._image_to_base64(b"not an image at all")
+
+    def test_empty_bytes_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.provider._image_to_base64(b"")
+
+    def test_jpeg_fast_path_trusts_magic_header(self):
+        # Pin current behavior: the fast path doesn't validate the JPEG body.
+        # A header followed by garbage is still encoded without error.
+        bogus = b"\xff\xd8\xff" + b"garbage payload"
+        result = self.provider._image_to_base64(bogus)
+        self.assertEqual(base64.b64decode(result), bogus)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test/test_llm_provider_response_parsing.py
+++ b/server/test/test_llm_provider_response_parsing.py
@@ -1,0 +1,207 @@
+"""
+Provider response-parsing tests: pin behavior of the dict-vs-JSON-string branch
+and the malformed-content/empty-content fallbacks. The SDKs are fully mocked.
+"""
+
+import io
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from llm_provider_base import MetadataGenerationRequest
+
+
+def _jpeg_bytes():
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), (10, 20, 30)).save(buf, format="JPEG", quality=80)
+    return buf.getvalue()
+
+
+def _request(**overrides):
+    defaults = dict(
+        image_data=_jpeg_bytes(),
+        uuid="uuid-1",
+        provider="test",
+        model="test-model",
+        api_key=None,
+        generate_keywords=True,
+        generate_caption=True,
+        generate_title=False,
+        generate_alt_text=False,
+        language="English",
+        temperature=0.2,
+        max_tokens=None,
+        system_prompt=None,
+        user_prompt=None,
+        submit_keywords=False,
+        submit_folder_names=False,
+        existing_keywords=None,
+    )
+    defaults.update(overrides)
+    return MetadataGenerationRequest(**defaults)
+
+
+# ----- Ollama --------------------------------------------------------------
+
+
+@pytest.fixture
+def ollama_provider(mocker):
+    """Build an OllamaProvider with the SDK Client mocked out."""
+    from llm_provider_ollama import OllamaProvider
+
+    fake_client = MagicMock(name="FakeOllamaClient")
+    mocker.patch("llm_provider_ollama.Client", return_value=fake_client)
+    provider = OllamaProvider({})
+    return provider, fake_client
+
+
+def test_ollama_dict_response_parsed_through(ollama_provider):
+    provider, fake_client = ollama_provider
+    fake_client.chat.return_value = {
+        "message": {
+            "content": '{"keywords": ["Mountain"], "caption": "scene", "title": "T", "alt_text": "A"}'
+        }
+    }
+    resp = provider.generate_metadata(_request())
+    assert resp.success is True
+    assert resp.keywords == ["Mountain"]
+    assert resp.caption == "scene"
+
+
+def test_ollama_typed_object_response_parsed(ollama_provider):
+    provider, fake_client = ollama_provider
+    typed = MagicMock()
+    typed.message.content = '{"keywords": ["X"], "caption": "c"}'
+    fake_client.chat.return_value = typed
+    resp = provider.generate_metadata(_request())
+    assert resp.success is True
+    assert resp.keywords == ["X"]
+
+
+def test_ollama_empty_content_returns_failure(ollama_provider):
+    provider, fake_client = ollama_provider
+    fake_client.chat.return_value = {"message": {"content": ""}}
+    resp = provider.generate_metadata(_request())
+    assert resp.success is False
+    assert "Empty response" in resp.error
+
+
+def test_ollama_malformed_json_returns_failure(ollama_provider):
+    provider, fake_client = ollama_provider
+    fake_client.chat.return_value = {"message": {"content": "{not json"}}
+    resp = provider.generate_metadata(_request())
+    assert resp.success is False
+    assert "JSON parsing error" in resp.error
+
+
+def test_ollama_sdk_exception_returns_failure(ollama_provider):
+    provider, fake_client = ollama_provider
+    fake_client.chat.side_effect = RuntimeError("network down")
+    resp = provider.generate_metadata(_request())
+    assert resp.success is False
+    assert "network down" in resp.error
+
+
+def test_ollama_caption_omitted_when_not_requested(ollama_provider):
+    provider, fake_client = ollama_provider
+    fake_client.chat.return_value = {
+        "message": {"content": '{"keywords": [], "caption": "ignore me"}'}
+    }
+    resp = provider.generate_metadata(_request(generate_caption=False))
+    assert resp.success is True
+    assert resp.caption is None
+
+
+# ----- LMStudio ------------------------------------------------------------
+
+
+@pytest.fixture
+def lmstudio_provider(mocker):
+    """Build an LMStudioProvider with the SDK fully mocked."""
+    fake_lms = mocker.patch("llm_provider_lmstudio.lms")
+    fake_response = MagicMock(name="FakeLMSResponse")
+    fake_model = MagicMock(name="FakeLMSModel")
+    fake_model.respond.return_value = fake_response
+    # Simulate no tokenize attribute so the fallback token-usage path is skipped
+    del fake_model.tokenize
+    del fake_model.apply_prompt_template
+
+    fake_client = MagicMock(name="FakeLMSClient")
+    fake_client.__enter__.return_value = fake_client
+    fake_client.__exit__.return_value = False
+    fake_client.files.prepare_image.return_value = MagicMock(name="image_handle")
+    fake_client.llm.model.return_value = fake_model
+    fake_lms.Client.return_value = fake_client
+    fake_lms.Chat.return_value = MagicMock(name="FakeChat")
+
+    from llm_provider_lmstudio import LMStudioProvider
+
+    provider = LMStudioProvider({})
+    return provider, fake_response
+
+
+def test_lmstudio_dict_parsed_pass_through(lmstudio_provider):
+    provider, fake_response = lmstudio_provider
+    fake_response.parsed = {
+        "keywords": ["Lake"],
+        "caption": "view",
+        "title": "T",
+        "alt_text": "A",
+    }
+    fake_response.stats = None
+    resp = provider.generate_metadata(_request())
+    assert resp.success is True
+    assert resp.keywords == ["Lake"]
+    assert resp.caption == "view"
+
+
+def test_lmstudio_json_string_parsed(lmstudio_provider):
+    provider, fake_response = lmstudio_provider
+    fake_response.parsed = '{"keywords": ["Lake"], "caption": "view"}'
+    fake_response.stats = None
+    resp = provider.generate_metadata(_request())
+    assert resp.success is True
+    assert resp.keywords == ["Lake"]
+
+
+def test_lmstudio_malformed_string_returns_failure(lmstudio_provider):
+    provider, fake_response = lmstudio_provider
+    fake_response.parsed = "not json at all"
+    fake_response.stats = None
+    resp = provider.generate_metadata(_request())
+    assert resp.success is False
+    assert "Unexpected non-JSON response" in resp.error
+
+
+def test_lmstudio_unexpected_type_returns_failure(lmstudio_provider):
+    provider, fake_response = lmstudio_provider
+    fake_response.parsed = 42  # neither dict nor str
+    fake_response.stats = None
+    resp = provider.generate_metadata(_request())
+    assert resp.success is False
+    assert "Unexpected response type" in resp.error
+
+
+def test_lmstudio_token_usage_from_stats(lmstudio_provider):
+    provider, fake_response = lmstudio_provider
+    fake_response.parsed = {"keywords": [], "caption": "x"}
+    stats = MagicMock()
+    stats.prompt_tokens = 12
+    stats.completion_tokens = 34
+    fake_response.stats = stats
+    resp = provider.generate_metadata(_request())
+    assert resp.success is True
+    assert resp.input_tokens == 12
+    assert resp.output_tokens == 34
+
+
+def test_lmstudio_zero_tokens_when_no_stats_no_tokenize(lmstudio_provider):
+    provider, fake_response = lmstudio_provider
+    fake_response.parsed = {"keywords": [], "caption": "x"}
+    fake_response.stats = None
+    fake_response.usage = None
+    resp = provider.generate_metadata(_request())
+    assert resp.success is True
+    assert resp.input_tokens == 0
+    assert resp.output_tokens == 0

--- a/server/test/test_normalize_keywords_structure.py
+++ b/server/test/test_normalize_keywords_structure.py
@@ -1,0 +1,171 @@
+import unittest
+
+from llm_provider_base import LLMProviderBase
+
+
+class _StubProvider(LLMProviderBase):
+    """Concrete subclass so we can exercise base-class helper methods."""
+
+    def generate_metadata(self, request):
+        raise NotImplementedError
+
+    def is_available(self):
+        return True
+
+    def generate_edit_recipe(self, request):
+        raise NotImplementedError
+
+    def list_available_models(self):
+        return []
+
+
+def _provider():
+    return _StubProvider({})
+
+
+class NormalizeKeywordLeafTests(unittest.TestCase):
+    def test_bare_string_returned_stripped(self):
+        self.assertEqual(
+            _provider()._normalize_keyword_leaf("  Mountain  "), "Mountain"
+        )
+
+    def test_empty_or_whitespace_string_returns_none(self):
+        self.assertIsNone(_provider()._normalize_keyword_leaf(""))
+        self.assertIsNone(_provider()._normalize_keyword_leaf("   "))
+
+    def test_dict_with_name_only(self):
+        self.assertEqual(
+            _provider()._normalize_keyword_leaf({"name": "Mountain"}),
+            {"name": "Mountain"},
+        )
+
+    def test_dict_strips_name_whitespace(self):
+        self.assertEqual(
+            _provider()._normalize_keyword_leaf({"name": "  Mountain  "}),
+            {"name": "Mountain"},
+        )
+
+    def test_dict_with_synonyms_dedupes_against_name(self):
+        result = _provider()._normalize_keyword_leaf(
+            {"name": "Mountain", "synonyms": ["mountain", "Peak"]}
+        )
+        self.assertEqual(result, {"name": "Mountain", "synonyms": ["Peak"]})
+
+    def test_dict_synonyms_dedupe_each_other_case_insensitive(self):
+        result = _provider()._normalize_keyword_leaf(
+            {"name": "Mountain", "synonyms": ["Peak", "PEAK", "peak", "Summit"]}
+        )
+        self.assertEqual(result, {"name": "Mountain", "synonyms": ["Peak", "Summit"]})
+
+    def test_dict_synonyms_non_list_dropped(self):
+        # synonyms field omitted entirely when not a list
+        self.assertEqual(
+            _provider()._normalize_keyword_leaf(
+                {"name": "Mountain", "synonyms": "Peak"}
+            ),
+            {"name": "Mountain"},
+        )
+
+    def test_dict_with_only_empty_synonyms_omits_field(self):
+        self.assertEqual(
+            _provider()._normalize_keyword_leaf(
+                {"name": "Mountain", "synonyms": ["", "  "]}
+            ),
+            {"name": "Mountain"},
+        )
+
+    def test_dict_missing_name_returns_none(self):
+        self.assertIsNone(_provider()._normalize_keyword_leaf({"synonyms": ["X"]}))
+
+    def test_dict_with_non_string_name_returns_none(self):
+        self.assertIsNone(_provider()._normalize_keyword_leaf({"name": None}))
+        self.assertIsNone(_provider()._normalize_keyword_leaf({"name": 42}))
+
+    def test_dict_with_empty_name_returns_none(self):
+        self.assertIsNone(_provider()._normalize_keyword_leaf({"name": "   "}))
+
+    def test_unsupported_types_return_none(self):
+        self.assertIsNone(_provider()._normalize_keyword_leaf(42))
+        self.assertIsNone(_provider()._normalize_keyword_leaf(None))
+        self.assertIsNone(_provider()._normalize_keyword_leaf(["not", "a", "leaf"]))
+
+
+class NormalizeKeywordsStructureTests(unittest.TestCase):
+    def test_flat_list_of_strings(self):
+        result = _provider()._normalize_keywords_structure(["Alpha", "Beta"])
+        self.assertEqual(result, ["Alpha", "Beta"])
+
+    def test_list_drops_empty_and_invalid_leaves(self):
+        result = _provider()._normalize_keywords_structure(
+            ["Alpha", "", "  ", None, 42, {"name": "Beta"}]
+        )
+        self.assertEqual(result, ["Alpha", {"name": "Beta"}])
+
+    def test_list_with_structured_objects(self):
+        result = _provider()._normalize_keywords_structure(
+            [{"name": "Alpha", "synonyms": ["A1"]}, {"name": "Beta"}]
+        )
+        self.assertEqual(
+            result,
+            [{"name": "Alpha", "synonyms": ["A1"]}, {"name": "Beta"}],
+        )
+
+    def test_dict_with_name_treated_as_leaf(self):
+        result = _provider()._normalize_keywords_structure(
+            {"name": "Mountain", "synonyms": ["Peak"]}
+        )
+        self.assertEqual(result, {"name": "Mountain", "synonyms": ["Peak"]})
+
+    def test_nested_dict_recurses_and_preserves_keys(self):
+        result = _provider()._normalize_keywords_structure(
+            {
+                "Nature": ["Mountain", "Lake"],
+                "People": [{"name": "Family"}],
+            }
+        )
+        self.assertEqual(
+            result,
+            {
+                "Nature": ["Mountain", "Lake"],
+                "People": [{"name": "Family"}],
+            },
+        )
+
+    def test_nested_dict_drops_empty_branches(self):
+        result = _provider()._normalize_keywords_structure(
+            {
+                "Nature": ["Mountain"],
+                "Empty": [],
+                "AlsoEmpty": [None, "", "  "],
+                "Nope": {},
+            }
+        )
+        self.assertEqual(result, {"Nature": ["Mountain"]})
+
+    def test_deeply_nested_structure(self):
+        result = _provider()._normalize_keywords_structure(
+            {"Top": {"Mid": {"Leaf": ["Found"]}}}
+        )
+        self.assertEqual(result, {"Top": {"Mid": {"Leaf": ["Found"]}}})
+
+    def test_list_of_lists_recurses(self):
+        result = _provider()._normalize_keywords_structure(
+            [["Alpha", "Beta"], ["Gamma"]]
+        )
+        self.assertEqual(result, [["Alpha", "Beta"], ["Gamma"]])
+
+    def test_empty_inputs(self):
+        self.assertEqual(_provider()._normalize_keywords_structure([]), [])
+        self.assertEqual(_provider()._normalize_keywords_structure({}), {})
+
+    def test_bare_string_normalized_as_leaf(self):
+        self.assertEqual(
+            _provider()._normalize_keywords_structure("  Mountain  "), "Mountain"
+        )
+
+    def test_unsupported_scalar_returns_none(self):
+        self.assertIsNone(_provider()._normalize_keywords_structure(42))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test/test_provider_is_available.py
+++ b/server/test/test_provider_is_available.py
@@ -1,0 +1,80 @@
+"""
+Health-check tests for provider is_available().
+These run on the /health hot path, so false positives/negatives have
+user-visible consequences.
+"""
+
+
+# ----- Ollama --------------------------------------------------------------
+
+
+def test_ollama_is_available_returns_false_when_sdk_missing(mocker):
+    mocker.patch("llm_provider_ollama.Client", None)
+    from llm_provider_ollama import OllamaProvider
+
+    provider = OllamaProvider({})
+    assert provider.is_available() is False
+
+
+def test_ollama_is_available_returns_false_when_sdk_raises(mocker):
+    fake_client_class = mocker.MagicMock()
+    fake_client_class.return_value.list.side_effect = ConnectionError(
+        "connection refused"
+    )
+    mocker.patch("llm_provider_ollama.Client", fake_client_class)
+
+    from llm_provider_ollama import OllamaProvider
+
+    provider = OllamaProvider({})
+    assert provider.is_available() is False
+
+
+def test_ollama_is_available_returns_true_when_sdk_responds(mocker):
+    fake_client_class = mocker.MagicMock()
+    fake_client_class.return_value.list.return_value = {"models": []}
+    mocker.patch("llm_provider_ollama.Client", fake_client_class)
+
+    from llm_provider_ollama import OllamaProvider
+
+    provider = OllamaProvider({})
+    assert provider.is_available() is True
+
+
+# ----- LMStudio ------------------------------------------------------------
+
+
+def test_lmstudio_is_available_rejects_host_without_colon(mocker):
+    fake_lms = mocker.patch("llm_provider_lmstudio.lms")
+    from llm_provider_lmstudio import LMStudioProvider
+
+    provider = LMStudioProvider({"base_url": "no-colon-here"})
+    assert provider.is_available() is False
+    # Critically, the SDK validation must NOT have been invoked when the host
+    # is malformed — the cheap pre-check short-circuits.
+    fake_lms.Client.is_valid_api_host.assert_not_called()
+
+
+def test_lmstudio_is_available_rejects_empty_host(mocker):
+    mocker.patch("llm_provider_lmstudio.lms")
+    from llm_provider_lmstudio import LMStudioProvider
+
+    provider = LMStudioProvider({"base_url": ""})
+    assert provider.is_available() is False
+
+
+def test_lmstudio_is_available_returns_false_on_sdk_exception(mocker):
+    fake_lms = mocker.patch("llm_provider_lmstudio.lms")
+    fake_lms.Client.is_valid_api_host.side_effect = RuntimeError("sdk borked")
+    from llm_provider_lmstudio import LMStudioProvider
+
+    provider = LMStudioProvider({"base_url": "host:1234"})
+    assert provider.is_available() is False
+
+
+def test_lmstudio_is_available_returns_sdk_result(mocker):
+    fake_lms = mocker.patch("llm_provider_lmstudio.lms")
+    fake_lms.Client.is_valid_api_host.return_value = True
+    from llm_provider_lmstudio import LMStudioProvider
+
+    provider = LMStudioProvider({"base_url": "host:1234"})
+    assert provider.is_available() is True

--- a/server/test/test_routes_index_options.py
+++ b/server/test/test_routes_index_options.py
@@ -1,0 +1,135 @@
+import unittest
+
+from routes_index import _extract_options
+
+
+class ExtractOptionsTests(unittest.TestCase):
+    def test_all_defaults(self):
+        opts = _extract_options({})
+        self.assertEqual(opts["language"], "German")
+        self.assertEqual(opts["temperature"], 0.2)
+        self.assertTrue(opts["generate_keywords"])
+        self.assertTrue(opts["generate_caption"])
+        self.assertTrue(opts["generate_title"])
+        self.assertTrue(opts["generate_alt_text"])
+        self.assertFalse(opts["submit_keywords"])
+        self.assertFalse(opts["submit_folder_names"])
+        self.assertEqual(opts["existing_keywords"], None)
+        self.assertEqual(opts["keyword_categories"], [])
+        self.assertEqual(opts["style_strength"], 0.5)
+
+    def test_keyword_categories_as_dict_json_string(self):
+        opts = _extract_options({"keyword_categories": '{"People": ["Family"]}'})
+        self.assertEqual(opts["keyword_categories"], {"People": ["Family"]})
+
+    def test_keyword_categories_as_list_json_string(self):
+        opts = _extract_options({"keyword_categories": '["A", "B"]'})
+        self.assertEqual(opts["keyword_categories"], ["A", "B"])
+
+    def test_keyword_categories_malformed_json_falls_back_to_empty_list(self):
+        opts = _extract_options({"keyword_categories": "{not valid json"})
+        self.assertEqual(opts["keyword_categories"], [])
+
+    def test_keyword_categories_passthrough_when_already_parsed(self):
+        # JSON requests deliver a parsed object directly (no string parsing)
+        opts = _extract_options({"keyword_categories": {"X": ["Y"]}})
+        self.assertEqual(opts["keyword_categories"], {"X": ["Y"]})
+
+    def test_style_strength_clamped_below_zero(self):
+        self.assertEqual(
+            _extract_options({"style_strength": "-1.5"})["style_strength"], 0.0
+        )
+
+    def test_style_strength_clamped_above_one(self):
+        self.assertEqual(
+            _extract_options({"style_strength": "9.9"})["style_strength"], 1.0
+        )
+
+    def test_style_strength_in_range_preserved(self):
+        self.assertEqual(
+            _extract_options({"style_strength": "0.7"})["style_strength"], 0.7
+        )
+
+    def test_style_strength_invalid_string_defaults_to_half(self):
+        self.assertEqual(
+            _extract_options({"style_strength": "not a number"})["style_strength"], 0.5
+        )
+
+    def test_style_strength_none_defaults_to_half(self):
+        self.assertEqual(
+            _extract_options({"style_strength": None})["style_strength"], 0.5
+        )
+
+    def test_boolean_coercion_accepts_true_false_strings(self):
+        opts = _extract_options(
+            {
+                "generate_keywords": "false",
+                "generate_caption": "FALSE",
+                "submit_keywords": "True",
+                "submit_folder_names": "TRUE",
+            }
+        )
+        self.assertFalse(opts["generate_keywords"])
+        self.assertFalse(opts["generate_caption"])
+        self.assertTrue(opts["submit_keywords"])
+        self.assertTrue(opts["submit_folder_names"])
+
+    def test_boolean_coercion_unrecognized_string_is_false(self):
+        # Anything that isn't lowercased "true" coerces to False
+        opts = _extract_options({"generate_keywords": "yes"})
+        self.assertFalse(opts["generate_keywords"])
+
+    def test_existing_keywords_raw_csv_string_dropped_to_none(self):
+        # Pin current behavior: a raw CSV string is fed through json.loads
+        # first; since "Alpha,Beta" isn't valid JSON, it falls back to None
+        # and existing_keywords becomes None. Likely a latent bug — the
+        # in-source comment claims CSVs are normalized to a list.
+        opts = _extract_options({"existing_keywords": "Alpha,Beta,Gamma"})
+        self.assertIsNone(opts["existing_keywords"])
+
+    def test_existing_keywords_json_quoted_csv_string_split(self):
+        # When the client JSON-encodes a CSV string, the inner string is
+        # split on commas into a list.
+        opts = _extract_options({"existing_keywords": '"  Alpha , Beta,  ,Gamma "'})
+        self.assertEqual(opts["existing_keywords"], ["Alpha", "Beta", "Gamma"])
+
+    def test_existing_keywords_list_input(self):
+        opts = _extract_options({"existing_keywords": ["Alpha", "  Beta  ", ""]})
+        self.assertEqual(opts["existing_keywords"], ["Alpha", "Beta"])
+
+    def test_existing_keywords_json_string_list(self):
+        # _parse_json_field will parse the JSON string into a list
+        opts = _extract_options({"existing_keywords": '["Alpha", "Beta"]'})
+        self.assertEqual(opts["existing_keywords"], ["Alpha", "Beta"])
+
+    def test_existing_keywords_missing_yields_none(self):
+        self.assertIsNone(_extract_options({})["existing_keywords"])
+
+    def test_regenerate_metadata_camelcase_supported(self):
+        opts = _extract_options({"regenerateMetadata": "false"})
+        self.assertFalse(opts["regenerate_metadata"])
+
+    def test_regenerate_metadata_snake_case_takes_precedence(self):
+        opts = _extract_options(
+            {"regenerate_metadata": "false", "regenerateMetadata": "true"}
+        )
+        self.assertFalse(opts["regenerate_metadata"])
+
+    def test_regenerate_metadata_default_true(self):
+        self.assertTrue(_extract_options({})["regenerate_metadata"])
+
+    def test_keyword_secondary_language_empty_becomes_none(self):
+        # Empty string `or None` evaluates to None
+        self.assertIsNone(
+            _extract_options({"keyword_secondary_language": ""})[
+                "keyword_secondary_language"
+            ]
+        )
+
+    def test_temperature_float_coerced(self):
+        opts = _extract_options({"temperature": "0.7"})
+        self.assertEqual(opts["temperature"], 0.7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test/test_safe_unit_interval.py
+++ b/server/test/test_safe_unit_interval.py
@@ -1,0 +1,44 @@
+import unittest
+
+from service_index import _safe_unit_interval
+
+
+class SafeUnitIntervalTests(unittest.TestCase):
+    def test_in_range_returned_unchanged(self):
+        self.assertEqual(_safe_unit_interval(0.0), 0.0)
+        self.assertEqual(_safe_unit_interval(0.5), 0.5)
+        self.assertEqual(_safe_unit_interval(1.0), 1.0)
+
+    def test_below_zero_clamped_up(self):
+        self.assertEqual(_safe_unit_interval(-0.1), 0.0)
+        self.assertEqual(_safe_unit_interval(-100.0), 0.0)
+
+    def test_above_one_clamped_down(self):
+        self.assertEqual(_safe_unit_interval(1.1), 1.0)
+        self.assertEqual(_safe_unit_interval(99.9), 1.0)
+
+    def test_int_coerced_to_float(self):
+        result = _safe_unit_interval(0)
+        self.assertEqual(result, 0.0)
+        self.assertIsInstance(result, float)
+
+    def test_string_numeric_coerced(self):
+        # float() accepts numeric strings; pin this behavior
+        self.assertEqual(_safe_unit_interval("0.5"), 0.5)
+
+    def test_nan_clamps_to_one(self):
+        # NaN comparisons in min/max are order-dependent in Python: with the
+        # current implementation `max(0.0, min(1.0, nan))` returns 1.0 because
+        # `nan < 1.0` is False, so min keeps 1.0, and max(0.0, 1.0) is 1.0.
+        # Pin this behavior so a refactor to short-circuit NaN is intentional.
+        self.assertEqual(_safe_unit_interval(float("nan")), 1.0)
+
+    def test_non_numeric_raises(self):
+        with self.assertRaises((TypeError, ValueError)):
+            _safe_unit_interval("not a number")
+        with self.assertRaises(TypeError):
+            _safe_unit_interval(None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test/test_service_metadata.py
+++ b/server/test/test_service_metadata.py
@@ -1,0 +1,209 @@
+import io
+
+import pytest
+from PIL import Image
+
+from llm_provider_base import MetadataGenerationResponse
+
+
+def _jpeg_bytes(color=(120, 0, 0)):
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="JPEG", quality=80)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def stub_providers(mocker):
+    """Replace the four provider classes with mocks before AnalysisService is built."""
+    for name in (
+        "OllamaProvider",
+        "LMStudioProvider",
+        "ChatGPTProvider",
+        "GeminiProvider",
+    ):
+        mock_cls = mocker.MagicMock(name=name)
+        mock_instance = mock_cls.return_value
+        mock_instance.is_available.return_value = True
+        mock_instance.list_available_models.return_value = []
+        mock_instance.generate_metadata.return_value = MetadataGenerationResponse(
+            uuid="stub", success=True, keywords={}, caption=None
+        )
+        mocker.patch(f"service_metadata.{name}", mock_cls)
+    yield
+
+
+@pytest.fixture
+def service(stub_providers):
+    # Import AFTER providers are stubbed so __init__ uses the mocks.
+    from service_metadata import AnalysisService
+
+    return AnalysisService(lazy_load=True)
+
+
+def test_constructor_registers_all_providers(service):
+    assert set(service.providers.keys()) == {"ollama", "lmstudio", "chatgpt", "gemini"}
+    for name in ("ollama", "lmstudio", "chatgpt", "gemini"):
+        assert service.provider_status[name] == "available"
+
+
+def test_constructor_marks_failing_provider_as_failed(mocker):
+    mocker.patch(
+        "service_metadata.OllamaProvider", side_effect=RuntimeError("ollama dead")
+    )
+    for name in ("LMStudioProvider", "ChatGPTProvider", "GeminiProvider"):
+        mock_cls = mocker.MagicMock()
+        mock_cls.return_value.is_available.return_value = True
+        mocker.patch(f"service_metadata.{name}", mock_cls)
+
+    from service_metadata import AnalysisService
+
+    svc = AnalysisService(lazy_load=True)
+    assert "ollama" not in svc.providers
+    assert svc.provider_status["ollama"] == "failed"
+    assert "ollama dead" in svc.provider_errors["ollama"]
+    # Other providers still register
+    assert {"lmstudio", "chatgpt", "gemini"}.issubset(svc.providers.keys())
+
+
+def test_analyze_batch_no_op_returns_none_pair(service):
+    # No images need anything → both outputs are None.
+    embeddings, metadata = service.analyze_batch(
+        image_triplets=[(_jpeg_bytes(), "uuid-1", "")],
+        options={},
+        image_model=None,
+        image_processor=None,
+        uuids_needing_embeddings=[],
+        uuids_needing_metadata=[],
+    )
+    assert embeddings is None
+    assert metadata is None
+
+
+def test_analyze_batch_accepts_list_for_uuids_needing(service):
+    # Regression test for the set-coercion change: callers pass lists, the
+    # function coerces them to sets internally.
+    triplets = [(_jpeg_bytes(), "uuid-1", ""), (_jpeg_bytes(), "uuid-2", "")]
+    # Pass lists of uuids that don't intersect with the batch → no work runs.
+    embeddings, metadata = service.analyze_batch(
+        image_triplets=triplets,
+        options={},
+        image_model=None,
+        image_processor=None,
+        uuids_needing_embeddings=["nonexistent-1", "nonexistent-2"],
+        uuids_needing_metadata=["nonexistent-3"],
+    )
+    # Both lists are non-empty so the inner branches execute, but no triplet
+    # uuid intersects, so the outputs are all-None.
+    assert embeddings == [None, None]
+    assert metadata == [None, None]
+
+
+def test_analyze_batch_accepts_set_for_uuids_needing(service):
+    triplets = [(_jpeg_bytes(), "uuid-1", "")]
+    embeddings, metadata = service.analyze_batch(
+        image_triplets=triplets,
+        options={},
+        image_model=None,
+        image_processor=None,
+        uuids_needing_embeddings={"nonexistent"},
+        uuids_needing_metadata={"nonexistent"},
+    )
+    assert embeddings == [None]
+    assert metadata == [None]
+
+
+def test_analyze_batch_default_compute_embeddings_true(service):
+    # When uuids_needing_embeddings is None, options['compute_embeddings']
+    # defaults to True → all uuids get embeddings (but image_model is None,
+    # so they'll be None, which is what we want to verify).
+    triplets = [(_jpeg_bytes(), "uuid-1", "")]
+    embeddings, metadata = service.analyze_batch(
+        image_triplets=triplets,
+        options={"compute_embeddings": False, "compute_metadata": False},
+        image_model=None,
+        image_processor=None,
+    )
+    assert embeddings is None
+    assert metadata is None
+
+
+def test_generate_metadata_single_falls_back_to_first_provider(service):
+    # Request a provider that isn't registered → falls back to the first one.
+    response = service.generate_metadata_single(
+        "uuid-x",
+        _jpeg_bytes(),
+        {
+            "provider": "doesnotexist",
+            "model": "any",
+            "generate_keywords": True,
+            "generate_caption": False,
+            "generate_title": False,
+            "generate_alt_text": False,
+            "language": "en",
+            "temperature": 0.2,
+            "submit_keywords": False,
+            "submit_folder_names": False,
+        },
+    )
+    assert response.success is True
+    # warning_msg about fallback should be set
+    assert response.warning is not None
+    assert "fallback" in response.warning.lower()
+
+
+def test_generate_metadata_single_no_providers_available(mocker):
+    # Make every provider class blow up so none register
+    for name in (
+        "OllamaProvider",
+        "LMStudioProvider",
+        "ChatGPTProvider",
+        "GeminiProvider",
+    ):
+        mocker.patch(f"service_metadata.{name}", side_effect=RuntimeError("nope"))
+
+    from service_metadata import AnalysisService
+
+    svc = AnalysisService(lazy_load=True)
+    assert svc.providers == {}
+
+    resp = svc.generate_metadata_single(
+        "uuid-x",
+        _jpeg_bytes(),
+        {
+            "model": "any",
+            "generate_keywords": True,
+            "generate_caption": False,
+            "generate_title": False,
+            "generate_alt_text": False,
+            "language": "en",
+            "temperature": 0.2,
+            "submit_keywords": False,
+            "submit_folder_names": False,
+        },
+    )
+    assert resp.success is False
+    assert "No LLM providers available" in resp.error
+
+
+def test_generate_metadata_single_provider_exception_caught(service):
+    # Make the (stubbed) ollama provider blow up mid-call
+    service.providers["ollama"].generate_metadata.side_effect = RuntimeError("boom")
+
+    resp = service.generate_metadata_single(
+        "uuid-x",
+        _jpeg_bytes(),
+        {
+            "provider": "ollama",
+            "model": "any",
+            "generate_keywords": True,
+            "generate_caption": False,
+            "generate_title": False,
+            "generate_alt_text": False,
+            "language": "en",
+            "temperature": 0.2,
+            "submit_keywords": False,
+            "submit_folder_names": False,
+        },
+    )
+    assert resp.success is False
+    assert "boom" in resp.error


### PR DESCRIPTION
Adds 8 test files (102 tests) for code paths that previously had no direct coverage:

- _flatten_keywords (service_index): list/dict/str inputs, nested dicts, structured {name, synonyms} objects, dedup
- _normalize_keywords_structure / _normalize_keyword_leaf (llm_provider_base): recursive walker with malformed-input edge cases
- _image_to_base64: JPEG fast-path vs PNG re-encode
- _safe_unit_interval: clamp behavior incl. NaN
- AnalysisService.analyze_batch: set coercion regression test for the recent list->set perf change; provider fallback and exception isolation
- _extract_options (routes_index): JSON parsing, style_strength clamping, bool coercion, snake_case/camelCase regenerate_metadata
- Ollama/LMStudio generate_metadata: dict vs JSON-string parsing, malformed/empty content, token-usage extraction
- is_available fast paths: SDK-missing, malformed-host short-circuit

Also pins two latent quirks worth flagging:
- _flatten_keywords emits synonyms even when name is missing/invalid
- _extract_options drops raw CSV existing_keywords (only json-quoted CSV triggers the documented split path)

Existing 42 tests still pass; total now 144.