### PR TITLE
perf(server): re-enable KleidiAI kernels, ~3x faster indexing

### DIFF
--- a/server-rs/Cargo.lock
+++ b/server-rs/Cargo.lock
@@ -4953,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "ndarray 0.17.2",
  "ort-sys",
@@ -4966,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -78,6 +78,21 @@ are already ONNX. Point `INSIGHTFACE_ROOT` at the directory containing
 the same location `insightface`'s own Python library uses, so the files
 are very likely already there if you've used InsightFace before).
 
+### Troubleshooting: `LRG_DISABLE_KLEIDIAI`
+
+Setting `LRG_DISABLE_KLEIDIAI=1` turns off ONNX Runtime's arm64 KleidiAI
+convolution kernels for every session. It exists only as a field escape
+hatch: onnxruntime 1.24 leaked ~25-31 MB per photo in those kernels (a
+14k-photo indexing run reached a 45 GB footprint), which is fixed in the
+1.28 build we ship. If unbounded memory growth during indexing ever
+reappears on an arm64 machine, set this to confirm the cause before
+digging further.
+
+It costs roughly **3x indexing throughput on Apple Silicon**
+(measured end to end: SigLIP2 316 ms -> 952 ms per photo, face detection
+37 ms -> 60 ms), so leave it unset in normal use. Embeddings are
+unaffected either way — search rankings and distances are identical.
+
 ## Docker
 
 `Dockerfile` here builds and ships the compiled binary (multi-stage:

--- a/server-rs/crates/lrg-ml/Cargo.toml
+++ b/server-rs/crates/lrg-ml/Cargo.toml
@@ -6,13 +6,20 @@ license.workspace = true
 
 [dependencies]
 lrg-imaging.workspace = true
-ort = { version = "2.0.0-rc.13", features = ["coreml"] }
+ort = "2.0.0-rc.13"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 ndarray = "0.16"
 thiserror = "2"
 log.workspace = true
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg"] }
+
+# CoreML is macOS-only, and ort ships no prebuilt binary satisfying the
+# `coreml` feature for any other target — requesting it unconditionally
+# fails the Linux link with "no builds available that satisfy the requested
+# feature set". Keep it scoped to the one platform that can use it.
+[target.'cfg(target_os = "macos")'.dependencies]
+ort = { version = "2.0.0-rc.13", features = ["coreml"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/server-rs/crates/lrg-ml/Cargo.toml
+++ b/server-rs/crates/lrg-ml/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 lrg-imaging.workspace = true
-ort = { version = "2.0.0-rc.10", features = ["coreml"] }
+ort = { version = "2.0.0-rc.13", features = ["coreml"] }
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 ndarray = "0.16"
 thiserror = "2"

--- a/server-rs/crates/lrg-ml/examples/bench_image.rs
+++ b/server-rs/crates/lrg-ml/examples/bench_image.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use ort::ep::{CoreML, CPU};
+use ort::ep::CPU;
 use ort::session::Session;
 use ort::value::Tensor;
 
@@ -18,8 +18,12 @@ fn main() -> ort::Result<()> {
 
     let builder = Session::builder()?;
     let mut builder = match ep.as_str() {
+        // CoreML is only linked in on macOS — see the target-scoped `ort`
+        // dependency in Cargo.toml.
+        #[cfg(target_os = "macos")]
         "coreml" => {
             use ort::ep::coreml::{ComputeUnits, ModelFormat};
+            use ort::ep::CoreML;
             builder.with_execution_providers([CoreML::default()
                 .with_model_format(ModelFormat::MLProgram)
                 .with_compute_units(ComputeUnits::All)

--- a/server-rs/crates/lrg-ml/examples/bench_image.rs
+++ b/server-rs/crates/lrg-ml/examples/bench_image.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use ort::execution_providers::{CPUExecutionProvider, CoreMLExecutionProvider};
+use ort::ep::{CoreML, CPU};
 use ort::session::Session;
 use ort::value::Tensor;
 
@@ -19,8 +19,8 @@ fn main() -> ort::Result<()> {
     let builder = Session::builder()?;
     let mut builder = match ep.as_str() {
         "coreml" => {
-            use ort::execution_providers::coreml::{ComputeUnits, ModelFormat};
-            builder.with_execution_providers([CoreMLExecutionProvider::default()
+            use ort::ep::coreml::{ComputeUnits, ModelFormat};
+            builder.with_execution_providers([CoreML::default()
                 .with_model_format(ModelFormat::MLProgram)
                 .with_compute_units(ComputeUnits::All)
                 .with_static_input_shapes(true)
@@ -28,7 +28,7 @@ fn main() -> ort::Result<()> {
                 .build()
                 .error_on_failure()])?
         }
-        _ => builder.with_execution_providers([CPUExecutionProvider::default().build()])?,
+        _ => builder.with_execution_providers([CPU::default().build()])?,
     };
 
     let load_start = Instant::now();

--- a/server-rs/crates/lrg-ml/src/faces.rs
+++ b/server-rs/crates/lrg-ml/src/faces.rs
@@ -118,9 +118,15 @@ fn thumbnail_112_jpeg(crop: &[u8], cw: usize, ch: usize) -> String {
 /// `detect_faces` call that never comes back down. Falling back to plain
 /// malloc/free per allocation is slower per call but keeps steady-state
 /// memory bounded, which matters far more for a long indexing run.
+///
+/// Also disables MLAS's KleidiAI convolution kernels — see
+/// [`crate::DISABLE_KLEIDIAI`]. SCRFD is convolution-heavy and ran every
+/// single `Session::run` through the leaking path, which made this the
+/// single largest source of memory growth during indexing.
 fn build_session(path: &Path) -> ort::Result<Session> {
     Session::builder()?
         .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?
+        .with_config_entry(crate::DISABLE_KLEIDIAI, "1")?
         .commit_from_file(path)
 }
 

--- a/server-rs/crates/lrg-ml/src/faces.rs
+++ b/server-rs/crates/lrg-ml/src/faces.rs
@@ -119,15 +119,15 @@ fn thumbnail_112_jpeg(crop: &[u8], cw: usize, ch: usize) -> String {
 /// malloc/free per allocation is slower per call but keeps steady-state
 /// memory bounded, which matters far more for a long indexing run.
 ///
-/// Also disables MLAS's KleidiAI convolution kernels — see
-/// [`crate::DISABLE_KLEIDIAI`]. SCRFD is convolution-heavy and ran every
-/// single `Session::run` through the leaking path, which made this the
-/// single largest source of memory growth during indexing.
+/// SCRFD is convolution-heavy, so it used to be the single largest source
+/// of memory growth during indexing via onnxruntime's leaking KleidiAI
+/// kernels. That leak is gone as of onnxruntime 1.28 and these sessions run
+/// with KleidiAI enabled again — see [`crate::DISABLE_KLEIDIAI`] for the
+/// measurements and the `LRG_DISABLE_KLEIDIAI` escape hatch.
 fn build_session(path: &Path) -> ort::Result<Session> {
-    Session::builder()?
-        .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?
-        .with_config_entry(crate::DISABLE_KLEIDIAI, "1")?
-        .commit_from_file(path)
+    let builder = Session::builder()?
+        .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?;
+    crate::apply_kleidiai_policy(builder)?.commit_from_file(path)
 }
 
 impl FaceModel {

--- a/server-rs/crates/lrg-ml/src/lib.rs
+++ b/server-rs/crates/lrg-ml/src/lib.rs
@@ -2,19 +2,59 @@
 //! (SCRFD + ArcFace) lands in M5.
 
 /// Session config key that turns off MLAS's KleidiAI convolution kernels
-/// (onnxruntime >= 1.25).
+/// (onnxruntime >= 1.25). Ignored on non-arm64 builds, where these kernels
+/// don't exist.
 ///
-/// Those kernels leak: `ArmKleidiAI::MlasConv` allocates a workspace with
-/// `operator new` on every convolution and never frees it. Measured on
-/// arm64 macOS with `malloc_history`, a face-detection indexing run
-/// retained ~31 MB per photo, 89% of it under that one frame — a 14k-photo
-/// catalog reached a 45 GB footprint on a 24 GB machine. The allocations
-/// are orphaned rather than owned by the session, so dropping and
-/// rebuilding the session does not reclaim them; the only fix available
-/// from the API side is to not take the KleidiAI path at all.
+/// History: under onnxruntime 1.24 (`ort` 2.0.0-rc.12) these kernels leaked
+/// badly — `ArmKleidiAI::MlasConv` allocated a workspace with `operator new`
+/// on every convolution and never freed it, which `malloc_history` pinned as
+/// 89% of all retained bytes while a 14k-photo catalog grew to a 45 GB
+/// footprint on a 24 GB machine. That is why the sessions used to set this
+/// key unconditionally.
 ///
-/// The key is ignored on non-arm64 builds, where these kernels don't exist.
+/// **The leak is fixed as of onnxruntime 1.28 (rc.13), so we no longer set
+/// it.** The original fix bundled the rc.12 -> rc.13 upgrade together with
+/// this key and credited the key with the improvement; re-measuring the two
+/// changes separately showed the upgrade did all the work and the key only
+/// cost speed. Same-binary A/B on rc.13, arm64 macOS, CPU EP, per image:
+///
+/// | | KleidiAI on | off | |
+/// |---|---|---|---|
+/// | SigLIP embed | ~480 ms | ~1950 ms | 4.1x |
+/// | SCRFD + ArcFace | ~68 ms | ~140 ms | 2.1x |
+///
+/// and `footprint` over 200 images is flat either way (<= 0.01 MB/image on
+/// both sessions), versus the 25-31 MB/photo that rc.12 retained.
+/// Embeddings are bit-identical between the two paths (worst-case cosine
+/// 1.000000 across a real photo set), so no index is affected.
+///
+/// [`kleidiai_disabled`] is the escape hatch if a future onnxruntime or some
+/// other arm64 host regresses this.
 pub const DISABLE_KLEIDIAI: &str = "mlas.disable_kleidiai";
+
+/// Whether to opt out of the KleidiAI kernels, via `LRG_DISABLE_KLEIDIAI=1`.
+///
+/// Off by default — see [`DISABLE_KLEIDIAI`] for why the kernels are safe to
+/// use again. This exists so a leak regression can be diagnosed and worked
+/// around in the field without shipping a new binary; it costs 2-4x indexing
+/// throughput on arm64, so it is not something to set casually.
+pub fn kleidiai_disabled() -> bool {
+    std::env::var("LRG_DISABLE_KLEIDIAI").as_deref() == Ok("1")
+}
+
+/// Applies the KleidiAI policy above to a session builder.
+pub(crate) fn apply_kleidiai_policy(
+    builder: ort::session::builder::SessionBuilder,
+) -> ort::Result<ort::session::builder::SessionBuilder> {
+    if kleidiai_disabled() {
+        log::warn!(
+            "LRG_DISABLE_KLEIDIAI=1: disabling MLAS KleidiAI kernels, \
+             expect 2-4x slower inference on arm64"
+        );
+        return Ok(builder.with_config_entry(DISABLE_KLEIDIAI, "1")?);
+    }
+    Ok(builder)
+}
 
 pub mod arcface;
 pub mod cv2_resize;

--- a/server-rs/crates/lrg-ml/src/lib.rs
+++ b/server-rs/crates/lrg-ml/src/lib.rs
@@ -1,6 +1,21 @@
 //! ONNX inference: SigLIP2 image/text embedding via `ort`. Face pipeline
 //! (SCRFD + ArcFace) lands in M5.
 
+/// Session config key that turns off MLAS's KleidiAI convolution kernels
+/// (onnxruntime >= 1.25).
+///
+/// Those kernels leak: `ArmKleidiAI::MlasConv` allocates a workspace with
+/// `operator new` on every convolution and never frees it. Measured on
+/// arm64 macOS with `malloc_history`, a face-detection indexing run
+/// retained ~31 MB per photo, 89% of it under that one frame — a 14k-photo
+/// catalog reached a 45 GB footprint on a 24 GB machine. The allocations
+/// are orphaned rather than owned by the session, so dropping and
+/// rebuilding the session does not reclaim them; the only fix available
+/// from the API side is to not take the KleidiAI path at all.
+///
+/// The key is ignored on non-arm64 builds, where these kernels don't exist.
+pub const DISABLE_KLEIDIAI: &str = "mlas.disable_kleidiai";
+
 pub mod arcface;
 pub mod cv2_resize;
 pub mod face_quality;

--- a/server-rs/crates/lrg-ml/src/siglip.rs
+++ b/server-rs/crates/lrg-ml/src/siglip.rs
@@ -75,9 +75,9 @@ fn build_session(path: &Path) -> ort::Result<Session> {
     let mut builder = Session::builder()?;
     #[cfg(target_os = "macos")]
     if std::env::var("LRG_ML_EP").as_deref() == Ok("coreml") {
-        use ort::execution_providers::coreml::{ComputeUnits, ModelFormat};
-        use ort::execution_providers::CoreMLExecutionProvider;
-        builder = builder.with_execution_providers([CoreMLExecutionProvider::default()
+        use ort::ep::coreml::{ComputeUnits, ModelFormat};
+        use ort::ep::CoreML;
+        builder = builder.with_execution_providers([CoreML::default()
             .with_model_format(ModelFormat::MLProgram)
             .with_compute_units(ComputeUnits::All)
             .with_model_cache_dir(std::env::temp_dir().join("lrg-coreml-cache").display())
@@ -90,6 +90,11 @@ fn build_session(path: &Path) -> ort::Result<Session> {
     // CPU-only platforms. See faces::build_session for the full writeup.
     builder = builder
         .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?;
+    // Same leaking KleidiAI convolution kernels as the face sessions (see
+    // `crate::DISABLE_KLEIDIAI`). SigLIP is attention-heavy rather than
+    // convolution-heavy, so it leaked far less per call than SCRFD — but
+    // its patch-embedding conv still runs once per image.
+    builder = builder.with_config_entry(crate::DISABLE_KLEIDIAI, "1")?;
     builder.commit_from_file(path)
 }
 

--- a/server-rs/crates/lrg-ml/src/siglip.rs
+++ b/server-rs/crates/lrg-ml/src/siglip.rs
@@ -90,12 +90,9 @@ fn build_session(path: &Path) -> ort::Result<Session> {
     // CPU-only platforms. See faces::build_session for the full writeup.
     builder = builder
         .with_execution_providers([ort::ep::CPU::default().with_arena_allocator(false).build()])?;
-    // Same leaking KleidiAI convolution kernels as the face sessions (see
-    // `crate::DISABLE_KLEIDIAI`). SigLIP is attention-heavy rather than
-    // convolution-heavy, so it leaked far less per call than SCRFD — but
-    // its patch-embedding conv still runs once per image.
-    builder = builder.with_config_entry(crate::DISABLE_KLEIDIAI, "1")?;
-    builder.commit_from_file(path)
+    // KleidiAI is left enabled: it is worth ~4x on this tower and no longer
+    // leaks on onnxruntime 1.28. See `crate::DISABLE_KLEIDIAI`.
+    crate::apply_kleidiai_policy(builder)?.commit_from_file(path)
 }
 
 impl SiglipModel {


### PR DESCRIPTION
## Summary

`b7aae11` fixed the indexing memory leak by bundling two changes: the `ort` rc.12 → rc.13 upgrade (onnxruntime 1.24 → 1.28) **and** setting `mlas.disable_kleidiai` on every session. It credited the config key with both the memory fix and a 2.2x face-detection speedup.

Re-measuring the two changes separately shows **the upgrade did all the work, and the key only costs speed**. This PR stops setting it.

## The leak is gone in onnxruntime 1.28

`phys_footprint` over 200 images with KleidiAI *enabled*, on rc.13:

| session | growth |
|---|---|
| SigLIP image tower | ≤ 0.01 MB/image |
| SCRFD + ArcFace | 0.00 MB/photo |

Against the 25–31 MB/photo rc.12 retained. Flat in both cases, so the key buys nothing now.

## What it was costing

Same-binary A/B on rc.13 (arm64 macOS, CPU EP, real photos, order-reversed to rule out thermal effects), per image:

| | KleidiAI on | off (shipped) | |
|---|---|---|---|
| SigLIP embed | ~480 ms | ~1950 ms | **4.1x** |
| SCRFD + ArcFace | ~68 ms | ~140 ms | **2.1x** |

The earlier "2.2x faster" reading compared rc.12+KleidiAI against rc.13+no-KleidiAI, so it measured the version bump rather than the key.

Verified end to end through the running binary (`/index_by_reference`, 12 photos):

| | before | after | |
|---|---|---|---|
| SigLIP2 embed | 952 ms/photo | **316 ms/photo** | 3.0x |
| face detect | 60 ms/photo | **37 ms/photo** | 1.6x |

## Index compatibility

Embeddings are unchanged — worst-case cosine **1.000000** between the two CPU paths across a real photo set, and searching indexes built both ways returns identical rankings with distances equal to 3 decimals. **No re-index needed.**

## Escape hatch

`LRG_DISABLE_KLEIDIAI=1` still turns the key on, so a future onnxruntime regression can be diagnosed in the field without shipping a new binary. Documented in `server-rs/README.md`, and the measurements are recorded on `DISABLE_KLEIDIAI` so the next person doesn't have to redo them.

## Test plan

- [x] `cargo fmt` / `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` — 182 passed
- [x] Live `/index_by_reference` + `/search` against the release binary, both with and without the escape hatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
