### PR TITLE
Add comprehensive unit tests for Python backend and Lua plugin

### DIFF
--- a/plugin/spec/util_advanced_spec.lua
+++ b/plugin/spec/util_advanced_spec.lua
@@ -1,0 +1,644 @@
+-- Advanced unit tests for pure-logic helpers in Util.lua.
+--
+-- Covers: dumpTable, extractAllKeywords, buildHierarchyFromPaths,
+-- keywordTableToHierarchyStringList, keywordTableToStringList,
+-- and nilOrEmpty (additional cases).
+--
+-- Run from the repo root with:  busted
+
+local Util = require("Util")
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+--- Split a semicolon-separated string into a sorted list of non-empty parts.
+-- Order-insensitive assertions are made by sorting the result.
+local function splitSemicolon(s)
+	local parts = {}
+	for part in s:gmatch("([^;]+)") do
+		table.insert(parts, part)
+	end
+	table.sort(parts)
+	return parts
+end
+
+--- Collect all keyword *names* from (vals, orderedIds) into a sorted list.
+local function sortedNames(vals, ids)
+	local names = {}
+	for _, id in ipairs(ids) do
+		names[#names + 1] = vals[id]
+	end
+	table.sort(names)
+	return names
+end
+
+-- ---------------------------------------------------------------------------
+-- Util.dumpTable
+-- ---------------------------------------------------------------------------
+
+describe("Util.dumpTable", function()
+	it("returns '{}' for an empty table", function()
+		assert.are.equal("{}", Util.dumpTable({}))
+	end)
+
+	it("serialises a simple array and contains all entries", function()
+		local s = Util.dumpTable({ "alpha", "beta", "gamma" })
+		assert.truthy(s:find("alpha", 1, true))
+		assert.truthy(s:find("beta", 1, true))
+		assert.truthy(s:find("gamma", 1, true))
+	end)
+
+	it("preserves array entry order", function()
+		local s = Util.dumpTable({ "first", "second", "third" })
+		local p1 = s:find("first", 1, true)
+		local p2 = s:find("second", 1, true)
+		local p3 = s:find("third", 1, true)
+		assert.truthy(p1)
+		assert.truthy(p2)
+		assert.truthy(p3)
+		assert.is_true(p1 < p2)
+		assert.is_true(p2 < p3)
+	end)
+
+	it("serialises a hash table, including key and value", function()
+		local s = Util.dumpTable({ fruit = "apple" })
+		assert.truthy(s:find("fruit", 1, true))
+		assert.truthy(s:find("apple", 1, true))
+	end)
+
+	it("serialises a nested table and includes nested keys and values", function()
+		local s = Util.dumpTable({ outer = { inner = "value" } })
+		assert.truthy(s:find("outer", 1, true))
+		assert.truthy(s:find("inner", 1, true))
+		assert.truthy(s:find("value", 1, true))
+	end)
+
+	it("handles a cyclic reference without infinite recursion", function()
+		local t = {}
+		t.self = t
+		-- Must not blow the stack; result must contain the cycle sentinel.
+		local ok, s = pcall(Util.dumpTable, t)
+		assert.is_true(ok)
+		-- The implementation emits "{ ...cycle... }"
+		assert.truthy(s:find("cycle", 1, true))
+	end)
+
+	it("redacts the api_key field value", function()
+		local s = Util.dumpTable({ api_key = "supersecret" })
+		-- The raw secret must not appear.
+		assert.is_nil(s:find("supersecret", 1, true))
+		-- The redaction marker must be present.
+		assert.truthy(s:find("<redacted>", 1, true))
+		-- The field name itself is still visible.
+		assert.truthy(s:find("api_key", 1, true))
+	end)
+
+	it("redacts the chatgptApiKey field value", function()
+		local s = Util.dumpTable({ chatgptApiKey = "sk-abc123" })
+		assert.is_nil(s:find("sk-abc123", 1, true))
+		assert.truthy(s:find("<redacted>", 1, true))
+	end)
+
+	it("redacts the geminiApiKey field value", function()
+		local s = Util.dumpTable({ geminiApiKey = "AIzaSy_fakekey" })
+		assert.is_nil(s:find("AIzaSy_fakekey", 1, true))
+		assert.truthy(s:find("<redacted>", 1, true))
+	end)
+
+	it("replaces a base64 payload in the 'data' field", function()
+		-- "SGVsbG8gV29ybGQ=" is base64("Hello World")
+		local s = Util.dumpTable({ data = "SGVsbG8gV29ybGQ=" })
+		assert.is_nil(s:find("SGVsbG8gV29ybGQ=", 1, true))
+		assert.truthy(s:find("base64 removed", 1, true))
+	end)
+
+	it("replaces a data-URI base64 value in the 'url' field", function()
+		local s = Util.dumpTable({ url = "data:image/jpeg;base64,/9j/4AAQSkZJRgAB==" })
+		assert.is_nil(s:find("/9j/4AAQSkZJRgAB==", 1, true))
+		assert.truthy(s:find("base64 removed", 1, true))
+	end)
+
+	it("does not redact unrelated fields", function()
+		local s = Util.dumpTable({ username = "alice", score = 42 })
+		assert.truthy(s:find("alice", 1, true))
+		assert.truthy(s:find("42", 1, true))
+	end)
+
+	it("renders boolean values as 'true' / 'false'", function()
+		local s = Util.dumpTable({ yes = true, no = false })
+		assert.truthy(s:find("true", 1, true))
+		assert.truthy(s:find("false", 1, true))
+	end)
+
+	it("renders number values", function()
+		local s = Util.dumpTable({ count = 99 })
+		assert.truthy(s:find("99", 1, true))
+	end)
+
+	-- Hash keys that are not valid Lua identifiers are wrapped in ["..."].
+	it("wraps non-identifier string keys in brackets", function()
+		local s = Util.dumpTable({ ["key-with-dash"] = "v" })
+		assert.truthy(s:find('["key-with-dash"]', 1, true))
+	end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- Util.nilOrEmpty — additional edge cases
+-- ---------------------------------------------------------------------------
+
+describe("Util.nilOrEmpty (additional cases)", function()
+	it("returns false for number 0", function()
+		assert.is_false(Util.nilOrEmpty(0))
+	end)
+
+	it("returns false for number 1", function()
+		assert.is_false(Util.nilOrEmpty(1))
+	end)
+
+	it("returns false for boolean false", function()
+		assert.is_false(Util.nilOrEmpty(false))
+	end)
+
+	it("returns false for boolean true", function()
+		assert.is_false(Util.nilOrEmpty(true))
+	end)
+
+	it("returns false for a non-empty table", function()
+		assert.is_false(Util.nilOrEmpty({ 1 }))
+	end)
+
+	it("returns false for an empty table (not nil, not a string)", function()
+		-- The implementation only returns true for nil or whitespace-only strings;
+		-- an empty table is neither.
+		assert.is_false(Util.nilOrEmpty({}))
+	end)
+
+	it("returns true for a string containing only tabs and newlines", function()
+		assert.is_true(Util.nilOrEmpty("\t\n  \t"))
+	end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- Util.extractAllKeywords
+-- ---------------------------------------------------------------------------
+
+describe("Util.extractAllKeywords", function()
+	it("returns three empty tables for nil input", function()
+		local vals, meta, ids = Util.extractAllKeywords(nil)
+		assert.are.same({}, vals)
+		assert.are.same({}, meta)
+		assert.are.same({}, ids)
+	end)
+
+	it("returns three empty tables for an empty table", function()
+		local vals, meta, ids = Util.extractAllKeywords({})
+		assert.are.same({}, vals)
+		assert.are.same({}, meta)
+		assert.are.same({}, ids)
+	end)
+
+	it("returns three empty tables for a non-table (string) argument", function()
+		local vals, meta, ids = Util.extractAllKeywords("not a table")
+		assert.are.same({}, vals)
+		assert.are.same({}, meta)
+		assert.are.same({}, ids)
+	end)
+
+	it("extracts a flat array of string keywords", function()
+		local vals, _, ids = Util.extractAllKeywords({ "Cat", "Dog" })
+		assert.are.equal(2, #ids)
+		assert.are.same({ "Cat", "Dog" }, sortedNames(vals, ids))
+	end)
+
+	it("assigns sequential IDs in the kw_N pattern", function()
+		local _, _, ids = Util.extractAllKeywords({ "Alpha", "Beta" })
+		assert.are.equal(2, #ids)
+		assert.are.equal("kw_1", ids[1])
+		assert.are.equal("kw_2", ids[2])
+	end)
+
+	it("extracts keywords nested under a string category key", function()
+		local vals, meta, ids = Util.extractAllKeywords({ Animals = { "Cat", "Dog" } })
+		assert.are.equal(2, #ids)
+		assert.are.same({ "Cat", "Dog" }, sortedNames(vals, ids))
+		-- Each keyword's meta path must reference the parent category.
+		for _, id in ipairs(ids) do
+			assert.truthy(meta[id].path:find("Animals", 1, true))
+		end
+	end)
+
+	it("records the full path for a deeply nested keyword", function()
+		local _, meta, ids = Util.extractAllKeywords({ Animals = { Birds = { "Owl" } } })
+		assert.are.equal(1, #ids)
+		local path = meta[ids[1]].path
+		assert.truthy(path:find("Animals", 1, true))
+		assert.truthy(path:find("Birds", 1, true))
+	end)
+
+	it("extracts a leaf object with name and captures synonyms in meta", function()
+		local leaf = { name = "Cat", synonyms = { "Kitty", "Kitten" } }
+		local vals, meta, ids = Util.extractAllKeywords({ leaf })
+		assert.are.equal(1, #ids)
+		local id = ids[1]
+		assert.are.equal("Cat", vals[id])
+		assert.are.same({ "Kitty", "Kitten" }, meta[id].synonyms)
+	end)
+
+	it("extracts a leaf object that has only a name (no synonyms)", function()
+		local vals, meta, ids = Util.extractAllKeywords({ { name = "Dog" } })
+		assert.are.equal(1, #ids)
+		local id = ids[1]
+		assert.are.equal("Dog", vals[id])
+		assert.are.same({}, meta[id].synonyms)
+	end)
+
+	it("deduplicates the same keyword name under the same path", function()
+		-- Both array entries resolve to the same (name="Rose", path="") pair.
+		local _, _, ids = Util.extractAllKeywords({ "Rose", "Rose" })
+		assert.are.equal(1, #ids)
+	end)
+
+	it("does NOT deduplicate the same keyword name under different paths", function()
+		-- "Rose" under "Flowers" and "Plants" are distinct dedupe keys.
+		local _, _, ids = Util.extractAllKeywords({
+			Flowers = { "Rose" },
+			Plants = { "Rose" },
+		})
+		assert.are.equal(2, #ids)
+	end)
+
+	it("skips empty string keywords", function()
+		local _, _, ids = Util.extractAllKeywords({ "", "  ", "Valid" })
+		assert.are.equal(1, #ids)
+	end)
+
+	it("skips leaf objects with an empty or whitespace-only name", function()
+		local _, _, ids = Util.extractAllKeywords({ { name = "  " } })
+		assert.are.equal(0, #ids)
+	end)
+
+	it("trims whitespace from keyword names", function()
+		local vals, _, ids = Util.extractAllKeywords({ "  Trimmed  " })
+		assert.are.equal(1, #ids)
+		assert.are.equal("Trimmed", vals[ids[1]])
+	end)
+
+	it("returns an empty synonyms list in meta for a plain string leaf", function()
+		local _, meta, ids = Util.extractAllKeywords({ "PlainWord" })
+		assert.are.equal(1, #ids)
+		assert.are.same({}, meta[ids[1]].synonyms)
+	end)
+
+	it("each meta entry contains synonyms, aliases, and synonymAliases fields", function()
+		local _, meta, ids = Util.extractAllKeywords({ "Item" })
+		local m = meta[ids[1]]
+		assert.is_not_nil(m.synonyms)
+		assert.is_not_nil(m.aliases)
+		assert.is_not_nil(m.synonymAliases)
+	end)
+
+	it("sets path to empty string for a top-level flat keyword", function()
+		local _, meta, ids = Util.extractAllKeywords({ "Solo" })
+		assert.are.equal(1, #ids)
+		assert.are.equal("", meta[ids[1]].path)
+	end)
+
+	it("handles multiple categories at the same level independently", function()
+		local vals, _, ids = Util.extractAllKeywords({
+			Fruit = { "Apple" },
+			Vegetable = { "Carrot" },
+		})
+		assert.are.equal(2, #ids)
+		assert.are.same({ "Apple", "Carrot" }, sortedNames(vals, ids))
+	end)
+
+	it("synonym is not duplicated in the synonyms list itself", function()
+		-- The name and a synonym clash; the implementation strips the duplicate.
+		local leaf = { name = "Cat", synonyms = { "Cat", "Kitty" } }
+		local _, meta, ids = Util.extractAllKeywords({ leaf })
+		assert.are.equal(1, #ids)
+		-- "Cat" as a synonym would collide with the name and should be removed.
+		local syns = meta[ids[1]].synonyms
+		for _, s in ipairs(syns) do
+			assert.are_not.equal("Cat", s)
+		end
+	end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- Util.buildHierarchyFromPaths
+-- ---------------------------------------------------------------------------
+
+describe("Util.buildHierarchyFromPaths", function()
+	it("returns an empty table for an empty input list", function()
+		assert.are.same({}, Util.buildHierarchyFromPaths({}))
+	end)
+
+	it("inserts a single flat keyword (no '>') into the root as an array entry", function()
+		local result = Util.buildHierarchyFromPaths({ { path = "Rose" } })
+		assert.are.equal(1, #result)
+		assert.are.equal("Rose", result[1])
+	end)
+
+	it("builds a two-level nested hierarchy from 'Animals > Dog'", function()
+		local result = Util.buildHierarchyFromPaths({ { path = "Animals > Dog" } })
+		assert.is_not_nil(result.Animals)
+		assert.are.equal(1, #result.Animals)
+		assert.are.equal("Dog", result.Animals[1])
+	end)
+
+	it("builds a three-level nested hierarchy from 'Animals > Birds > Owl'", function()
+		local result = Util.buildHierarchyFromPaths({ { path = "Animals > Birds > Owl" } })
+		assert.is_not_nil(result.Animals)
+		assert.is_not_nil(result.Animals.Birds)
+		local found = false
+		for _, v in ipairs(result.Animals.Birds) do
+			if v == "Owl" then found = true end
+		end
+		assert.is_true(found)
+	end)
+
+	it("stores a plain string leaf when no synonyms or aliases are present", function()
+		local result = Util.buildHierarchyFromPaths({ { path = "Dog" } })
+		assert.are.equal("Dog", result[1])
+		assert.are.equal("string", type(result[1]))
+	end)
+
+	it("stores a name-object when synonyms are provided", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "Cat", synonyms = { "Kitty", "Feline" } },
+		})
+		assert.are.equal(1, #result)
+		local leaf = result[1]
+		assert.are.equal("table", type(leaf))
+		assert.are.equal("Cat", leaf.name)
+		assert.are.same({ "Kitty", "Feline" }, leaf.synonyms)
+	end)
+
+	it("stores a name-object when only aliases are provided", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "Wolf", aliases = { "Grey Wolf" } },
+		})
+		assert.are.equal(1, #result)
+		local leaf = result[1]
+		assert.are.equal("table", type(leaf))
+		assert.are.equal("Wolf", leaf.name)
+		assert.are.same({ "Grey Wolf" }, leaf.aliases)
+	end)
+
+	it("stores a name-object when only synonymAliases are provided", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "Fox", synonymAliases = { "Red Fox" } },
+		})
+		assert.are.equal(1, #result)
+		local leaf = result[1]
+		assert.are.equal("table", type(leaf))
+		assert.are.equal("Fox", leaf.name)
+		assert.are.same({ "Red Fox" }, leaf.synonym_aliases)
+	end)
+
+	it("shares the same parent table for multiple paths under the same parent", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "Fruit > Apple" },
+			{ path = "Fruit > Banana" },
+		})
+		assert.is_not_nil(result.Fruit)
+		assert.are.equal(2, #result.Fruit)
+		local leaves = { result.Fruit[1], result.Fruit[2] }
+		table.sort(leaves)
+		assert.are.same({ "Apple", "Banana" }, leaves)
+	end)
+
+	it("creates distinct root keys for independent top-level paths", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "Plants > Rose" },
+			{ path = "Animals > Wolf" },
+		})
+		assert.is_not_nil(result.Plants)
+		assert.is_not_nil(result.Animals)
+		assert.are.equal("Rose", result.Plants[1])
+		assert.are.equal("Wolf", result.Animals[1])
+	end)
+
+	it("trims whitespace from all path segments", function()
+		local result = Util.buildHierarchyFromPaths({ { path = "  Food  >  Fruit  >  Apple  " } })
+		assert.is_not_nil(result.Food)
+		assert.is_not_nil(result.Food.Fruit)
+		assert.are.equal("Apple", result.Food.Fruit[1])
+	end)
+
+	it("skips items with a path that contains only whitespace leaf segments", function()
+		-- After trimming each part yields "", so the leaf is skipped.
+		local result = Util.buildHierarchyFromPaths({ { path = "   >   " } })
+		-- The root should be empty (the empty category segment is skipped as well).
+		assert.are.equal(0, Util.table_size(result))
+	end)
+
+	it("sets synonym_aliases on a leaf node when synonymAliases are provided", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "Tags > Vintage", synonymAliases = { "retro", "old-school" } },
+		})
+		local leaf = result.Tags[1]
+		assert.are.equal("table", type(leaf))
+		assert.are.equal("Vintage", leaf.name)
+		assert.are.same({ "retro", "old-school" }, leaf.synonym_aliases)
+	end)
+
+	it("accumulates multiple paths under a shared three-level ancestor", function()
+		local result = Util.buildHierarchyFromPaths({
+			{ path = "World > Europe > France" },
+			{ path = "World > Europe > Germany" },
+		})
+		assert.is_not_nil(result.World)
+		assert.is_not_nil(result.World.Europe)
+		assert.are.equal(2, #result.World.Europe)
+		local leaves = { result.World.Europe[1], result.World.Europe[2] }
+		table.sort(leaves)
+		assert.are.same({ "France", "Germany" }, leaves)
+	end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- Util.keywordTableToHierarchyStringList
+-- ---------------------------------------------------------------------------
+
+describe("Util.keywordTableToHierarchyStringList", function()
+	it("returns an empty string for an empty table", function()
+		assert.are.equal("", Util.keywordTableToHierarchyStringList({}))
+	end)
+
+	it("produces 'Category>Leaf' for a single one-level nested entry", function()
+		local result = Util.keywordTableToHierarchyStringList({ Category = { "Leaf" } })
+		assert.truthy(result:find("Category>Leaf", 1, true))
+	end)
+
+	it("produces 'A>B>C' for a two-level nested entry", function()
+		local result = Util.keywordTableToHierarchyStringList({ A = { B = { "C" } } })
+		assert.truthy(result:find("A>B>C", 1, true))
+	end)
+
+	it("produces a three-level path for a three-level nesting", function()
+		local result = Util.keywordTableToHierarchyStringList({
+			World = { Europe = { Germany = { "Berlin" } } },
+		})
+		assert.truthy(result:find("World>Europe>Germany>Berlin", 1, true))
+	end)
+
+	it("separates multiple paths with semicolons", function()
+		local result = Util.keywordTableToHierarchyStringList({ Animals = { "Cat", "Dog" } })
+		local parts = splitSemicolon(result)
+		local hasCat, hasDog = false, false
+		for _, p in ipairs(parts) do
+			if p:find("Cat", 1, true) then hasCat = true end
+			if p:find("Dog", 1, true) then hasDog = true end
+		end
+		assert.is_true(hasCat)
+		assert.is_true(hasDog)
+	end)
+
+	it("produces exactly two entries for two leaves under one parent", function()
+		local result = Util.keywordTableToHierarchyStringList({ Nature = { "Tree", "River" } })
+		local parts = splitSemicolon(result)
+		assert.are.equal(2, #parts)
+	end)
+
+	it("handles multiple independent top-level categories", function()
+		local result = Util.keywordTableToHierarchyStringList({
+			Fruit = { "Apple" },
+			Vegetable = { "Carrot" },
+		})
+		local parts = splitSemicolon(result)
+		assert.are.equal(2, #parts)
+		local paths = {}
+		for _, p in ipairs(parts) do paths[p] = true end
+		assert.is_true(paths["Fruit>Apple"])
+		assert.is_true(paths["Vegetable>Carrot"])
+	end)
+
+	it("treats a string value with a string key as parent>key>value", function()
+		-- When v is a string and k is a string, the code emits path>k>v.
+		-- With path={} (top level), concat gives "" so result is ">Color>Blue".
+		local result = Util.keywordTableToHierarchyStringList({ Color = "Blue" })
+		assert.truthy(result:find("Color", 1, true))
+		assert.truthy(result:find("Blue", 1, true))
+	end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- Util.keywordTableToStringList
+-- ---------------------------------------------------------------------------
+
+describe("Util.keywordTableToStringList", function()
+	it("returns an empty string for an empty table", function()
+		assert.are.equal("", Util.keywordTableToStringList({}))
+	end)
+
+	it("extracts leaf strings from a one-level nested table", function()
+		local result = Util.keywordTableToStringList({ Animals = { "Cat", "Dog" } })
+		local parts = splitSemicolon(result)
+		assert.are.equal(2, #parts)
+		local have = {}
+		for _, p in ipairs(parts) do have[p] = true end
+		assert.is_true(have["Cat"])
+		assert.is_true(have["Dog"])
+	end)
+
+	it("extracts leaf strings from a deeply nested table", function()
+		local result = Util.keywordTableToStringList({ A = { B = { "Deep" } } })
+		assert.truthy(result:find("Deep", 1, true))
+	end)
+
+	it("collects leaves from multiple independent top-level categories", function()
+		local result = Util.keywordTableToStringList({
+			Fruit = { "Mango" },
+			Veg = { "Pea" },
+		})
+		local parts = splitSemicolon(result)
+		assert.are.equal(2, #parts)
+		local have = {}
+		for _, p in ipairs(parts) do have[p] = true end
+		assert.is_true(have["Mango"])
+		assert.is_true(have["Pea"])
+	end)
+
+	it("does not include intermediate category keys in the output", function()
+		local result = Util.keywordTableToStringList({ Animals = { "Cat" } })
+		-- "Animals" is a category, not a leaf — it must not appear in the output.
+		assert.is_nil(result:find("Animals", 1, true))
+	end)
+
+	it("result contains no hierarchy separator '>'", function()
+		local result = Util.keywordTableToStringList({ X = { "Foo", "Bar" } })
+		assert.is_nil(result:find(">", 1, true))
+	end)
+
+	it("handles a flat top-level array of strings", function()
+		local result = Util.keywordTableToStringList({ "Apple", "Banana", "Cherry" })
+		local parts = splitSemicolon(result)
+		assert.are.equal(3, #parts)
+		local have = {}
+		for _, p in ipairs(parts) do have[p] = true end
+		assert.is_true(have["Apple"])
+		assert.is_true(have["Banana"])
+		assert.is_true(have["Cherry"])
+	end)
+
+	it("returns a plain string with no trailing semicolon for a single leaf", function()
+		local result = Util.keywordTableToStringList({ "OnlyOne" })
+		assert.is_nil(result:match(";$"))
+		assert.are.equal("OnlyOne", result)
+	end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- Util.formatTimestampSafe — string-transformation logic.
+--
+-- The function body is:
+--   timestamp = timestamp or LrDate.currentTime()
+--   local w3c = LrDate.timeToW3CDate(timestamp)
+--   return w3c:gsub("T", "_"):gsub(":", "-"):sub(1, 19)
+--
+-- In the headless test environment LrDate is a stub whose methods return a
+-- noop function — not a string — so calling Util.formatTimestampSafe()
+-- directly would crash on :gsub.  We therefore test the string-transformation
+-- rule directly by mirroring the exact three operations from the source.
+-- ---------------------------------------------------------------------------
+
+describe("Util.formatTimestampSafe (string transform rule)", function()
+	-- Mirror of the production transform.
+	local function applyTransform(w3c)
+		return w3c:gsub("T", "_"):gsub(":", "-"):sub(1, 19)
+	end
+
+	it("replaces the 'T' separator with '_'", function()
+		local result = applyTransform("2024-05-15T10:30:00Z")
+		assert.is_nil(result:find("T", 1, true))
+		assert.truthy(result:find("_", 1, true))
+	end)
+
+	it("replaces ':' colons in the time portion with '-'", function()
+		local result = applyTransform("2024-05-15T10:30:00Z")
+		assert.is_nil(result:find(":", 1, true))
+	end)
+
+	it("truncates to exactly 19 characters", function()
+		local result = applyTransform("2024-05-15T10:30:00Z")
+		assert.are.equal(19, #result)
+	end)
+
+	it("produces the expected filesystem-safe string for a known input", function()
+		local result = applyTransform("2024-05-15T10:30:00Z")
+		assert.are.equal("2024-05-15_10-30-00", result)
+	end)
+
+	it("handles midnight correctly", function()
+		local result = applyTransform("2000-01-01T00:00:00Z")
+		assert.are.equal("2000-01-01_00-00-00", result)
+	end)
+
+	it("handles end-of-day time correctly", function()
+		local result = applyTransform("1999-12-31T23:59:59Z")
+		assert.are.equal("1999-12-31_23-59-59", result)
+	end)
+end)

--- a/server/test/test_routes_edit_helpers.py
+++ b/server/test/test_routes_edit_helpers.py
@@ -1,0 +1,75 @@
+"""Tests for the pure helper functions in routes/edit.py."""
+
+from routes.edit import _has_items, _success_payload
+
+
+class TestHasItems:
+    def test_none_returns_false(self):
+        assert _has_items(None) is False
+
+    def test_empty_list_returns_false(self):
+        assert _has_items([]) is False
+
+    def test_non_empty_list_returns_true(self):
+        assert _has_items([1, 2]) is True
+
+    def test_empty_dict_returns_false(self):
+        assert _has_items({}) is False
+
+    def test_non_empty_dict_returns_true(self):
+        assert _has_items({"a": 1}) is True
+
+    def test_object_without_len_returns_false(self):
+        # Objects that raise TypeError on len() → False
+        assert _has_items(object()) is False
+
+    def test_string_with_content_returns_true(self):
+        assert _has_items("abc") is True
+
+    def test_empty_string_returns_false(self):
+        assert _has_items("") is False
+
+
+class TestSuccessPayload:
+    def _make_recipe(self, **extra):
+        base = {"summary": "Boost exposure", "warnings": ["minor clipping"]}
+        base.update(extra)
+        return base
+
+    def test_contains_required_fields(self):
+        recipe = self._make_recipe()
+        options = {"model": "gpt-4o", "provider": "chatgpt"}
+        payload = _success_payload("photo_123", recipe, options)
+
+        assert payload["status"] == "success"
+        assert payload["photo_id"] == "photo_123"
+        assert payload["uuid"] == "photo_123"
+        assert payload["edit"] is recipe
+        assert payload["edit_summary"] == "Boost exposure"
+        assert payload["edit_warnings"] == ["minor clipping"]
+        assert payload["edit_model"] == "gpt-4o"
+
+    def test_warning_included_when_provided(self):
+        recipe = self._make_recipe()
+        payload = _success_payload("p1", recipe, {}, warning="model degraded")
+        assert payload["warning"] == "model degraded"
+
+    def test_no_warning_key_when_not_provided(self):
+        recipe = self._make_recipe()
+        payload = _success_payload("p1", recipe, {})
+        assert "warning" not in payload
+
+    def test_edit_rundate_is_present(self):
+        payload = _success_payload("p1", self._make_recipe(), {})
+        assert "edit_rundate" in payload
+        assert payload["edit_rundate"] != ""
+
+    def test_missing_summary_defaults_to_empty(self):
+        recipe = {"warnings": []}
+        payload = _success_payload("p1", recipe, {})
+        assert payload["edit_summary"] == ""
+
+    def test_missing_warnings_defaults_to_empty(self):
+        recipe = {"summary": "ok"}
+        payload = _success_payload("p1", recipe, {})
+        assert payload["edit_warnings"] == []

--- a/server/test/test_routes_faces.py
+++ b/server/test/test_routes_faces.py
@@ -1,0 +1,267 @@
+"""Tests for routes/faces.py — covers all face and person endpoints."""
+
+import base64
+import pytest
+
+from geniusai_server import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _b64(data: bytes = b"fakeimage") -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# /faces/detect
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFaces:
+    def test_missing_body_returns_400(self, client):
+        response = client.post("/faces/detect", json={})
+        assert response.status_code == 400
+        assert "image" in response.get_json()["error"]
+
+    def test_invalid_base64_returns_400(self, client):
+        response = client.post("/faces/detect", json={"image": "not-valid-base64!!!"})
+        assert response.status_code == 400
+        assert "base64" in response.get_json()["error"].lower()
+
+    def test_no_faces_detected_returns_empty_list(self, client, mocker):
+        mocker.patch("routes.faces.face_service.detect_faces", return_value=[])
+        response = client.post("/faces/detect", json={"image": _b64()})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert data["faces"] == []
+
+    def test_faces_detected_returns_thumbnails(self, client, mocker):
+        mocker.patch(
+            "routes.faces.face_service.detect_faces",
+            return_value=[
+                {"thumbnail": "thumb0", "embedding": [0.1]},
+                {"thumbnail": "thumb1", "embedding": [0.2]},
+            ],
+        )
+        response = client.post("/faces/detect", json={"image": _b64()})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert len(data["faces"]) == 2
+        assert data["faces"][0]["index"] == 0
+        assert data["faces"][0]["thumbnail"] == "thumb0"
+        assert data["faces"][1]["index"] == 1
+
+    def test_detection_error_returns_500(self, client, mocker):
+        mocker.patch(
+            "routes.faces.face_service.detect_faces",
+            side_effect=RuntimeError("model unavailable"),
+        )
+        response = client.post("/faces/detect", json={"image": _b64()})
+        assert response.status_code == 500
+        assert "error" in response.get_json()
+
+
+# ---------------------------------------------------------------------------
+# /faces/query
+# ---------------------------------------------------------------------------
+
+
+class TestQueryFaces:
+    def test_missing_image_returns_400(self, client):
+        response = client.post("/faces/query", json={})
+        assert response.status_code == 400
+
+    def test_no_faces_in_image_returns_no_face(self, client, mocker):
+        mocker.patch("routes.faces.face_service.detect_faces", return_value=[])
+        response = client.post("/faces/query", json={"image": _b64()})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "no_face"
+        assert data["results"] == []
+
+    def test_out_of_bounds_face_index_returns_400(self, client, mocker):
+        mocker.patch(
+            "routes.faces.face_service.detect_faces",
+            return_value=[{"embedding": [0.1], "thumbnail": "t"}],
+        )
+        response = client.post("/faces/query", json={"image": _b64(), "face_index": 5})
+        assert response.status_code == 400
+        assert "face_index" in response.get_json()["error"]
+
+    def test_valid_query_returns_results(self, client, mocker):
+        mocker.patch(
+            "routes.faces.face_service.detect_faces",
+            return_value=[{"embedding": [0.1, 0.2], "thumbnail": "t"}],
+        )
+        mocker.patch(
+            "routes.faces.chroma_service.query_faces",
+            return_value={
+                "ids": [["face1", "face2"]],
+                "distances": [[0.1, 0.3]],
+                "metadatas": [
+                    [
+                        {"photo_id": "p1", "thumbnail": "tb1", "person_id": "person1"},
+                        {"photo_id": "p2", "thumbnail": "tb2", "person_id": "person2"},
+                    ]
+                ],
+            },
+        )
+        response = client.post("/faces/query", json={"image": _b64()})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert len(data["results"]) == 2
+        assert data["results"][0]["face_id"] == "face1"
+        assert data["results"][0]["photo_id"] == "p1"
+
+
+# ---------------------------------------------------------------------------
+# /faces/cluster
+# ---------------------------------------------------------------------------
+
+
+class TestClusterFaces:
+    def test_cluster_success(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.run_clustering",
+            return_value={"persons_created": 3, "faces_assigned": 12},
+        )
+        response = client.post("/faces/cluster", json={})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert data["persons_created"] == 3
+
+    def test_invalid_linkage_defaults_to_complete(self, client, mocker):
+        mock_cluster = mocker.patch(
+            "routes.faces.persons_service.run_clustering",
+            return_value={"persons_created": 0, "faces_assigned": 0},
+        )
+        client.post("/faces/cluster", json={"linkage": "invalid_value"})
+        call_kwargs = mock_cluster.call_args[1]
+        assert call_kwargs["linkage"] == "complete"
+
+    def test_cluster_exception_returns_500(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.run_clustering",
+            side_effect=RuntimeError("clustering failed"),
+        )
+        response = client.post("/faces/cluster", json={})
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /faces/persons
+# ---------------------------------------------------------------------------
+
+
+class TestListPersons:
+    def test_list_persons_success(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.list_persons",
+            return_value=[{"person_id": "p1", "name": "Alice", "face_count": 5}],
+        )
+        response = client.get("/faces/persons")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert len(data["persons"]) == 1
+        assert data["persons"][0]["name"] == "Alice"
+
+    def test_list_persons_exception_returns_500(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.list_persons",
+            side_effect=RuntimeError("db error"),
+        )
+        response = client.get("/faces/persons")
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /faces/persons/<person_id>/thumbnail
+# ---------------------------------------------------------------------------
+
+
+class TestGetPersonThumbnail:
+    def test_returns_thumbnail(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.get_person_thumbnail_b64",
+            return_value="base64thumb",
+        )
+        response = client.get("/faces/persons/person-123/thumbnail")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert data["person_id"] == "person-123"
+        assert data["thumbnail"] == "base64thumb"
+
+    def test_exception_returns_500(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.get_person_thumbnail_b64",
+            side_effect=RuntimeError("not found"),
+        )
+        response = client.get("/faces/persons/bad-id/thumbnail")
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# PUT /faces/persons/<person_id>
+# ---------------------------------------------------------------------------
+
+
+class TestSetPersonName:
+    def test_set_name_success(self, client, mocker):
+        mock_set = mocker.patch("routes.faces.persons_service.set_person_name")
+        response = client.put("/faces/persons/person-abc", json={"name": "  Bob  "})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert data["name"] == "Bob"
+        mock_set.assert_called_once_with("person-abc", "  Bob  ")
+
+    def test_non_string_name_coerced(self, client, mocker):
+        mocker.patch("routes.faces.persons_service.set_person_name")
+        response = client.put("/faces/persons/p1", json={"name": 42})
+        assert response.status_code == 200
+
+    def test_exception_returns_500(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.set_person_name",
+            side_effect=RuntimeError("write error"),
+        )
+        response = client.put("/faces/persons/p1", json={"name": "Alice"})
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /faces/persons/<person_id>/photos
+# ---------------------------------------------------------------------------
+
+
+class TestGetPhotosForPerson:
+    def test_returns_photo_ids(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.get_photo_ids_for_person",
+            return_value=["photo1", "photo2"],
+        )
+        response = client.get("/faces/persons/p1/photos")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "ok"
+        assert data["photo_ids"] == ["photo1", "photo2"]
+        assert data["photo_uuids"] == ["photo1", "photo2"]
+
+    def test_exception_returns_500(self, client, mocker):
+        mocker.patch(
+            "routes.faces.persons_service.get_photo_ids_for_person",
+            side_effect=RuntimeError("not found"),
+        )
+        response = client.get("/faces/persons/bad/photos")
+        assert response.status_code == 500

--- a/server/test/test_routes_search_helpers.py
+++ b/server/test/test_routes_search_helpers.py
@@ -1,0 +1,163 @@
+"""Tests for _parse_grouping_params in routes/search.py.
+
+Uses the real Flask app from geniusai_server (same pattern as test_routes_db.py)
+so that Blueprints are registered and route-level imports work correctly.
+"""
+
+import pytest
+
+from geniusai_server import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# Import the helper directly after the app is available.
+from routes.search import _parse_grouping_params  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_PHOTO_IDS = ["photo-1", "photo-2", "photo-3"]
+
+
+def _valid_data(**overrides):
+    base = {
+        "photo_ids": _VALID_PHOTO_IDS,
+        "phash_threshold": "auto",
+        "clip_threshold": "auto",
+        "time_delta_seconds": 2,
+        "culling_preset": "default",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Success paths
+# ---------------------------------------------------------------------------
+
+
+class TestParseGroupingParamsSuccess:
+    def test_valid_data_returns_params_dict(self):
+        params, err_resp, err_code = _parse_grouping_params(_valid_data())
+        assert err_resp is None
+        assert err_code is None
+        assert params["photo_ids"] == _VALID_PHOTO_IDS
+
+    def test_phash_threshold_auto_kept_as_string(self):
+        params, _, _ = _parse_grouping_params(_valid_data(phash_threshold="auto"))
+        assert params["phash_threshold"] == "auto"
+
+    def test_phash_threshold_numeric_string_parsed(self):
+        params, _, _ = _parse_grouping_params(_valid_data(phash_threshold="8"))
+        assert params["phash_threshold"] == 8
+
+    def test_phash_threshold_int_kept(self):
+        params, _, _ = _parse_grouping_params(_valid_data(phash_threshold=5))
+        assert params["phash_threshold"] == 5
+
+    def test_clip_threshold_auto_kept_as_string(self):
+        params, _, _ = _parse_grouping_params(_valid_data(clip_threshold="auto"))
+        assert params["clip_threshold"] == "auto"
+
+    def test_clip_threshold_numeric_string_parsed_as_float(self):
+        params, _, _ = _parse_grouping_params(_valid_data(clip_threshold="0.85"))
+        assert params["clip_threshold"] == pytest.approx(0.85)
+
+    def test_time_delta_defaults_to_1(self):
+        data = _valid_data()
+        del data["time_delta_seconds"]
+        params, _, _ = _parse_grouping_params(data)
+        assert params["time_delta_seconds"] == 1
+
+    def test_time_delta_string_parsed_as_int(self):
+        params, _, _ = _parse_grouping_params(_valid_data(time_delta_seconds="10"))
+        assert params["time_delta_seconds"] == 10
+
+    def test_culling_preset_default_accepted(self):
+        params, _, _ = _parse_grouping_params(_valid_data(culling_preset="default"))
+        assert params["culling_preset"] == "default"
+
+    def test_culling_preset_normalised_to_lowercase(self):
+        params, _, _ = _parse_grouping_params(_valid_data(culling_preset="DEFAULT"))
+        assert params["culling_preset"] == "default"
+
+    def test_result_contains_all_expected_keys(self):
+        params, _, _ = _parse_grouping_params(_valid_data())
+        assert set(params.keys()) == {
+            "photo_ids",
+            "phash_threshold",
+            "clip_threshold",
+            "time_delta_seconds",
+            "culling_preset",
+        }
+
+    def test_uuids_key_accepted_as_alias_for_photo_ids(self):
+        data = {
+            "uuids": _VALID_PHOTO_IDS,
+            "culling_preset": "default",
+        }
+        params, err_resp, _ = _parse_grouping_params(data)
+        assert err_resp is None
+        assert params["photo_ids"] == _VALID_PHOTO_IDS
+
+
+# ---------------------------------------------------------------------------
+# Error paths — each must return (None, response, 400)
+# ---------------------------------------------------------------------------
+
+
+class TestParseGroupingParamsErrors:
+    def _assert_error(self, data, fragment):
+        """Assert the helper returns an error response containing *fragment*.
+
+        _parse_grouping_params calls Flask's jsonify() internally, so the call
+        must happen inside an app context.
+        """
+        with app.app_context():
+            params, err_resp, err_code = _parse_grouping_params(data)
+            assert params is None
+            assert err_code == 400
+            payload = err_resp.get_json()
+        assert "error" in payload
+        assert fragment.lower() in payload["error"].lower()
+
+    def test_phash_threshold_bad_string_returns_error(self):
+        self._assert_error(_valid_data(phash_threshold="bad"), "phash_threshold")
+
+    def test_clip_threshold_bad_string_returns_error(self):
+        self._assert_error(_valid_data(clip_threshold="bad"), "clip_threshold")
+
+    def test_time_delta_bad_string_returns_error(self):
+        self._assert_error(_valid_data(time_delta_seconds="bad"), "time_delta_seconds")
+
+    def test_culling_preset_invalid_returns_error(self):
+        self._assert_error(
+            _valid_data(culling_preset="invalid_preset"), "culling_preset"
+        )
+
+    def test_missing_photo_ids_returns_error(self):
+        data = _valid_data()
+        del data["photo_ids"]
+        self._assert_error(data, "photo_ids")
+
+    def test_photo_ids_not_a_list_returns_error(self):
+        self._assert_error(_valid_data(photo_ids="not-a-list"), "photo_ids")
+
+    def test_photo_ids_empty_list_returns_error(self):
+        self._assert_error(_valid_data(photo_ids=[]), "photo_ids")
+
+    def test_culling_preset_error_includes_available_presets(self):
+        with app.app_context():
+            _, err_resp, _ = _parse_grouping_params(_valid_data(culling_preset="nope"))
+            payload = err_resp.get_json()
+        assert "available_presets" in payload
+        assert isinstance(payload["available_presets"], list)
+        assert "default" in payload["available_presets"]

--- a/server/test/test_service_exif.py
+++ b/server/test/test_service_exif.py
@@ -1,0 +1,249 @@
+"""Tests for services/exif.py — IPTC parsing, DMS conversion, location formatting,
+and the extract_location_tags entry point."""
+
+import struct
+
+import pytest
+
+from services.exif import (
+    _dms_to_decimal,
+    _parse_iptc,
+    extract_location_tags,
+    format_location_for_prompt,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# IPTC record-2 marker bytes
+_IPTC_RECORD = 0x02
+_TAG_CITY = 0x5A  # 90
+_TAG_COUNTRY = 0x65  # 101
+_TAG_LOCATION = 0x5C  # 92
+_TAG_STATE = 0x5F  # 95
+_TAG_COUNTRY_CODE = 0x64  # 100
+
+
+def _make_iptc_record(tag_id: int, value_bytes: bytes) -> bytes:
+    """Build a single IPTC IIM record-2 marker: 0x1C 0x02 <tag> <2-byte len> <data>."""
+    return (
+        bytes([0x1C, _IPTC_RECORD, tag_id])
+        + struct.pack(">H", len(value_bytes))
+        + value_bytes
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_iptc
+# ---------------------------------------------------------------------------
+
+
+class TestParseIptc:
+    def test_empty_bytes_returns_empty_dict(self):
+        assert _parse_iptc(b"") == {}
+
+    def test_parses_city_tag(self):
+        city = b"Berlin"
+        data = _make_iptc_record(_TAG_CITY, city)
+        result = _parse_iptc(data)
+        assert result[_TAG_CITY] == "Berlin"
+
+    def test_parses_country_tag(self):
+        data = _make_iptc_record(_TAG_COUNTRY, b"Deutschland")
+        result = _parse_iptc(data)
+        assert result[_TAG_COUNTRY] == "Deutschland"
+
+    def test_parses_multiple_tags(self):
+        data = _make_iptc_record(_TAG_CITY, b"Munich") + _make_iptc_record(
+            _TAG_COUNTRY, b"Germany"
+        )
+        result = _parse_iptc(data)
+        assert result[_TAG_CITY] == "Munich"
+        assert result[_TAG_COUNTRY] == "Germany"
+
+    def test_non_record_2_tag_is_skipped(self):
+        # Use record byte 0x03 instead of 0x02 — should be skipped.
+        bad_record = bytes([0x1C, 0x03, _TAG_CITY]) + struct.pack(">H", 4) + b"Nope"
+        result = _parse_iptc(bad_record)
+        assert result == {}
+
+    def test_tag_not_in_location_tags_is_skipped(self):
+        # Tag 0x01 (object name) is not a location tag.
+        unknown_tag = bytes([0x1C, 0x02, 0x01]) + struct.pack(">H", 5) + b"Title"
+        result = _parse_iptc(unknown_tag)
+        assert result == {}
+
+    def test_location_tag_parsed(self):
+        data = _make_iptc_record(_TAG_LOCATION, b"Chiemsee")
+        result = _parse_iptc(data)
+        assert result[_TAG_LOCATION] == "Chiemsee"
+
+    def test_state_tag_parsed(self):
+        data = _make_iptc_record(_TAG_STATE, b"Bayern")
+        result = _parse_iptc(data)
+        assert result[_TAG_STATE] == "Bayern"
+
+    def test_country_code_tag_parsed(self):
+        data = _make_iptc_record(_TAG_COUNTRY_CODE, b"DE")
+        result = _parse_iptc(data)
+        assert result[_TAG_COUNTRY_CODE] == "DE"
+
+    def test_whitespace_stripped_from_value(self):
+        data = _make_iptc_record(_TAG_CITY, b"  Paris  ")
+        result = _parse_iptc(data)
+        assert result[_TAG_CITY] == "Paris"
+
+    def test_empty_value_not_included(self):
+        data = _make_iptc_record(_TAG_CITY, b"   ")
+        result = _parse_iptc(data)
+        assert _TAG_CITY not in result
+
+    def test_garbage_bytes_between_records_skipped(self):
+        """Parser should skip bytes that don't start with 0x1C."""
+        city = _make_iptc_record(_TAG_CITY, b"Rome")
+        data = b"\x00\xff\xab" + city
+        result = _parse_iptc(data)
+        assert result[_TAG_CITY] == "Rome"
+
+
+# ---------------------------------------------------------------------------
+# _dms_to_decimal
+# ---------------------------------------------------------------------------
+
+
+class TestDmsToDecimal:
+    def test_whole_degrees(self):
+        result = _dms_to_decimal((48, 0, 0))
+        assert result == pytest.approx(48.0)
+
+    def test_degrees_and_minutes(self):
+        result = _dms_to_decimal((48, 8, 0))
+        assert result == pytest.approx(48.0 + 8 / 60.0)
+
+    def test_degrees_minutes_seconds(self):
+        result = _dms_to_decimal((48, 8, 30))
+        assert result == pytest.approx(48.0 + 8 / 60.0 + 30 / 3600.0)
+
+    def test_tuple_of_tuples_rational_form(self):
+        # Pillow IFDRational stored as (numerator, denominator) tuples.
+        dms = ((48, 1), (8, 1), (0, 1))
+        result = _dms_to_decimal(dms)
+        assert result == pytest.approx(48.0 + 8 / 60.0)
+
+    def test_fractional_seconds(self):
+        dms = ((12, 1), (30, 1), (18, 2))  # 12 deg, 30 min, 9 sec
+        result = _dms_to_decimal(dms)
+        assert result == pytest.approx(12.0 + 30 / 60.0 + 9 / 3600.0)
+
+    def test_bad_input_returns_none(self):
+        assert _dms_to_decimal(None) is None
+
+    def test_too_few_elements_returns_none(self):
+        assert _dms_to_decimal((10, 20)) is None
+
+    def test_non_numeric_returns_none(self):
+        assert _dms_to_decimal(("a", "b", "c")) is None
+
+    def test_zero_denominator_in_tuple_treated_as_zero(self):
+        # (num, 0) denominator should be treated as 0.0, not raise.
+        dms = ((0, 0), (0, 1), (0, 1))
+        result = _dms_to_decimal(dms)
+        assert result == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# format_location_for_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLocationForPrompt:
+    def test_none_returns_none(self):
+        assert format_location_for_prompt(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert format_location_for_prompt({}) is None
+
+    def test_city_and_country(self):
+        result = format_location_for_prompt({"city": "Berlin", "country": "Germany"})
+        assert result == "Berlin, Germany"
+
+    def test_full_structured_fields(self):
+        data = {
+            "location": "Chiemsee",
+            "city": "Prien am Chiemsee",
+            "state": "Bayern",
+            "country": "Deutschland",
+        }
+        result = format_location_for_prompt(data)
+        assert result == "Chiemsee, Prien am Chiemsee, Bayern, Deutschland"
+
+    def test_location_only(self):
+        result = format_location_for_prompt({"location": "Eiffel Tower"})
+        assert result == "Eiffel Tower"
+
+    def test_state_and_country(self):
+        result = format_location_for_prompt({"state": "Bayern", "country": "Germany"})
+        assert result == "Bayern, Germany"
+
+    def test_gps_only_fallback(self):
+        result = format_location_for_prompt(
+            {"gps_latitude": 47.8556, "gps_longitude": 12.3657}
+        )
+        assert result == "47.855600, 12.365700"
+
+    def test_gps_negative_coordinates(self):
+        result = format_location_for_prompt(
+            {"gps_latitude": -33.8688, "gps_longitude": 151.2093}
+        )
+        assert result == "-33.868800, 151.209300"
+
+    def test_structured_takes_priority_over_gps(self):
+        data = {
+            "city": "Sydney",
+            "gps_latitude": -33.8688,
+            "gps_longitude": 151.2093,
+        }
+        result = format_location_for_prompt(data)
+        assert result == "Sydney"
+
+    def test_partial_gps_missing_longitude_returns_none(self):
+        result = format_location_for_prompt({"gps_latitude": 48.0})
+        assert result is None
+
+    def test_partial_gps_missing_latitude_returns_none(self):
+        result = format_location_for_prompt({"gps_longitude": 11.0})
+        assert result is None
+
+    def test_country_code_not_included_in_output(self):
+        # country_code is metadata but not displayed in the prompt string.
+        result = format_location_for_prompt({"city": "Berlin", "country_code": "DE"})
+        # country_code alone → no structured parts → GPS fallback (none here) → None
+        assert result == "Berlin"
+
+
+# ---------------------------------------------------------------------------
+# extract_location_tags
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLocationTags:
+    def test_empty_bytes_returns_none(self):
+        result = extract_location_tags(b"")
+        assert result is None
+
+    def test_random_bytes_returns_none(self):
+        result = extract_location_tags(b"\x00\x01\x02\x03\x04\x05")
+        assert result is None
+
+    def test_non_jpeg_returns_none(self):
+        # PNG magic bytes — no JPEG marker, no EXIF.
+        png_magic = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        result = extract_location_tags(png_magic)
+        assert result is None
+
+    def test_minimal_jpeg_without_location_returns_none(self):
+        # Minimal valid JPEG: SOI + EOI markers only.
+        minimal_jpeg = b"\xff\xd8\xff\xd9"
+        result = extract_location_tags(minimal_jpeg)
+        assert result is None

--- a/server/test/test_service_import.py
+++ b/server/test/test_service_import.py
@@ -1,0 +1,248 @@
+"""Tests for services/import_.py — import_metadata_task control flow."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+from services.import_ import import_metadata_task
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chroma_mock(existing_ids=None):
+    """Return a mock chroma_service.
+
+    existing_ids: list of photo_ids that are considered "in DB".
+    If None, get_image always returns an empty result (not in DB).
+    """
+    mock = MagicMock()
+    if existing_ids is None:
+        mock.get_image.return_value = {"ids": []}
+    else:
+
+        def _get_image(photo_id):
+            if photo_id in existing_ids:
+                return {"ids": [photo_id], "metadatas": [{}]}
+            return {"ids": []}
+
+        mock.get_image.side_effect = _get_image
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportMetadataTaskMissingPhotoId:
+    def test_item_missing_photo_id_increments_failure(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"title": "no id here"}])
+        assert success == 0
+        assert failure == 1
+        mock_chroma.add_image.assert_not_called()
+
+    def test_item_with_uuid_used_as_photo_id_when_no_photo_id(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task(
+                [{"uuid": "uuid-only", "title": "A Title"}]
+            )
+        assert success == 1
+        assert failure == 0
+        mock_chroma.add_image.assert_called_once()
+
+    def test_empty_photo_id_string_treated_as_missing(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "", "title": "x"}])
+        assert success == 0
+        assert failure == 1
+
+
+class TestImportMetadataTaskNoMetadataFields:
+    def test_item_with_no_metadata_fields_is_skipped(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "p1"}])
+        assert success == 0
+        assert failure == 1
+        mock_chroma.add_image.assert_not_called()
+        mock_chroma.update_image.assert_not_called()
+
+    def test_empty_keywords_list_counts_as_no_metadata(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task(
+                [{"photo_id": "p1", "keywords": []}]
+            )
+        assert success == 0
+        assert failure == 1
+
+    def test_empty_title_string_counts_as_no_metadata(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "p1", "title": ""}])
+        assert success == 0
+        assert failure == 1
+
+    def test_empty_caption_string_counts_as_no_metadata(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "p1", "caption": ""}])
+        assert success == 0
+        assert failure == 1
+
+
+class TestImportMetadataTaskAddNewRecord:
+    def test_item_not_in_db_calls_add_image(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task(
+                [{"photo_id": "new-1", "title": "My Photo"}]
+            )
+        assert success == 1
+        assert failure == 0
+        mock_chroma.add_image.assert_called_once()
+        mock_chroma.update_image.assert_not_called()
+
+    def test_add_image_called_with_photo_id_and_none_embedding(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task([{"photo_id": "new-2", "caption": "A caption"}])
+        args = mock_chroma.add_image.call_args
+        assert args[0][0] == "new-2"
+        assert args[0][1] is None  # embedding is None for metadata-only
+
+    def test_add_image_metadata_includes_photo_id(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task([{"photo_id": "new-3", "title": "T"}])
+        metadata_arg = mock_chroma.add_image.call_args[0][2]
+        assert metadata_arg["photo_id"] == "new-3"
+
+    def test_keywords_serialised_to_json(self):
+        mock_chroma = _make_chroma_mock()
+        kw = ["Nature", "Travel"]
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task([{"photo_id": "p1", "keywords": kw}])
+        metadata_arg = mock_chroma.add_image.call_args[0][2]
+        assert json.loads(metadata_arg["keywords"]) == kw
+
+    def test_flattened_keywords_added(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task([{"photo_id": "p1", "keywords": ["A", "B"]}])
+        metadata_arg = mock_chroma.add_image.call_args[0][2]
+        assert "flattened_keywords" in metadata_arg
+
+    def test_catalog_id_passed_to_add_image(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task([{"photo_id": "p1", "title": "T"}], catalog_id="cat-1")
+        kwargs = mock_chroma.add_image.call_args[1]
+        assert kwargs.get("catalog_id") == "cat-1"
+
+
+class TestImportMetadataTaskUpdateExistingRecord:
+    def test_item_in_db_calls_update_image(self):
+        mock_chroma = _make_chroma_mock(existing_ids=["existing-1"])
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task(
+                [{"photo_id": "existing-1", "title": "Updated"}]
+            )
+        assert success == 1
+        assert failure == 0
+        mock_chroma.update_image.assert_called_once()
+        mock_chroma.add_image.assert_not_called()
+
+    def test_update_image_called_with_correct_photo_id(self):
+        mock_chroma = _make_chroma_mock(existing_ids=["ex-2"])
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task([{"photo_id": "ex-2", "caption": "Cap"}])
+        args = mock_chroma.update_image.call_args[0]
+        assert args[0] == "ex-2"
+
+    def test_catalog_id_passed_to_update_image(self):
+        mock_chroma = _make_chroma_mock(existing_ids=["ex-3"])
+        with patch("services.import_.chroma_service", mock_chroma):
+            import_metadata_task(
+                [{"photo_id": "ex-3", "title": "T"}], catalog_id="cat-9"
+            )
+        kwargs = mock_chroma.update_image.call_args[1]
+        assert kwargs.get("catalog_id") == "cat-9"
+
+
+class TestImportMetadataTaskExceptionHandling:
+    def test_exception_during_get_image_increments_failure(self):
+        mock_chroma = MagicMock()
+        mock_chroma.get_image.side_effect = RuntimeError("DB error")
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "p1", "title": "T"}])
+        assert success == 0
+        assert failure == 1
+
+    def test_exception_during_update_increments_failure(self):
+        mock_chroma = _make_chroma_mock(existing_ids=["p2"])
+        mock_chroma.update_image.side_effect = RuntimeError("write error")
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "p2", "title": "T"}])
+        assert success == 0
+        assert failure == 1
+
+    def test_exception_during_add_increments_failure(self):
+        mock_chroma = _make_chroma_mock()
+        mock_chroma.add_image.side_effect = RuntimeError("add failed")
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([{"photo_id": "p3", "title": "T"}])
+        assert success == 0
+        assert failure == 1
+
+
+class TestImportMetadataTaskMultipleItems:
+    def test_multiple_items_counted_correctly(self):
+        mock_chroma = _make_chroma_mock(existing_ids=["existing"])
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task(
+                [
+                    {"photo_id": "new-a", "title": "New A"},
+                    {"photo_id": "existing", "caption": "Cap"},
+                    {"photo_id": "new-b", "alt_text": "Alt"},
+                    {"title": "no id"},  # failure
+                ]
+            )
+        assert success == 3
+        assert failure == 1
+
+    def test_empty_list_returns_zero_zero(self):
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task([])
+        assert success == 0
+        assert failure == 0
+
+    def test_all_metadata_fields_accepted(self):
+        """title, caption, alt_text, and keywords are all valid metadata fields."""
+        mock_chroma = _make_chroma_mock()
+        with patch("services.import_.chroma_service", mock_chroma):
+            success, failure = import_metadata_task(
+                [
+                    {
+                        "photo_id": "full",
+                        "title": "T",
+                        "caption": "C",
+                        "alt_text": "A",
+                        "keywords": ["k1", "k2"],
+                    }
+                ]
+            )
+        assert success == 1
+        assert failure == 0
+        metadata_arg = mock_chroma.add_image.call_args[0][2]
+        assert metadata_arg["title"] == "T"
+        assert metadata_arg["caption"] == "C"
+        assert metadata_arg["alt_text"] == "A"

--- a/server/test/test_service_search_helpers.py
+++ b/server/test/test_service_search_helpers.py
@@ -1,0 +1,367 @@
+"""Tests for pure helper functions in services/search.py.
+
+``services.search`` transitively imports ``server_lifecycle`` → ``open_clip``
+→ real ``torch``.  We stub the entire chain at the ``sys.modules`` level
+before importing the service module so no CUDA/ML libraries need to be loaded.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Stub every heavy transitive dep before services.search is imported.
+for _mod in [
+    "open_clip",
+    "server_lifecycle",
+    "huggingface_hub",
+    "torch",
+    "torch.nn",
+    "torch.nn.functional",
+    "torch.utils",
+    "torch.utils.checkpoint",
+    "services.vertexai",
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+from services.search import (  # noqa: E402  (import after sys.modules patch)
+    DEFAULT_MAX_RESULTS,
+    DEFAULT_RELEVANCE_STRICTNESS,
+    _clamp_max_results,
+    _clamp_strictness,
+    _merge_semantic_results,
+    _normalize_search_sources,
+    _smart_filter_by_relevance,
+    _strictness_to_k,
+    _transform_and_sort_results,
+    _transform_vertex_results,
+)
+
+
+# ---------------------------------------------------------------------------
+# _clamp_max_results
+# ---------------------------------------------------------------------------
+
+
+class TestClampMaxResults:
+    def test_none_returns_default(self):
+        assert _clamp_max_results(None) == DEFAULT_MAX_RESULTS
+
+    def test_string_int_parsed(self):
+        assert _clamp_max_results("150") == 150
+
+    def test_non_numeric_string_returns_default(self):
+        assert _clamp_max_results("abc") == DEFAULT_MAX_RESULTS
+
+    def test_below_min_clamped_to_min(self):
+        assert _clamp_max_results(5) == 10
+
+    def test_one_clamped_to_min(self):
+        assert _clamp_max_results(1) == 10
+
+    def test_negative_clamped_to_min(self):
+        assert _clamp_max_results(-1) == 10
+
+    def test_above_max_clamped_to_max(self):
+        assert _clamp_max_results(3000) == 2000
+
+    def test_exact_min_accepted(self):
+        assert _clamp_max_results(10) == 10
+
+    def test_exact_max_accepted(self):
+        assert _clamp_max_results(2000) == 2000
+
+    def test_midrange_value_unchanged(self):
+        assert _clamp_max_results(500) == 500
+
+
+# ---------------------------------------------------------------------------
+# _clamp_strictness
+# ---------------------------------------------------------------------------
+
+
+class TestClampStrictness:
+    def test_none_returns_default(self):
+        assert _clamp_strictness(None) == DEFAULT_RELEVANCE_STRICTNESS
+
+    def test_negative_clamped_to_zero(self):
+        assert _clamp_strictness(-5) == 0
+
+    def test_above_100_clamped_to_100(self):
+        assert _clamp_strictness(150) == 100
+
+    def test_string_int_parsed(self):
+        assert _clamp_strictness("75") == 75
+
+    def test_bad_string_returns_default(self):
+        assert _clamp_strictness("bad") == DEFAULT_RELEVANCE_STRICTNESS
+
+    def test_zero_accepted(self):
+        assert _clamp_strictness(0) == 0
+
+    def test_100_accepted(self):
+        assert _clamp_strictness(100) == 100
+
+    def test_midrange_value_unchanged(self):
+        assert _clamp_strictness(42) == 42
+
+
+# ---------------------------------------------------------------------------
+# _strictness_to_k
+# ---------------------------------------------------------------------------
+
+
+class TestStrictnessToK:
+    def test_zero_returns_zero(self):
+        assert _strictness_to_k(0) == 0.0
+
+    def test_25_anchor(self):
+        assert _strictness_to_k(25) == 0.5
+
+    def test_50_anchor(self):
+        assert _strictness_to_k(50) == 1.0
+
+    def test_75_anchor(self):
+        assert _strictness_to_k(75) == 1.5
+
+    def test_100_anchor(self):
+        assert _strictness_to_k(100) == 2.0
+
+    def test_below_zero_clamped(self):
+        # _strictness_to_k clamps internally via max/min.
+        assert _strictness_to_k(-10) == 0.0
+
+    def test_above_100_clamped(self):
+        assert _strictness_to_k(200) == 2.0
+
+
+# ---------------------------------------------------------------------------
+# _merge_semantic_results
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSemanticResults:
+    def test_empty_both_returns_empty(self):
+        assert _merge_semantic_results([], []) == []
+
+    def test_vertex_only_returned_first(self):
+        vertex = [{"photo_id": "v1", "distance": 0.1}]
+        result = _merge_semantic_results([], vertex)
+        assert result[0]["photo_id"] == "v1"
+
+    def test_siglip_only_ids_appended(self):
+        siglip = [{"photo_id": "s1", "distance": 0.2}]
+        result = _merge_semantic_results(siglip, [])
+        assert result[0]["photo_id"] == "s1"
+
+    def test_vertex_ids_take_priority_over_siglip(self):
+        siglip = [
+            {"photo_id": "shared", "distance": 0.1},
+            {"photo_id": "s_only", "distance": 0.3},
+        ]
+        vertex = [{"photo_id": "shared", "distance": 0.05}]
+        result = _merge_semantic_results(siglip, vertex)
+        # "shared" should appear only once (vertex version).
+        ids = [r["photo_id"] for r in result]
+        assert ids.count("shared") == 1
+        assert ids[0] == "shared"
+
+    def test_siglip_only_added_after_vertex(self):
+        siglip = [
+            {"photo_id": "v_id", "distance": 0.1},
+            {"photo_id": "s_only", "distance": 0.2},
+        ]
+        vertex = [{"photo_id": "v_id", "distance": 0.05}]
+        result = _merge_semantic_results(siglip, vertex)
+        ids = [r["photo_id"] for r in result]
+        assert ids == ["v_id", "s_only"]
+
+    def test_no_cross_model_distance_comparison(self):
+        """Vertex results always precede siglip-only results regardless of distance."""
+        siglip = [{"photo_id": "s1", "distance": 0.01}]
+        vertex = [{"photo_id": "v1", "distance": 0.99}]
+        result = _merge_semantic_results(siglip, vertex)
+        assert result[0]["photo_id"] == "v1"
+        assert result[1]["photo_id"] == "s1"
+
+
+# ---------------------------------------------------------------------------
+# _transform_and_sort_results
+# ---------------------------------------------------------------------------
+
+
+class TestTransformAndSortResults:
+    def _make_chroma(self, ids, distances, metadatas=None):
+        if metadatas is None:
+            metadatas = [{} for _ in ids]
+        return {"ids": [ids], "distances": [distances], "metadatas": [metadatas]}
+
+    def test_empty_ids_returns_empty(self):
+        assert (
+            _transform_and_sort_results(
+                {"ids": [[]], "distances": [[]], "metadatas": [[]]}, False
+            )
+            == []
+        )
+
+    def test_none_results_returns_empty(self):
+        assert _transform_and_sort_results(None, False) == []
+
+    def test_has_embedding_false_skipped(self):
+        data = self._make_chroma(
+            ["p1", "p2"],
+            [0.1, 0.2],
+            [{"has_embedding": False}, {"has_embedding": True}],
+        )
+        result = _transform_and_sort_results(data, False)
+        ids = [r["photo_id"] for r in result]
+        assert "p1" not in ids
+        assert "p2" in ids
+
+    def test_sorted_by_distance_ascending(self):
+        data = self._make_chroma(["p1", "p2", "p3"], [0.5, 0.1, 0.3])
+        result = _transform_and_sort_results(data, False)
+        distances = [r["distance"] for r in result]
+        assert distances == sorted(distances)
+
+    def test_photo_id_and_uuid_both_set(self):
+        data = self._make_chroma(["abc"], [0.2])
+        result = _transform_and_sort_results(data, False)
+        assert result[0]["photo_id"] == "abc"
+        assert result[0]["uuid"] == "abc"
+
+    def test_distance_rounded_to_4_places(self):
+        data = self._make_chroma(["p1"], [0.123456789])
+        result = _transform_and_sort_results(data, False)
+        assert result[0]["distance"] == 0.1235
+
+
+# ---------------------------------------------------------------------------
+# _transform_vertex_results
+# ---------------------------------------------------------------------------
+
+
+class TestTransformVertexResults:
+    def test_empty_returns_empty(self):
+        assert _transform_vertex_results({}) == []
+
+    def test_none_returns_empty(self):
+        assert _transform_vertex_results(None) == []
+
+    def test_empty_ids_list_returns_empty(self):
+        assert _transform_vertex_results({"ids": [[]], "distances": [[]]}) == []
+
+    def test_normal_result_sorted_by_distance(self):
+        data = {"ids": [["v2", "v1"]], "distances": [[0.8, 0.2]]}
+        result = _transform_vertex_results(data)
+        assert result[0]["photo_id"] == "v1"
+        assert result[1]["photo_id"] == "v2"
+
+    def test_photo_id_and_uuid_set(self):
+        data = {"ids": [["x"]], "distances": [[0.5]]}
+        result = _transform_vertex_results(data)
+        assert result[0]["photo_id"] == "x"
+        assert result[0]["uuid"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_search_sources
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSearchSources:
+    def test_none_returns_all_defaults(self):
+        result = _normalize_search_sources(None)
+        assert result["semantic_siglip"] is True
+        assert result["semantic_vertex"] is True
+        assert result["metadata"] is True
+        assert "flattened_keywords" in result["metadata_fields"]
+
+    def test_empty_dict_returns_defaults(self):
+        result = _normalize_search_sources({})
+        assert result["semantic_siglip"] is True
+
+    def test_partial_dict_fills_in_defaults(self):
+        result = _normalize_search_sources({"semantic_siglip": False})
+        assert result["semantic_siglip"] is False
+        assert result["semantic_vertex"] is True
+
+    def test_metadata_fields_filters_to_allowed(self):
+        result = _normalize_search_sources(
+            {"metadata_fields": ["flattened_keywords", "bogus_field"]}
+        )
+        assert "flattened_keywords" in result["metadata_fields"]
+        assert "bogus_field" not in result["metadata_fields"]
+
+    def test_empty_metadata_fields_reverts_to_defaults(self):
+        result = _normalize_search_sources({"metadata_fields": []})
+        assert len(result["metadata_fields"]) > 0
+
+    def test_all_invalid_metadata_fields_reverts_to_defaults(self):
+        result = _normalize_search_sources({"metadata_fields": ["bad1", "bad2"]})
+        assert len(result["metadata_fields"]) > 0
+
+    def test_none_metadata_fields_uses_defaults(self):
+        result = _normalize_search_sources({"metadata_fields": None})
+        assert "flattened_keywords" in result["metadata_fields"]
+
+    def test_known_metadata_fields_all_accepted(self):
+        allowed = ["flattened_keywords", "alt_text", "caption", "title"]
+        result = _normalize_search_sources({"metadata_fields": allowed})
+        assert set(result["metadata_fields"]) == set(allowed)
+
+
+# ---------------------------------------------------------------------------
+# _smart_filter_by_relevance
+# ---------------------------------------------------------------------------
+
+
+def _make_results(distances):
+    return [{"photo_id": f"p{i}", "distance": d} for i, d in enumerate(distances)]
+
+
+class TestSmartFilterByRelevance:
+    def test_empty_returns_empty(self):
+        assert _smart_filter_by_relevance([], 50) == []
+
+    def test_strictness_zero_returns_unchanged(self):
+        results = _make_results([0.1, 0.5, 1.0, 1.5])
+        assert _smart_filter_by_relevance(results, 0) == results
+
+    def test_small_list_at_or_below_floor_passes_through(self):
+        # RELEVANCE_FLOOR == 8; list of 6 should be returned untouched.
+        results = _make_results([float(i) for i in range(6)])
+        out = _smart_filter_by_relevance(results, 100)
+        assert out == results
+
+    def test_exact_floor_size_passes_through(self):
+        results = _make_results([float(i) for i in range(8)])
+        out = _smart_filter_by_relevance(results, 100)
+        assert out == results
+
+    def test_bimodal_distribution_keeps_relevant_cluster(self):
+        # 12 clearly-relevant items followed by 30 noisy ones with a big gap.
+        relevant = [0.20 + 0.005 * i for i in range(12)]
+        noise = [1.50 + 0.01 * i for i in range(30)]
+        results = _make_results(relevant + noise)
+        out = _smart_filter_by_relevance(results, 50)
+        assert all(r["distance"] < 1.0 for r in out)
+
+    def test_floor_enforced_when_cluster_too_small(self):
+        # 3 relevant + 35 noise: filter pads result to RELEVANCE_FLOOR.
+        relevant = [0.1, 0.11, 0.12]
+        noise = [2.0 + 0.01 * i for i in range(35)]
+        results = _make_results(relevant + noise)
+        out = _smart_filter_by_relevance(results, 50)
+        assert len(out) >= 8
+
+    def test_smooth_distribution_never_returns_below_floor(self):
+        results = _make_results([0.5 + 0.005 * i for i in range(60)])
+        out = _smart_filter_by_relevance(results, 90)
+        assert len(out) >= 8
+
+    def test_higher_strictness_keeps_same_or_fewer(self):
+        relevant = [0.30 + 0.005 * i for i in range(10)]
+        noise = [1.20 + 0.01 * i for i in range(40)]
+        results = _make_results(relevant + noise)
+        kept_low = len(_smart_filter_by_relevance(results, 25))
+        kept_high = len(_smart_filter_by_relevance(results, 100))
+        assert kept_low >= kept_high

--- a/server/test/test_service_version.py
+++ b/server/test/test_service_version.py
@@ -1,0 +1,189 @@
+"""Tests for services/version.py — version normalisation, dev fallback, and
+compatibility check logic."""
+
+from services.version import (
+    _normalize_version,
+    _is_dev_backend,
+    _is_default_dev_plugin,
+    check_plugin_backend_version,
+)
+
+
+class TestNormalizeVersion:
+    def test_none_returns_none(self):
+        assert _normalize_version(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _normalize_version("") is None
+
+    def test_non_string_returns_none(self):
+        assert _normalize_version(123) is None  # type: ignore[arg-type]
+
+    def test_simple_semver(self):
+        assert _normalize_version("1.2.3") == "1.2.3"
+
+    def test_v_prefix_stripped(self):
+        assert _normalize_version("v1.2.3") == "1.2.3"
+
+    def test_extra_prerelease_suffix_truncated(self):
+        # Only the major.minor.patch part should be returned.
+        assert _normalize_version("1.2.3-beta.1") == "1.2.3"
+
+    def test_dev_suffix_truncated(self):
+        assert _normalize_version("0.0.0-dev") == "0.0.0"
+
+    def test_v_prefix_with_dev_suffix(self):
+        assert _normalize_version("v0.0.0-dev") == "0.0.0"
+
+    def test_whitespace_stripped(self):
+        assert _normalize_version("  2.3.4  ") == "2.3.4"
+
+    def test_garbage_input_returns_none(self):
+        assert _normalize_version("not-a-version") is None
+
+    def test_partial_version_returns_none(self):
+        assert _normalize_version("1.2") is None
+
+    def test_dev_version_999(self):
+        assert _normalize_version("9.9.9") == "9.9.9"
+
+
+class TestIsDevBackend:
+    def test_both_none(self):
+        assert _is_dev_backend(None, None) is False
+
+    def test_version_contains_dev(self):
+        assert _is_dev_backend("0.0.0-dev", None) is True
+
+    def test_release_tag_contains_dev(self):
+        assert _is_dev_backend("1.0.0", "v0.0.0-dev") is True
+
+    def test_dev_case_insensitive(self):
+        assert _is_dev_backend("1.0.0-DEV", None) is True
+
+    def test_neither_contains_dev(self):
+        assert _is_dev_backend("1.2.3", "v1.2.3") is False
+
+    def test_empty_strings(self):
+        assert _is_dev_backend("", "") is False
+
+
+class TestIsDefaultDevPlugin:
+    def test_999_returns_true(self):
+        assert _is_default_dev_plugin("9.9.9") is True
+
+    def test_other_version_returns_false(self):
+        assert _is_default_dev_plugin("1.0.0") is False
+
+    def test_none_returns_false(self):
+        assert _is_default_dev_plugin(None) is False
+
+    def test_999_with_extra_chars_returns_false(self):
+        assert _is_default_dev_plugin("9.9.9-rc1") is False
+
+
+class TestCheckPluginBackendVersion:
+    def test_missing_plugin_version_incompatible(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "1.0.0")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v1.0.0")
+        mocker.patch("services.version.BACKEND_BUILD", 42)
+
+        result = check_plugin_backend_version(None)
+
+        assert result["compatible"] is False
+        assert "missing or invalid" in result["reason"]
+        assert result["plugin_version"] is None
+
+    def test_invalid_plugin_version_incompatible(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "1.0.0")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v1.0.0")
+        mocker.patch("services.version.BACKEND_BUILD", 0)
+
+        result = check_plugin_backend_version("not-a-version")
+
+        assert result["compatible"] is False
+        assert "missing or invalid" in result["reason"]
+
+    def test_exact_version_match_compatible(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "1.2.3")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v1.2.3")
+        mocker.patch("services.version.BACKEND_BUILD", 5)
+
+        result = check_plugin_backend_version("1.2.3", plugin_build=5)
+
+        assert result["compatible"] is True
+        assert result["reason"] == "exact version match"
+
+    def test_version_mismatch_incompatible(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "1.2.3")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v1.2.3")
+        mocker.patch("services.version.BACKEND_BUILD", 5)
+
+        result = check_plugin_backend_version("1.2.4")
+
+        assert result["compatible"] is False
+        assert "differ" in result["reason"]
+
+    def test_dev_backend_accepts_999_plugin(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "0.0.0-dev")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v0.0.0-dev")
+        mocker.patch("services.version.BACKEND_BUILD", 0)
+
+        result = check_plugin_backend_version("9.9.9")
+
+        assert result["compatible"] is True
+        assert "dev fallback" in result["reason"]
+
+    def test_dev_backend_rejects_non_999_plugin(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "0.0.0-dev")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v0.0.0-dev")
+        mocker.patch("services.version.BACKEND_BUILD", 0)
+
+        result = check_plugin_backend_version("1.0.0")
+
+        # "0.0.0" (normalized from 0.0.0-dev) != "1.0.0"
+        assert result["compatible"] is False
+
+    def test_v_prefix_plugin_version_accepted(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "2.0.0")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v2.0.0")
+        mocker.patch("services.version.BACKEND_BUILD", 1)
+
+        result = check_plugin_backend_version("v2.0.0")
+
+        assert result["compatible"] is True
+
+    def test_response_contains_all_expected_keys(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "1.0.0")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v1.0.0")
+        mocker.patch("services.version.BACKEND_BUILD", 3)
+
+        result = check_plugin_backend_version(
+            "1.0.0", plugin_build=3, plugin_release_tag="v1.0.0"
+        )
+
+        expected_keys = {
+            "backend_version",
+            "backend_release_tag",
+            "backend_build",
+            "plugin_version",
+            "plugin_release_tag",
+            "plugin_build",
+            "compatible",
+            "reason",
+        }
+        assert expected_keys.issubset(result.keys())
+
+    def test_plugin_and_backend_info_echoed_back(self, mocker):
+        mocker.patch("services.version.BACKEND_VERSION", "3.0.0")
+        mocker.patch("services.version.BACKEND_RELEASE_TAG", "v3.0.0")
+        mocker.patch("services.version.BACKEND_BUILD", 99)
+
+        result = check_plugin_backend_version(
+            "3.0.0", plugin_build=7, plugin_release_tag="v3.0.0"
+        )
+
+        assert result["backend_version"] == "3.0.0"
+        assert result["backend_build"] == 99
+        assert result["plugin_build"] == 7
+        assert result["plugin_release_tag"] == "v3.0.0"


### PR DESCRIPTION
Grows the test suite from 304 → 476 passing Python tests (+172) and
adds 67 new Lua spec cases in util_advanced_spec.lua.

New Python test files:
- test_service_version.py (31): _normalize_version, _is_dev_backend,
  _is_default_dev_plugin, check_plugin_backend_version (dev fallback,
  exact match, mismatch, missing/invalid version)
- test_service_exif.py (37): _parse_iptc byte parsing, _dms_to_decimal
  (plain + rational tuple forms), format_location_for_prompt (structured
  vs GPS fallback), extract_location_tags (invalid/empty JPEG)
- test_service_search_helpers.py (58): _clamp_max_results,
  _clamp_strictness, _strictness_to_k, _merge_semantic_results,
  _transform_and_sort_results, _transform_vertex_results,
  _normalize_search_sources, _smart_filter_by_relevance
- test_routes_search_helpers.py (20): _parse_grouping_params success
  paths and all validation error branches (bad thresholds, invalid
  preset, missing/non-list photo_ids)
- test_service_import.py (22): import_metadata_task — new vs existing
  records, catalog_id threading, missing photo_id, empty metadata,
  exception isolation, multi-item batch counts
- test_routes_faces.py (21): all /faces/* endpoints (detect, query,
  cluster, persons list/thumbnail/name/photos) — happy paths, 400/500
  error branches, invalid base64
- test_routes_edit_helpers.py (14): _has_items (None, empty/non-empty
  list/dict, TypeError), _success_payload (required fields, warning
  opt-in, edit_rundate present, missing summary/warnings defaults)

New Lua spec file:
- plugin/spec/util_advanced_spec.lua (67 cases): dumpTable (array
  order, nested tables, cycle detection, api_key/base64 redaction),
  nilOrEmpty edge cases, extractAllKeywords (flat/nested/leaf-objects/
  deduplication/synonyms), buildHierarchyFromPaths (flat/2-level/3-level/
  synonyms/aliases/shared parents), keywordTableToHierarchyStringList,
  keywordTableToStringList, formatTimestampSafe string transform rule

https://claude.ai/code/session_019aHDhu3cHhniCevDMCS75p