### PR TITLE
fix: send catalog keyword vocabulary from plugin to backend

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua
@@ -650,6 +650,11 @@ local function showAiEditDialog(ctx)
 		providerFromKey = props.modelKey
 	end
 
+	local catalogKeywords = MetadataManager.collectCatalogKeywordNames(
+		LrApplication.activeCatalog(),
+		500
+	)
+
 	local options = {
 		scope = props.scope,
 		provider = providerFromKey,
@@ -678,6 +683,7 @@ local function showAiEditDialog(ctx)
 		submit_folder_names = props.submitFolderName,
 		showPhotoContextDialog = props.showPhotoContextDialog,
 		use_training_style = props.useTrainingStyle ~= false,
+		catalog_keywords = (catalogKeywords and #catalogKeywords > 0) and catalogKeywords or nil,
 	}
 
 	if providerFromKey == "chatgpt" then

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -882,6 +882,16 @@ LrTasks.startAsyncTask(function()
 			end
 		end
 
+		-- Send flat catalog keyword vocabulary for LLM context
+		-- (limited to 500 to avoid overflowing the prompt)
+		local catalogKeywords = MetadataManager.collectCatalogKeywordNames(
+			LrApplication.activeCatalog(),
+			500
+		)
+		if catalogKeywords and #catalogKeywords > 0 then
+			options.catalog_keywords = catalogKeywords
+		end
+
 		-- Create progress scope
 		local progressScope = LrProgressScope({
 			title = LOC("$$$/LrGeniusAI/AnalyzeAndIndex/ProgressTitle=Processing photos..."),

--- a/server/src/providers/base.py
+++ b/server/src/providers/base.py
@@ -784,15 +784,73 @@ class LLMProviderBase(ABC):
         return None
 
     @final
-    def _normalize_keywords_structure(self, value: Any) -> Any:
+    def _normalize_keywords_structure(
+        self, value: Any, catalog_keywords: list[str] | None = None
+    ) -> Any:
+        """
+        Normalize keyword structure from LLM response.
+
+        When catalog_keywords is provided, also:
+        - Deduplicates keywords (case-insensitive) within the returned list
+        - Normalizes keyword names to match the existing catalog vocabulary
+          (e.g. LLM returns "frühling" → uses "Frühling" from catalog)
+        - This prevents creating duplicate Lightroom keywords that differ only
+          in casing or minor spelling from existing catalog entries.
+
+        Args:
+            value: Raw keyword data from LLM (list, dict, or string)
+            catalog_keywords: Optional flat list of existing catalog keyword names
+                             for deduplication and name normalization
+
+        Returns:
+            Normalized keyword structure
+        """
+        # Build a case-insensitive lookup from catalog vocabulary for
+        # name normalization: "frühling" → "Frühling" (canonical catalog name)
+        catalog_lookup: dict[str, str] | None = None
+        if catalog_keywords:
+            catalog_lookup = {}
+            for name in catalog_keywords:
+                if isinstance(name, str) and name.strip():
+                    catalog_lookup[name.strip().lower()] = name.strip()
+
+        # Track seen names (lowercase) to remove duplicates within the response
+        seen_lower: set[str] = set()
+
+        def _resolve_name(name: str) -> str | None:
+            """Normalize keyword name: dedup + prefer catalog spelling."""
+            cleaned = name.strip()
+            if not cleaned:
+                return None
+            lower = cleaned.lower()
+            # Use catalog's canonical spelling if available (case-insensitive match)
+            if catalog_lookup and lower in catalog_lookup:
+                return catalog_lookup[lower]
+            return cleaned
+
         if isinstance(value, list):
             normalized_list: list[Any] = []
             for item in value:
                 normalized_leaf = self._normalize_keyword_leaf(item)
                 if normalized_leaf is not None:
-                    normalized_list.append(normalized_leaf)
+                    # Apply dedup + catalog name normalization
+                    leaf_name: str | None = None
+                    if isinstance(normalized_leaf, str):
+                        leaf_name = _resolve_name(normalized_leaf)
+                    elif isinstance(normalized_leaf, dict):
+                        raw = normalized_leaf.get("name")
+                        if isinstance(raw, str):
+                            resolved = _resolve_name(raw)
+                            if resolved:
+                                normalized_leaf["name"] = resolved
+                                leaf_name = resolved.lower()
+                    if leaf_name:
+                        key = leaf_name.lower() if isinstance(leaf_name, str) else ""
+                        if key and key not in seen_lower:
+                            seen_lower.add(key)
+                            normalized_list.append(normalized_leaf)
                 elif isinstance(item, (dict, list)):
-                    nested = self._normalize_keywords_structure(item)
+                    nested = self._normalize_keywords_structure(item, catalog_keywords)
                     if nested not in (None, {}, []):
                         normalized_list.append(nested)
             return normalized_list
@@ -803,13 +861,23 @@ class LLMProviderBase(ABC):
 
             normalized_dict: dict[str, Any] = {}
             for key, item in value.items():
-                normalized_item = self._normalize_keywords_structure(item)
+                normalized_item = self._normalize_keywords_structure(
+                    item, catalog_keywords
+                )
                 if normalized_item in (None, {}, []):
                     continue
                 normalized_dict[key] = normalized_item
             return normalized_dict
 
         normalized_leaf = self._normalize_keyword_leaf(value)
+        if isinstance(normalized_leaf, str):
+            resolved = _resolve_name(normalized_leaf)
+            if resolved:
+                r_lower = resolved.lower()
+                if r_lower not in seen_lower:
+                    seen_lower.add(r_lower)
+                    return resolved
+            return None
         return normalized_leaf
 
     def _prepare_edit_response_structure(self) -> dict[str, Any]:

--- a/server/src/providers/chatgpt.py
+++ b/server/src/providers/chatgpt.py
@@ -213,7 +213,8 @@ class ChatGPTProvider(LLMProviderBase):
 
             # Extract metadata
             keywords = self._normalize_keywords_structure(
-                parsed_data.get("keywords", [])
+                parsed_data.get("keywords", []),
+                catalog_keywords=request.catalog_keywords,
             )
 
             caption = parsed_data.get("caption") if request.generate_caption else None

--- a/server/src/providers/gemini.py
+++ b/server/src/providers/gemini.py
@@ -261,7 +261,8 @@ class GeminiProvider(LLMProviderBase):
 
             # Extract metadata
             keywords = self._normalize_keywords_structure(
-                parsed_data.get("keywords", [])
+                parsed_data.get("keywords", []),
+                catalog_keywords=request.catalog_keywords,
             )
             # logger.debug(f"Extracted keywords: {keywords} .. type: {type(keywords)}")
 

--- a/server/src/providers/lmstudio.py
+++ b/server/src/providers/lmstudio.py
@@ -140,7 +140,10 @@ class LMStudioProvider(LLMProviderBase):
                 )
 
             # Extract metadata
-            keywords = self._normalize_keywords_structure(content.get("keywords", []))
+            keywords = self._normalize_keywords_structure(
+                content.get("keywords", []),
+                catalog_keywords=request.catalog_keywords,
+            )
 
             caption = content.get("caption") if request.generate_caption else None
             title = content.get("title") if request.generate_title else None

--- a/server/src/providers/ollama.py
+++ b/server/src/providers/ollama.py
@@ -154,7 +154,8 @@ class OllamaProvider(LLMProviderBase):
 
             # Extract metadata
             keywords = self._normalize_keywords_structure(
-                parsed_data.get("keywords", [])
+                parsed_data.get("keywords", []),
+                catalog_keywords=request.catalog_keywords,
             )
             caption = parsed_data.get("caption") if request.generate_caption else None
             title = parsed_data.get("title") if request.generate_title else None


### PR DESCRIPTION
## Description

The backend already supports sending the full catalog keyword vocabulary to the LLM via the `catalog_keywords` field in `MetadataGenerationRequest`, and injects it into the prompt. However, the Lua plugin never populated this field.

## Changes

### Plugin (Lua)
- **TaskAnalyzeAndIndex.lua**: Call `MetadataManager.collectCatalogKeywordNames()` (limit 500) and pass as `options.catalog_keywords`
- **TaskAiEditPhotos.lua**: Same for the AI edit path

### Backend (Python)
- **base.py** (`_normalize_keywords_structure`): Added deduplication (case-insensitive) and catalog name normalization within the response. If the LLM returns "fruehling" and the catalog has "Fruehling", the canonical catalog spelling is used
- All providers (ollama, chatgpt, gemini, lmstudio): Pass `request.catalog_keywords` to the normalization function

## Related Issues
Closes #213
