### PR TITLE
fix(server): honor custom prompt and date_time on the index routes

### DIFF
--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -60,6 +60,11 @@ struct MetadataOptions {
     existing_keywords: Option<Vec<String>>,
     folder_names: Option<String>,
     user_context: Option<String>,
+    /// Custom system prompt from the plugin's "Instructions / Prompt" field
+    /// (multipart/JSON field `prompt`). `None` falls back to
+    /// `DEFAULT_SYSTEM_PROMPT`.
+    system_prompt: Option<String>,
+    date_time: Option<String>,
     keyword_categories: Option<KeywordCategories>,
     bilingual_keywords: bool,
     keyword_secondary_language: Option<String>,
@@ -222,6 +227,14 @@ pub(crate) fn parse_options(fields: &HashMap<String, String>) -> ParsedOptions {
             existing_keywords,
             folder_names: fields.get("folder_names").cloned(),
             user_context: fields.get("user_context").cloned(),
+            system_prompt: fields
+                .get("prompt")
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
+            date_time: fields
+                .get("date_time")
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
             keyword_categories: fields
                 .get("keyword_categories")
                 .and_then(|raw| parse_keyword_categories(raw)),
@@ -891,7 +904,7 @@ async fn generate_metadata_for_photo(
         language: mo.language.clone(),
         temperature: mo.temperature,
         max_tokens: mo.max_tokens,
-        system_prompt: None,
+        system_prompt: mo.system_prompt.clone(),
         user_prompt: None,
         submit_keywords: mo.submit_keywords,
         submit_folder_names: mo.submit_folder_names,
@@ -899,7 +912,7 @@ async fn generate_metadata_for_photo(
         location_data,
         folder_names: mo.folder_names.clone(),
         user_context: mo.user_context.clone(),
-        date_time: None,
+        date_time: mo.date_time.clone(),
         keyword_categories: mo.keyword_categories.clone(),
         bilingual_keywords: mo.bilingual_keywords,
         keyword_secondary_language: mo.keyword_secondary_language.clone(),
@@ -993,6 +1006,29 @@ mod keyword_option_tests {
         assert!(parse_options(&fields(&[]))
             .metadata_request
             .keyword_categories
+            .is_none());
+    }
+
+    #[test]
+    fn custom_prompt_and_date_time_are_wired() {
+        let opts = parse_options(&fields(&[
+            ("prompt", "  You are a bird expert.  "),
+            ("date_time", "2026-07-28 11:18:22"),
+        ]));
+        let mo = &opts.metadata_request;
+        assert_eq!(mo.system_prompt.as_deref(), Some("You are a bird expert."));
+        assert_eq!(mo.date_time.as_deref(), Some("2026-07-28 11:18:22"));
+    }
+
+    #[test]
+    fn blank_or_absent_prompt_falls_back_to_default() {
+        assert!(parse_options(&fields(&[("prompt", "   ")]))
+            .metadata_request
+            .system_prompt
+            .is_none());
+        assert!(parse_options(&fields(&[]))
+            .metadata_request
+            .system_prompt
             .is_none());
     }
 


### PR DESCRIPTION
## Problem

The prompt entered in the Lightroom GUI ("Instructions / Prompt" in the Analyze & Index dialog) had no effect on analysis results.

The plugin was sending it correctly all along — `TaskAnalyzeAndIndex.lua:787` puts `props.selectedPrompt` into the options, and `APISearchIndex.lua` sends it as the `prompt` field on both `/index` (multipart) and `/index_by_reference` (JSON). The backend threw it away:

- `parse_options()` in `index_upload.rs` never read the `prompt` field, so it wasn't in `MetadataOptions` at all.
- The `MetadataGenerationRequest` was built with a hardcoded `system_prompt: None`, so `prepare_system_prompt()` always fell back to `DEFAULT_SYSTEM_PROMPT`.

`/edit` already wired this up correctly (`edit.rs:367`), which is why the AI-edit prompt works — only the analyze/index path was missing it.

`date_time` had the same shape of gap: parsed into `capture_time` for storage, but the request's `date_time` — consumed by `prepare_user_prompt` for the "Photo taken on:" context line — was hardcoded `None`.

## Fix

All in `crates/lrg-api/src/routes/index_upload.rs`:

- Add `system_prompt` and `date_time` to `MetadataOptions`, parsed from the `prompt` / `date_time` fields, trimmed, with blank treated as absent so the default prompt still applies.
- Pass both through into `MetadataGenerationRequest`.
- Two new unit tests covering both fields and the blank-prompt fallback.

Both `/index` and `/index_by_reference` funnel through `parse_options`, so one fix covers both.

No plugin changes needed — this requires a rebuilt backend binary to take effect.

## Testing

`cargo fmt`, `cargo clippy --workspace --all-targets`, and `cargo test -p lrg-api` all clean.

Live-tested against the running binary + LM Studio (gemma-4-e4b), with a prompt instructing the model to ignore the image and emit a sentinel keyword:

- `/index` → `{"keywords":["PROMPTWORKS"]}`
- `/index_by_reference` → `{"keywords":["BYREFWORKS","BYREFWORKS"]}`

Both returned image-derived keywords before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)