### PR TITLE
fix(docker): install libprotobuf-dev for well-known-types protos

### DIFF
--- a/server-rs/Dockerfile
+++ b/server-rs/Dockerfile
@@ -15,10 +15,14 @@ WORKDIR /app
 # pkg-config + libssl-dev: openssl-sys (reqwest's native-tls, ureq in ort-sys)
 # links against the system OpenSSL rather than vendoring it.
 # protobuf-compiler: prost-build (pulled in transitively by lancedb/lance).
+# libprotobuf-dev: ships the well-known-types .proto files (google/protobuf/empty.proto
+# etc.) under /usr/include — protobuf-compiler only provides the protoc binary itself,
+# and lance-encoding's build script imports empty.proto.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     protobuf-compiler \
+    libprotobuf-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Baked in via option_env!() at compile time (lrg-common::version) — same


### PR DESCRIPTION
## Summary
- Docker build of `server-rs` failed compiling `lance-encoding v8.0.0`: `protoc failed: google/protobuf/empty.proto: File not found`
- `protobuf-compiler` only provides the `protoc` binary on Debian; the well-known-types `.proto` files (`google/protobuf/empty.proto`, etc.) ship in the separate `libprotobuf-dev` package
- Add `libprotobuf-dev` to the builder stage's apt install

## Test plan
- [ ] `docker build -t geniusai-server -f server-rs/Dockerfile server-rs` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)