### PR TITLE
fix(plugin): apply top-level keyword when hierarchy is disabled

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/MetadataManager.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/MetadataManager.lua
@@ -165,8 +165,12 @@ function MetadataManager.applyMetadata(photo, response, validatedData, options)
 			)
 		end
 
+		-- The top-level keyword is the container for every generated keyword and is
+		-- independent of the hierarchy setting: hierarchy only controls whether the LLM
+		-- groups keywords into categories underneath it. With hierarchy off the keywords
+		-- become one flat level of children here rather than moving to catalog root.
 		local topKeyword = nil
-		if prefs.useKeywordHierarchy and options.useTopLevelKeyword then
+		if options.useTopLevelKeyword then
 			catalog:withWriteAccessDo(
 				"$$$/lrc-ai-assistant/AnalyzeImageTask/saveTopKeyword=Save AI generated keywords",
 				function()
@@ -193,7 +197,10 @@ function MetadataManager.applyMetadata(photo, response, validatedData, options)
 				end
 			)
 			-- Keep track of used top-level keywords
-			if not Util.table_contains(prefs.knownTopLevelKeywords, options.topLevelKeyword) then
+			if
+				options.topLevelKeyword
+				and not Util.table_contains(prefs.knownTopLevelKeywords, options.topLevelKeyword)
+			then
 				table.insert(prefs.knownTopLevelKeywords, options.topLevelKeyword)
 			end
 		end
@@ -782,7 +789,10 @@ function MetadataManager.addKeywordRecursively(
 					then
 						log:trace("Skipping keyword: " .. tostring(keywordName) .. " as it is reserved.")
 					else
-						local currentParent = prefs.useKeywordHierarchy and parent or nil
+						-- `parent` is already the correct target in both modes: the enclosing
+						-- category with hierarchy on, the top-level keyword (or nil) with
+						-- hierarchy off — the recursion below keeps it pinned there.
+						local currentParent = parent
 
 						-- Bilingual translations + their same-language aliases all land in the
 						-- LR synonym field of the primary keyword. The primary's own aliases
@@ -807,11 +817,14 @@ function MetadataManager.addKeywordRecursively(
 			end
 		end
 		if type(value) == "table" and not isKeywordLeafObject(value) then
+			-- Hierarchy off: never deepen the tree. Keep handing the same parent down so a
+			-- nested response still lands as one flat level under the top-level keyword.
+			local childParent = prefs.useKeywordHierarchy and keyword or parent
 			MetadataManager.addKeywordRecursively(
 				photo,
 				catalog,
 				value,
-				keyword,
+				childParent,
 				existingKeywordNames,
 				currentTopLevelKeyword,
 				sessionCache


### PR DESCRIPTION
## Problem

The top-level keyword is not respected when keyword hierarchy is disabled — the generated keywords land flat at catalog root and the top-level keyword itself is never created.

The two settings are orthogonal: **hierarchy** only controls whether the LLM groups keywords into categories (`options.keyword_categories`, built in `TaskAnalyzeAndIndex.lua`), while the **top-level keyword** is the container all generated keywords live under. `MetadataManager.applyMetadata` conflated them and gated the entire top-level-keyword block — create the keyword, merge its marker synonym, `photo:addKeyword(topKeyword)` — behind `prefs.useKeywordHierarchy`.

The dialog leaves the checkbox and text field fully enabled regardless of the hierarchy setting and persists both to prefs, so a user turning hierarchy off silently loses the container. Worse, the name was still *reserved* (`addKeywordRecursively` skips a generated keyword matching `currentTopLevelKeyword`), so in flat mode the setting only ever suppressed a keyword instead of applying one.

## Changes

- Create and apply the top-level keyword whenever `useTopLevelKeyword` is set, independent of the hierarchy setting, and parent the generated keywords under it in both modes.
- With hierarchy off, hand the same parent down the recursion instead of the just-created keyword, so a nested response collapses to one flat level of children under the top-level keyword rather than deepening the tree.
- Guard the `knownTopLevelKeywords` bookkeeping against a nil `options.topLevelKeyword`, now reachable in flat mode.

Resulting layout with hierarchy off and top-level keyword `LrGeniusAI`:

```
LrGeniusAI
├── Dog
├── Beach
└── Sunset
```

The alias/de-clutter index stays scoped to the top-level keyword's subtree, which remains correct now that keywords live under it in both modes.

## Testing

`stylua` and `luacheck` clean, `busted` 102/102 passing.

Not yet verified inside Lightroom. The earlier iteration of this fix was tested there by the
author and applied the top-level keyword flat instead of as a parent, which is what this
version corrects — so a re-run with hierarchy off + top-level keyword on is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
