### PR TITLE
fix: deduplicate photo IDs in get_images_batch to prevent delta mode reset

### DIFF
--- a/server/src/services/chroma.py
+++ b/server/src/services/chroma.py
@@ -340,7 +340,9 @@ def get_images_batch(photo_ids: list, *, catalog_id=None) -> dict:
     if collection is None or not photo_ids:
         return {}
     normalized = [_normalize_photo_id(pid) for pid in photo_ids]
-    valid = [pid for pid in normalized if pid]
+    valid = list(
+        dict.fromkeys(pid for pid in normalized if pid)
+    )  # dedupe, preserve order
     if not valid:
         return {}
 


### PR DESCRIPTION
## Summary
- `get_images_batch` was passing duplicate IDs to ChromaDB's `collection.get()`, which throws "Expected IDs to be unique"
- The exception was silently swallowed, leaving `existing_records` empty
- `check-unprocessed` then reported all photos as needing processing, resetting delta mode on every run
- Fix: deduplicate the ID list with `dict.fromkeys()` before chunking/querying (preserves order)

## Root cause from logs
```
get_images_batch failed: Expected IDs to be unique, found 42 duplicated IDs: ...
check-unprocessed: 13405 of 13405 photos need processing
```

## Test plan
- [ ] Run delta mode on a catalog with previously processed photos — should report 0 needing processing (not the full count)
- [ ] Confirm `get_images_batch` no longer warns about duplicate IDs in the server log

🤖 Generated with [Claude Code](https://claude.com/claude-code)