### PR TITLE
fix(server): stop unbounded memory growth from onnxruntime KleidiAI convs

### DIFF
--- a/server-rs/Cargo.lock
+++ b/server-rs/Cargo.lock
@@ -4953,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "ndarray 0.17.2",
  "ort-sys",
@@ -4966,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",

--- a/server-rs/crates/lrg-ml/Cargo.toml
+++ b/server-rs/crates/lrg-ml/Cargo.toml
@@ -6,13 +6,20 @@ license.workspace = true
 
 [dependencies]
 lrg-imaging.workspace = true
-ort = { version = "2.0.0-rc.13", features = ["coreml"] }
+ort = "2.0.0-rc.13"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 ndarray = "0.16"
 thiserror = "2"
 log.workspace = true
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg"] }
+
+# CoreML is macOS-only, and ort ships no prebuilt binary satisfying the
+# `coreml` feature for any other target — requesting it unconditionally
+# fails the Linux link with "no builds available that satisfy the requested
+# feature set". Keep it scoped to the one platform that can use it.
+[target.'cfg(target_os = "macos")'.dependencies]
+ort = { version = "2.0.0-rc.13", features = ["coreml"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/server-rs/crates/lrg-ml/Cargo.toml
+++ b/server-rs/crates/lrg-ml/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 lrg-imaging.workspace = true
-ort = { version = "2.0.0-rc.10", features = ["coreml"] }
+ort = { version = "2.0.0-rc.13", features = ["coreml"] }
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 ndarray = "0.16"
 thiserror = "2"

--- a/server-rs/crates/lrg-ml/examples/bench_image.rs
+++ b/server-rs/crates/lrg-ml/examples/bench_image.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use ort::ep::{CoreML, CPU};
+use ort::ep::CPU;
 use ort::session::Session;
 use ort::value::Tensor;
 
@@ -18,8 +18,12 @@ fn main() -> ort::Result<()> {
 
     let builder = Session::builder()?;
     let mut builder = match ep.as_str() {
+        // CoreML is only linked in on macOS — see the target-scoped `ort`
+        // dependency in Cargo.toml.
+        #[cfg(target_os = "macos")]
         "coreml" => {
             use ort::ep::coreml::{ComputeUnits, ModelFormat};
+            use ort::ep::CoreML;
             builder.with_execution_providers([CoreML::default()
                 .with_model_format(ModelFormat::MLProgram)
                 .with_compute_units(ComputeUnits::All)

--- a/server-rs/crates/lrg-ml/examples/bench_image.rs
+++ b/server-rs/crates/lrg-ml/examples/bench_image.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use ort::execution_providers::{CPUExecutionProvider, CoreMLExecutionProvider};
+use ort::ep::{CoreML, CPU};
 use ort::session::Session;
 use ort::value::Tensor;
 
@@ -19,8 +19,8 @@ fn main() -> ort::Result<()> {
     let builder = Session::builder()?;
     let mut builder = match ep.as_str() {
         "coreml" => {
-            use ort::execution_providers::coreml::{ComputeUnits, ModelFormat};
-            builder.with_execution_providers([CoreMLExecutionProvider::default()
+            use ort::ep::coreml::{ComputeUnits, ModelFormat};
+            builder.with_execution_providers([CoreML::default()
                 .with_model_format(ModelFormat::MLProgram)
                 .with_compute_units(ComputeUnits::All)
                 .with_static_input_shapes(true)
@@ -28,7 +28,7 @@ fn main() -> ort::Result<()> {
                 .build()
                 .error_on_failure()])?
         }
-        _ => builder.with_execution_providers([CPUExecutionProvider::default().build()])?,
+        _ => builder.with_execution_providers([CPU::default().build()])?,
     };
 
     let load_start = Instant::now();

--- a/server-rs/crates/lrg-ml/src/faces.rs
+++ b/server-rs/crates/lrg-ml/src/faces.rs
@@ -118,9 +118,15 @@ fn thumbnail_112_jpeg(crop: &[u8], cw: usize, ch: usize) -> String {
 /// `detect_faces` call that never comes back down. Falling back to plain
 /// malloc/free per allocation is slower per call but keeps steady-state
 /// memory bounded, which matters far more for a long indexing run.
+///
+/// Also disables MLAS's KleidiAI convolution kernels — see
+/// [`crate::DISABLE_KLEIDIAI`]. SCRFD is convolution-heavy and ran every
+/// single `Session::run` through the leaking path, which made this the
+/// single largest source of memory growth during indexing.
 fn build_session(path: &Path) -> ort::Result<Session> {
     Session::builder()?
         .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?
+        .with_config_entry(crate::DISABLE_KLEIDIAI, "1")?
         .commit_from_file(path)
 }
 

--- a/server-rs/crates/lrg-ml/src/lib.rs
+++ b/server-rs/crates/lrg-ml/src/lib.rs
@@ -1,6 +1,21 @@
 //! ONNX inference: SigLIP2 image/text embedding via `ort`. Face pipeline
 //! (SCRFD + ArcFace) lands in M5.
 
+/// Session config key that turns off MLAS's KleidiAI convolution kernels
+/// (onnxruntime >= 1.25).
+///
+/// Those kernels leak: `ArmKleidiAI::MlasConv` allocates a workspace with
+/// `operator new` on every convolution and never frees it. Measured on
+/// arm64 macOS with `malloc_history`, a face-detection indexing run
+/// retained ~31 MB per photo, 89% of it under that one frame — a 14k-photo
+/// catalog reached a 45 GB footprint on a 24 GB machine. The allocations
+/// are orphaned rather than owned by the session, so dropping and
+/// rebuilding the session does not reclaim them; the only fix available
+/// from the API side is to not take the KleidiAI path at all.
+///
+/// The key is ignored on non-arm64 builds, where these kernels don't exist.
+pub const DISABLE_KLEIDIAI: &str = "mlas.disable_kleidiai";
+
 pub mod arcface;
 pub mod cv2_resize;
 pub mod face_quality;

--- a/server-rs/crates/lrg-ml/src/siglip.rs
+++ b/server-rs/crates/lrg-ml/src/siglip.rs
@@ -75,9 +75,9 @@ fn build_session(path: &Path) -> ort::Result<Session> {
     let mut builder = Session::builder()?;
     #[cfg(target_os = "macos")]
     if std::env::var("LRG_ML_EP").as_deref() == Ok("coreml") {
-        use ort::execution_providers::coreml::{ComputeUnits, ModelFormat};
-        use ort::execution_providers::CoreMLExecutionProvider;
-        builder = builder.with_execution_providers([CoreMLExecutionProvider::default()
+        use ort::ep::coreml::{ComputeUnits, ModelFormat};
+        use ort::ep::CoreML;
+        builder = builder.with_execution_providers([CoreML::default()
             .with_model_format(ModelFormat::MLProgram)
             .with_compute_units(ComputeUnits::All)
             .with_model_cache_dir(std::env::temp_dir().join("lrg-coreml-cache").display())
@@ -90,6 +90,11 @@ fn build_session(path: &Path) -> ort::Result<Session> {
     // CPU-only platforms. See faces::build_session for the full writeup.
     builder = builder
         .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?;
+    // Same leaking KleidiAI convolution kernels as the face sessions (see
+    // `crate::DISABLE_KLEIDIAI`). SigLIP is attention-heavy rather than
+    // convolution-heavy, so it leaked far less per call than SCRFD — but
+    // its patch-embedding conv still runs once per image.
+    builder = builder.with_config_entry(crate::DISABLE_KLEIDIAI, "1")?;
     builder.commit_from_file(path)
 }
 


### PR DESCRIPTION
## Problem

A release-build indexing run on a 14k-photo catalog reached **45 GB phys_footprint on a 24 GB machine** (swap 13 GB, machine thrashing). `ps` RSS read only 3.8 GB — the rest was compressed/swapped, so RSS was actively misleading here.

This is the fourth occurrence of the indexing-OOM class, but a genuinely new mechanism. The LanceDB-defaults and per-photo `scan_meta` fixes were both intact and working; the whole decode/RAW/pHash/store path measured flat at **1.4 MB/photo**.

## Root cause

onnxruntime's ARM KleidiAI convolution kernels leak. `ArmKleidiAI::MlasConv` allocates a workspace with C++ `operator new` on every convolution and never frees it. Symbolicated `malloc_history` attributed **89.4% of all retained bytes** to that single stack frame:

```
lrg_ml::faces::FaceModel::detect_faces (faces.rs:205)
  -> ort::session::Session::run
    -> onnxruntime::Conv<float>::Compute
      -> MlasConv
        -> ArmKleidiAI::MlasConv
          -> operator new          <-- never freed
```

SCRFD (`det_10g.onnx`) is convolution-heavy and runs once per photo, so face detection dominated. SigLIP is attention-heavy and leaked far less, but its patch-embedding conv takes the same path.

Isolation by task, 100 photos each:

| tasks | per photo |
|---|---|
| none (decode + pHash + culling + store) | 1.4 MB |
| embeddings (SigLIP) | 4.0 MB |
| **faces (SCRFD + ArcFace)** | **30.9 MB** |

Only 7 of those 100 photos contained a face, so the cost is the per-photo detection run, not ArcFace.

## Fix

Set `mlas.disable_kleidiai=1` on the face and SigLIP sessions. That config key only exists in onnxruntime >= 1.25 (microsoft/onnxruntime#27136), which is what forces the `ort` rc.12 -> rc.13 bump (onnxruntime 1.24 -> 1.28). The CoreML EP also moved from `ort::execution_providers` to `ort::ep` in rc.13.

## Results

100 photos, identical work per run (same 100 successes, same 7 faces detected):

| config | before | after |
|---|---|---|
| faces only | 25.0 MB/photo | **0.7 MB/photo** |
| embeddings + faces | ~26 MB/photo | **1.1 MB/photo** |
| faces wall clock | 30.1 s | **13.4 s** (2.2x faster) |

Face detection got *faster* because removing the leaking kernel removed its allocation churn too.

## Compatibility

**No re-index needed.** Indexing the same photos with the old and new binaries and running identical searches gives identical result rankings, with distances equal to 4 decimals (largest difference 1 ulp, e.g. `0.9206` -> `0.9207`).

## Alternatives measured and rejected

- **Arena / memory-pattern knobs are irrelevant.** All four combinations of `with_arena_allocator` x `with_memory_pattern` leaked 23-27 MB/photo. The existing `with_arena_allocator(false)` is correctly wired to `DisableCpuMemArena`; it just addresses a different mechanism.
- **Session recycling cannot work.** `POST /unload` drops both sessions and reclaimed *nothing* (3853 MB before and after) — the allocations are orphaned, not owned by session state.

## Testing

- `cargo test --workspace`: 182 passed, 0 failed
- `cargo clippy --workspace --all-targets`: clean
- Verified live against the real release binary via `/index_by_reference`, per CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
