### PR TITLE
fix(ci): install the Vulkan SDK and ship the ggml backends on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,62 @@ jobs:
             echo "::error::libclang.dll not found; bindgen cannot run" && exit 1
           fi
 
+      # Windows is the one target that enables llama.cpp's Vulkan backend (see
+      # crates/lrg-llama/Cargo.toml), and that needs the Vulkan SDK: without it
+      # llama-cpp-sys-2's build.rs panics outright ("Please install Vulkan SDK
+      # and ensure that VULKAN_SDK env variable is set"), because it links
+      # vulkan-1.lib from $VULKAN_SDK\Lib and ggml's CMake needs the SDK's
+      # glslc to compile the compute shaders. The version is pinned rather than
+      # tracking `latest` so an SDK release can never break a tagged build;
+      # bump it deliberately.
+      - name: Install Vulkan SDK (Windows)
+        if: matrix.os_name == 'windows'
+        shell: pwsh
+        env:
+          VULKAN_SDK_VERSION: '1.4.328.0'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = $env:VULKAN_SDK_VERSION
+          $installer = Join-Path $env:RUNNER_TEMP 'vulkan-sdk-installer.exe'
+          $base = "https://sdk.lunarg.com/sdk/download/$version/windows"
+          # LunarG renamed the Windows installer after 1.4.309.0. Try the
+          # current name first, then the old one, so bumping the pin in either
+          # direction keeps working.
+          $downloaded = $false
+          foreach ($name in @("vulkansdk-windows-X64-$version.exe", "VulkanSDK-$version-Installer.exe")) {
+            try {
+              Invoke-WebRequest -Uri "$base/$name" -OutFile $installer -UseBasicParsing
+              Write-Host "Downloaded $name"
+              $downloaded = $true
+              break
+            } catch {
+              Write-Host "Not available: $name ($($_.Exception.Message))"
+            }
+          }
+          if (-not $downloaded) {
+            throw "could not download Vulkan SDK $version from $base"
+          }
+
+          $sdkDir = "C:\VulkanSDK\$version"
+          # The installer is a Qt Installer Framework GUI binary, so the shell
+          # does not wait for it on its own — hence Start-Process -Wait.
+          $proc = Start-Process -FilePath $installer -Wait -PassThru -NoNewWindow -ArgumentList @(
+            '--root', $sdkDir, '--accept-licenses', '--default-answer', '--confirm-command', 'install'
+          )
+          if ($proc.ExitCode -ne 0) {
+            throw "Vulkan SDK installer exited with $($proc.ExitCode)"
+          }
+
+          foreach ($required in @("$sdkDir\Lib\vulkan-1.lib", "$sdkDir\Bin\glslc.exe")) {
+            if (-not (Test-Path $required)) {
+              throw "Vulkan SDK install incomplete: $required is missing"
+            }
+          }
+
+          "VULKAN_SDK=$sdkDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "$sdkDir\Bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          Write-Host "Vulkan SDK $version installed at $sdkDir"
+
       - name: Cache cargo registry and build artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,32 @@ jobs:
             echo "::error::libclang.dll not found; bindgen cannot run" && exit 1
           fi
 
+          # Build llama.cpp with Ninja instead of cmake's default Visual Studio
+          # generator. Not a preference — the VS generator cannot build the
+          # Vulkan backend here. ggml-vulkan generates its shaders with a host
+          # tool (`vulkan-shaders-gen`) pulled in via ExternalProject_Add, and
+          # that CMakeLists sets CMP0147 NEW, which asks MSBuild to run custom
+          # build steps in parallel. MSBuild then runs the external project's
+          # steps out of order, so the install step fires before the configure
+          # step has written cmake_install.cmake:
+          #
+          #   CMake error : Not a file: .../vulkan-shaders-gen-build/cmake_install.cmake
+          #   The system cannot find the batch label specified - VCEnd
+          #   error MSB8066: Custom build for '...vulkan-shaders-gen-install.rule;
+          #                  ...vulkan-shaders-gen-complete.rule' exited with code 1
+          #
+          # Ninja expresses those steps as ordinary dependency edges, so they
+          # cannot race, and it builds the whole thing faster besides. Only
+          # llama-cpp-sys-2 uses the cmake crate in this workspace, so this
+          # variable cannot affect any other dependency. cmake-rs skips the
+          # -A/-T flags for Ninja and passes cl.exe plus its INCLUDE/LIB/PATH
+          # environment through to cmake, which is also what lets the nested
+          # vulkan-shaders-gen configure step find a compiler.
+          if ! ninja --version; then
+            echo "::error::ninja not on PATH; the Vulkan build needs it" && exit 1
+          fi
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+
       # Windows is the one target that enables llama.cpp's Vulkan backend (see
       # crates/lrg-llama/Cargo.toml), and that needs the Vulkan SDK: without it
       # llama-cpp-sys-2's build.rs panics outright ("Please install Vulkan SDK
@@ -169,7 +195,7 @@ jobs:
         if: matrix.os_name == 'windows'
         shell: pwsh
         env:
-          VULKAN_SDK_VERSION: '1.4.328.0'
+          VULKAN_SDK_VERSION: '1.4.357.0'
         run: |
           $ErrorActionPreference = 'Stop'
           $installer = Join-Path $env:RUNNER_TEMP 'vulkan-sdk-installer.exe'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,33 @@ jobs:
           fi
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
 
+          # Build into a short target dir, because the Vulkan backend cannot be
+          # built from the default one on Windows. vulkan-shaders-gen is an
+          # ExternalProject nested inside OUT_DIR, so its build tree carries the
+          # whole prefix chain:
+          #
+          #   <target>/release/build/llama-cpp-sys-2-<hash>/out/build/ggml/src/
+          #   ggml-vulkan/vulkan-shaders-gen-prefix/src/vulkan-shaders-gen-build/
+          #   CMakeFiles/CMakeScratch/TryCompile-XXXXXX/CMakeFiles/cmTC_XXXXX.dir/
+          #
+          # From D:\a\LrGeniusAI\LrGeniusAI\server-rs\target that is 247 of the
+          # 250 characters CMake allows for an object path, and cl.exe resolves
+          # its relative /Fo against that directory — so the compiler check that
+          # opens the sub-build fails on MAX_PATH before any shader is compiled:
+          #
+          #   testCCompiler.c : fatal error C1083: Cannot open compiler
+          #                     generated file: '': Invalid argument
+          #   -- Check for working C compiler: .../cl.exe - broken
+          #
+          # `D:\t` is on the same volume the workspace already builds in and
+          # drops ~39 characters off every path, which clears the limit. Steps
+          # that read build output go through $TARGET_DIR for this reason — and
+          # it carries the POSIX spelling of the same directory, because the
+          # MSYS `find`/`cp` in those bash steps would read a `D:\...` argument
+          # as a relative path.
+          echo 'CARGO_TARGET_DIR=D:\t' >> "$GITHUB_ENV"
+          echo 'TARGET_DIR=/d/t' >> "$GITHUB_ENV"
+
       # Windows is the one target that enables llama.cpp's Vulkan backend (see
       # crates/lrg-llama/Cargo.toml), and that needs the Vulkan SDK: without it
       # llama-cpp-sys-2's build.rs panics outright ("Please install Vulkan SDK
@@ -271,7 +298,11 @@ jobs:
           set -euo pipefail
           BUILD_DIR="build/lrgenius-server"
           mkdir -p "$BUILD_DIR"
-          cp "server-rs/target/release/geniusai-server${{ matrix.bin_ext }}" "$BUILD_DIR/lrgenius-server${{ matrix.bin_ext }}"
+          # Windows overrides CARGO_TARGET_DIR to keep llama.cpp's build paths
+          # under MAX_PATH (see the prerequisites step); everywhere else the
+          # workspace default applies.
+          TARGET_DIR="${TARGET_DIR:-server-rs/target}"
+          cp "$TARGET_DIR/release/geniusai-server${{ matrix.bin_ext }}" "$BUILD_DIR/lrgenius-server${{ matrix.bin_ext }}"
           if [ "${{ matrix.os_name }}" != "windows" ]; then
             chmod +x "$BUILD_DIR/lrgenius-server"
           fi
@@ -297,8 +328,8 @@ jobs:
               cp "$dll" "$BUILD_DIR/"
               found=$((found + 1))
             done < <(
-              find server-rs/target/release -maxdepth 1 \( -name 'ggml*.dll' -o -name 'llama.dll' \) -print
-              find server-rs/target/release/build -path '*/out/backends/*' -name 'ggml*.dll' -print
+              find "$TARGET_DIR/release" -maxdepth 1 \( -name 'ggml*.dll' -o -name 'llama.dll' \) -print
+              find "$TARGET_DIR/release/build" -path '*/out/backends/*' -name 'ggml*.dll' -print
             )
             # llama.dll is not optional the way a backend module is: the exe
             # imports it directly and will not start without it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,9 +161,10 @@ jobs:
       # llama-cpp-sys-2's build.rs panics outright ("Please install Vulkan SDK
       # and ensure that VULKAN_SDK env variable is set"), because it links
       # vulkan-1.lib from $VULKAN_SDK\Lib and ggml's CMake needs the SDK's
-      # glslc to compile the compute shaders. The version is pinned rather than
-      # tracking `latest` so an SDK release can never break a tagged build;
-      # bump it deliberately.
+      # glslc to compile the compute shaders. A pinned version is preferred so
+      # an SDK release cannot silently change a tagged build, with a fallback
+      # to whatever LunarG currently calls latest so the release does not go
+      # down the day that pinned build is retired from their CDN.
       - name: Install Vulkan SDK (Windows)
         if: matrix.os_name == 'windows'
         shell: pwsh
@@ -171,25 +172,33 @@ jobs:
           VULKAN_SDK_VERSION: '1.4.328.0'
         run: |
           $ErrorActionPreference = 'Stop'
-          $version = $env:VULKAN_SDK_VERSION
           $installer = Join-Path $env:RUNNER_TEMP 'vulkan-sdk-installer.exe'
-          $base = "https://sdk.lunarg.com/sdk/download/$version/windows"
-          # LunarG renamed the Windows installer after 1.4.309.0. Try the
-          # current name first, then the old one, so bumping the pin in either
-          # direction keeps working.
-          $downloaded = $false
-          foreach ($name in @("vulkansdk-windows-X64-$version.exe", "VulkanSDK-$version-Installer.exe")) {
-            try {
-              Invoke-WebRequest -Uri "$base/$name" -OutFile $installer -UseBasicParsing
-              Write-Host "Downloaded $name"
-              $downloaded = $true
-              break
-            } catch {
-              Write-Host "Not available: $name ($($_.Exception.Message))"
+
+          # LunarG renamed the Windows installer after 1.4.309.0, so try the
+          # current name first and the old one second — that way bumping the
+          # pin in either direction keeps working.
+          function Save-VulkanInstaller($v) {
+            $base = "https://sdk.lunarg.com/sdk/download/$v/windows"
+            foreach ($name in @("vulkansdk-windows-X64-$v.exe", "VulkanSDK-$v-Installer.exe")) {
+              try {
+                Invoke-WebRequest -Uri "$base/$name" -OutFile $installer -UseBasicParsing
+                Write-Host "Downloaded $name"
+                return $true
+              } catch {
+                Write-Host "Not available: $base/$name ($($_.Exception.Message))"
+              }
             }
+            return $false
           }
-          if (-not $downloaded) {
-            throw "could not download Vulkan SDK $version from $base"
+
+          $version = $env:VULKAN_SDK_VERSION
+          if (-not (Save-VulkanInstaller $version)) {
+            $latest = (Invoke-RestMethod -Uri 'https://vulkan.lunarg.com/sdk/latest.json' -UseBasicParsing).windows
+            Write-Host "::warning::pinned Vulkan SDK $version is unavailable; falling back to latest ($latest). Update VULKAN_SDK_VERSION."
+            if (-not $latest -or -not (Save-VulkanInstaller $latest)) {
+              throw "could not download Vulkan SDK $version, nor the current latest"
+            }
+            $version = $latest
           }
 
           $sdkDir = "C:\VulkanSDK\$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,13 +259,30 @@ jobs:
           # stage either.
           if [ "${{ matrix.os_name }}" = "windows" ]; then
             found=0
+            # Two locations, because llama-cpp-sys-2 treats them differently:
+            # it hard-links the shared libs it installs into OUT_DIR/bin (ggml,
+            # ggml-base, llama) up into target/release, but the *loadable*
+            # backend modules — ggml-vulkan and the ggml-cpu-* variants, which
+            # are the ones that actually compute — are installed to
+            # OUT_DIR/backends and left there. Collecting only the first set
+            # ships an exe whose ggml_backend_load_all() finds nothing next to
+            # it, i.e. no GPU *and* no CPU inference.
             while IFS= read -r dll; do
               cp "$dll" "$BUILD_DIR/"
               found=$((found + 1))
-            done < <(find server-rs/target/release -maxdepth 2 -name 'ggml*.dll' -print)
+            done < <(
+              find server-rs/target/release -maxdepth 2 -name 'ggml*.dll' -print
+              find server-rs/target/release/build -path '*/out/backends/*' -name 'ggml*.dll' -print
+            )
             echo "Staged $found ggml backend DLL(s)"
             if [ "$found" -eq 0 ]; then
               echo "::error::no ggml*.dll found; a dynamic-backends build must produce them" && exit 1
+            fi
+            # The Vulkan module is the entire point of the Windows build, so a
+            # missing one is a hard failure: shipping a silently GPU-less (and
+            # here, backend-less) binary is worse than failing the release.
+            if ! ls "$BUILD_DIR"/ggml-vulkan*.dll >/dev/null 2>&1; then
+              echo "::error::no ggml-vulkan*.dll staged; the Vulkan backend did not build" && exit 1
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,13 +271,19 @@ jobs:
               cp "$dll" "$BUILD_DIR/"
               found=$((found + 1))
             done < <(
-              find server-rs/target/release -maxdepth 2 -name 'ggml*.dll' -print
+              find server-rs/target/release -maxdepth 1 \( -name 'ggml*.dll' -o -name 'llama.dll' \) -print
               find server-rs/target/release/build -path '*/out/backends/*' -name 'ggml*.dll' -print
             )
+            # llama.dll is not optional the way a backend module is: the exe
+            # imports it directly and will not start without it.
+            if [ ! -f "$BUILD_DIR/llama.dll" ]; then
+              echo "::error::llama.dll missing; the packaged exe would not start" && exit 1
+            fi
             echo "Staged $found ggml backend DLL(s)"
             if [ "$found" -eq 0 ]; then
               echo "::error::no ggml*.dll found; a dynamic-backends build must produce them" && exit 1
             fi
+
             # The Vulkan module is the entire point of the Windows build, so a
             # missing one is a hard failure: shipping a silently GPU-less (and
             # here, backend-less) binary is worse than failing the release.
@@ -288,6 +294,9 @@ jobs:
 
           echo "=== Staged binary ==="
           ls -lh "$BUILD_DIR"
+          # The ggml backend modules dominate the download size of the
+          # installer, so make the number easy to find in the log.
+          echo "=== Staged payload size: $(du -sh "$BUILD_DIR" | cut -f1) ==="
 
       - name: Prepare plugin files
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ cargo build --release -p lrg-server
 
 ```bash
 # Needs cmake + libclang. macOS: libclang ships with the Xcode CLT, `brew install cmake`.
-# Linux: `apt install cmake libclang-dev`. Windows also builds Vulkan (not CUDA — see lrg-llama/Cargo.toml).
+# Linux: `apt install cmake libclang-dev`. Windows also builds Vulkan (not CUDA — see
+# lrg-llama/Cargo.toml) and additionally needs the Vulkan SDK with VULKAN_SDK set.
 cargo build --release -p lrg-server --features llamacpp
 cargo clippy --workspace --all-targets --features llamacpp   # must also be clean when you touch this path
 ```

--- a/installers/windows/setup.iss
+++ b/installers/windows/setup.iss
@@ -16,9 +16,13 @@ SourceDir=..\..
 [Files]
 ; Backend: a single native binary, no bundled Python runtime.
 Source: "build\lrgenius-server\lrgenius-server.exe"; DestDir: "{app}\backend"; Flags: ignoreversion
-; llama.cpp's Vulkan backend is a loadable ggml module, so these must sit
-; beside the exe or the server runs CPU-only. skipifsourcedoesntexist keeps
-; the installer buildable when the llamacpp feature is off.
+; llama.cpp ships as shared libraries: llama.dll plus the loadable ggml backend
+; modules (the CPU variants and Vulkan). Both must sit beside the exe — it will
+; not start without llama.dll, and ggml only discovers backends in its own
+; directory, so a missing module silently downgrades to CPU.
+; skipifsourcedoesntexist keeps the installer buildable when the llamacpp
+; feature is off.
+Source: "build\lrgenius-server\llama.dll"; DestDir: "{app}\backend"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "build\lrgenius-server\ggml*.dll"; DestDir: "{app}\backend"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "installers\windows\run_hidden.vbs"; DestDir: "{app}\backend"; Flags: ignoreversion
 

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -33,7 +33,8 @@ minutes to a cold build, which nobody working on an unrelated crate should pay.
 ```bash
 # macOS: libclang ships with the Xcode command line tools; brew install cmake
 # Linux: apt install cmake libclang-dev
-# Windows: also builds Vulkan, deliberately not CUDA (see crates/lrg-llama/Cargo.toml)
+# Windows: cmake + LLVM, plus the Vulkan SDK (VULKAN_SDK must be set — the build
+#   panics without it). Vulkan, deliberately not CUDA: see crates/lrg-llama/Cargo.toml
 cargo build --release -p lrg-server --features llamacpp
 cargo clippy --workspace --all-targets --features llamacpp
 ```

--- a/server-rs/crates/lrg-llama/Cargo.toml
+++ b/server-rs/crates/lrg-llama/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 # In-process llama.cpp inference. Kept in its own crate so that the heavy
-# native toolchain requirement (cmake + libclang for bindgen, plus a CUDA
-# toolkit on Windows) only applies when the `llamacpp` feature is actually
+# native toolchain requirement (cmake + libclang for bindgen, plus the Vulkan
+# SDK on Windows) only applies when the `llamacpp` feature is actually
 # enabled, and so that `cargo build` for anyone touching an unrelated crate
 # stays fast.
 
@@ -28,7 +28,8 @@ llama-cpp-2 = { version = "0.1.154", features = ["mtmd", "llguidance"] }
 # Vulkan is built as a loadable ggml backend (`dynamic-backends`) so one Windows
 # binary starts on any GPU vendor and falls back to CPU when there is none. See
 # the packaging notes in the release workflow: the resulting ggml-*.dll files
-# must ship next to the exe.
+# must ship next to the exe. Building this needs the Vulkan SDK installed with
+# VULKAN_SDK set — llama-cpp-sys-2's build.rs panics without it.
 #
 # CUDA is deliberately *not* enabled. Building it requires a CUDA toolkit on the
 # runner, which is a long install and a long compile, and it cannot be validated

--- a/server-rs/crates/lrg-llama/Cargo.toml
+++ b/server-rs/crates/lrg-llama/Cargo.toml
@@ -27,18 +27,32 @@ llama-cpp-2 = { version = "0.1.154", features = ["mtmd", "llguidance"] }
 
 # Vulkan is built as a loadable ggml backend (`dynamic-backends`) so one Windows
 # binary starts on any GPU vendor and falls back to CPU when there is none. See
-# the packaging notes in the release workflow: the resulting ggml-*.dll files
-# must ship next to the exe. Building this needs the Vulkan SDK installed with
-# VULKAN_SDK set — llama-cpp-sys-2's build.rs panics without it.
+# the packaging notes in the release workflow: llama.dll and the resulting
+# ggml-*.dll files must ship next to the exe. Building this needs the Vulkan SDK
+# installed with VULKAN_SDK set — llama-cpp-sys-2's build.rs panics without it.
 #
-# CUDA is deliberately *not* enabled. Building it requires a CUDA toolkit on the
-# runner, which is a long install and a long compile, and it cannot be validated
-# from a development machine — a release build that fails on Windows is far worse
-# than one without CUDA. Vulkan lands within ~10-20% of CUDA for llama.cpp
-# inference and covers NVIDIA, AMD and Intel with a single build. To add CUDA
-# later: put "cuda" back in this list and install the toolkit in the release
-# workflow (e.g. Jimver/cuda-toolkit), then watch a real CI run — with
-# `dynamic-backends` the exe must still start on a machine with no NVIDIA driver.
+# CUDA is deliberately *not* enabled, and the tradeoff is genuinely close:
+#   * For NVIDIA users CUDA is faster than Vulkan, and by more than the commonly
+#     quoted ~10-20% — that figure describes token generation, while a vision
+#     model spends nearly all its time in prompt processing, where CUDA's lead
+#     is largest.
+#   * Against that: nvcc compiling ggml's kernels across the default
+#     architecture list is a very long CI step, and ggml-cuda.dll links the CUDA
+#     runtime dynamically, so the cuBLAS redistributables would ship in the
+#     installer — hundreds of megabytes for a Lightroom plugin.
+#   * Vulkan covers NVIDIA, AMD and Intel with one build, including the
+#     integrated GPUs common in laptops, which CUDA does nothing for. And users
+#     who want maximum NVIDIA speed can already point the plugin at Ollama or
+#     LM Studio (see lrg-providers), both of which ship their own CUDA builds.
+#
+# To enable it later: add "cuda" to this list and install the toolkit in the
+# release workflow (e.g. Jimver/cuda-toolkit), pinned to a 12.x line — CUDA 13
+# drops the sm_50/61/70 virtual architectures and with them Pascal cards, which
+# are still common in photo workstations. Stage the cudart/cublas/cublasLt
+# redistributables next to ggml-cuda.dll, or the module silently fails to load.
+# `src/device.rs` already handles the consequence of running both: an NVIDIA card
+# then registers twice, once as CUDA0 and once as Vulkan0, and llama.cpp does not
+# deduplicate that on its own.
 [target.'cfg(target_os = "windows")'.dependencies]
 llama-cpp-2 = { version = "0.1.154", features = [
     "mtmd",

--- a/server-rs/crates/lrg-llama/src/device.rs
+++ b/server-rs/crates/lrg-llama/src/device.rs
@@ -1,0 +1,212 @@
+//! Picking one GPU when llama.cpp can see more than one.
+//!
+//! llama.cpp's default layer split spreads a model across *every* registered
+//! device. That is right for a rack of matched cards and wrong for the machines
+//! this runs on, where the extra devices are usually not extra capacity:
+//!
+//!   * A laptop reports its integrated GPU alongside the discrete one, so the
+//!     default splits the model between a fast card and a slow one sharing
+//!     system RAM — worse than using the discrete card on its own.
+//!   * Should the Windows build ever enable CUDA next to Vulkan (see
+//!     `Cargo.toml` for why it does not today), one NVIDIA card is registered
+//!     *twice*, as `CUDA0` and as `Vulkan0`. llama.cpp does not deduplicate
+//!     that, so the default would split a model across two views of a single
+//!     card and count its VRAM twice.
+//!
+//! So we choose exactly one device and pass it to
+//! `LlamaModelParams::with_devices`. The ranking already prefers CUDA over
+//! Vulkan, which costs nothing while only Vulkan ships and means enabling CUDA
+//! does not also mean rediscovering the duplicate-device problem.
+
+/// What we need to know about a ggml backend device to rank it.
+///
+/// Mirrors the fields of `llama_cpp_2::LlamaBackendDevice` that matter here,
+/// so the ranking can be exercised without a GPU (or a llama.cpp build).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Device {
+    pub index: usize,
+    /// Backend registry name, e.g. `"CUDA"`, `"Vulkan"`, `"Metal"`, `"CPU"`.
+    pub backend: String,
+    /// Human-readable, e.g. `"NVIDIA GeForce RTX 4070"`.
+    pub description: String,
+    pub kind: DeviceKind,
+    pub memory_total: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeviceKind {
+    Cpu,
+    Gpu,
+    IntegratedGpu,
+    Other,
+}
+
+/// Snapshot the ggml devices llama.cpp currently has registered.
+///
+/// Only meaningful after `LlamaBackend::init()`, which is what loads the
+/// backend modules in the first place.
+pub(crate) fn available() -> Vec<Device> {
+    llama_cpp_2::list_llama_ggml_backend_devices()
+        .into_iter()
+        .map(|d| Device {
+            index: d.index,
+            backend: d.backend,
+            description: d.description,
+            kind: match d.device_type {
+                llama_cpp_2::LlamaBackendDeviceType::Cpu => DeviceKind::Cpu,
+                llama_cpp_2::LlamaBackendDeviceType::Gpu => DeviceKind::Gpu,
+                llama_cpp_2::LlamaBackendDeviceType::IntegratedGpu => DeviceKind::IntegratedGpu,
+                _ => DeviceKind::Other,
+            },
+            memory_total: d.memory_total,
+        })
+        .collect()
+}
+
+/// Preference score for a backend. Higher wins; `None` means "never pick".
+fn backend_rank(backend: &str) -> Option<u8> {
+    // Case-insensitive: the registry name casing is llama.cpp's business, not
+    // a contract we should depend on.
+    match backend.to_ascii_lowercase().as_str() {
+        "cuda" => Some(4),
+        "metal" => Some(3),
+        "vulkan" => Some(2),
+        // Anything else that presents as a GPU (ROCm, SYCL, OpenCL…) is still
+        // better than falling back to CPU, but we would rather have a backend
+        // we actually ship and test.
+        _ => Some(1),
+    }
+}
+
+/// Choose the GPU to run on, or `None` to let llama.cpp decide (CPU only).
+///
+/// CPU devices are never returned: llama.cpp always keeps the CPU backend
+/// available for layers that stay off the GPU, and naming it explicitly here
+/// would pin the whole model to it.
+pub(crate) fn select_gpu(devices: &[Device]) -> Option<&Device> {
+    devices
+        .iter()
+        .filter(|d| matches!(d.kind, DeviceKind::Gpu | DeviceKind::IntegratedGpu))
+        .max_by_key(|d| {
+            (
+                backend_rank(&d.backend).unwrap_or(0),
+                // Discrete before integrated, whatever the backend.
+                u8::from(matches!(d.kind, DeviceKind::Gpu)),
+                // Between two otherwise equal cards, take the roomier one.
+                d.memory_total,
+                // Deterministic tie-break so the choice is stable across runs;
+                // max_by_key keeps the last maximum, so invert the index to
+                // land on the first-registered device.
+                usize::MAX - d.index,
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dev(index: usize, backend: &str, kind: DeviceKind, memory_total: usize) -> Device {
+        Device {
+            index,
+            backend: backend.to_string(),
+            description: format!("{backend} device {index}"),
+            kind,
+            memory_total,
+        }
+    }
+
+    const GB: usize = 1024 * 1024 * 1024;
+
+    #[test]
+    fn prefers_cuda_over_vulkan_for_the_same_card() {
+        // Exactly what a Windows NVIDIA machine reports once both modules load.
+        let devices = [
+            dev(0, "CUDA", DeviceKind::Gpu, 12 * GB),
+            dev(1, "Vulkan", DeviceKind::Gpu, 12 * GB),
+            dev(2, "CPU", DeviceKind::Cpu, 32 * GB),
+        ];
+        let picked = select_gpu(&devices).expect("a GPU should be selected");
+        assert_eq!(picked.backend, "CUDA");
+        assert_eq!(picked.index, 0);
+    }
+
+    #[test]
+    fn falls_back_to_vulkan_without_cuda() {
+        let devices = [
+            dev(0, "Vulkan", DeviceKind::Gpu, 8 * GB),
+            dev(1, "CPU", DeviceKind::Cpu, 32 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().backend, "Vulkan");
+    }
+
+    #[test]
+    fn prefers_discrete_over_integrated() {
+        // Laptop with an Intel iGPU and a discrete card, both via Vulkan.
+        let devices = [
+            dev(0, "Vulkan", DeviceKind::IntegratedGpu, 2 * GB),
+            dev(1, "Vulkan", DeviceKind::Gpu, 6 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().index, 1);
+    }
+
+    #[test]
+    fn takes_the_larger_card_when_backends_tie() {
+        let devices = [
+            dev(0, "Vulkan", DeviceKind::Gpu, 4 * GB),
+            dev(1, "Vulkan", DeviceKind::Gpu, 16 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().index, 1);
+    }
+
+    #[test]
+    fn cuda_wins_even_against_a_larger_vulkan_device() {
+        // The same 12 GB card seen twice must not be beaten by a bigger number
+        // on the Vulkan side; and an 8 GB CUDA card is still the better pick
+        // than a 12 GB Vulkan view of a *different* card would be, because the
+        // backend gap dominates.
+        let devices = [
+            dev(0, "Vulkan", DeviceKind::Gpu, 16 * GB),
+            dev(1, "CUDA", DeviceKind::Gpu, 8 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().backend, "CUDA");
+    }
+
+    #[test]
+    fn integrated_gpu_is_still_better_than_nothing() {
+        let devices = [
+            dev(0, "Vulkan", DeviceKind::IntegratedGpu, 2 * GB),
+            dev(1, "CPU", DeviceKind::Cpu, 16 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().index, 0);
+    }
+
+    #[test]
+    fn cpu_only_machine_selects_nothing() {
+        let devices = [dev(0, "CPU", DeviceKind::Cpu, 16 * GB)];
+        assert!(select_gpu(&devices).is_none());
+    }
+
+    #[test]
+    fn no_devices_selects_nothing() {
+        assert!(select_gpu(&[]).is_none());
+    }
+
+    #[test]
+    fn ties_resolve_to_the_first_registered_device() {
+        let devices = [
+            dev(0, "CUDA", DeviceKind::Gpu, 12 * GB),
+            dev(1, "CUDA", DeviceKind::Gpu, 12 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().index, 0);
+    }
+
+    #[test]
+    fn backend_name_casing_does_not_matter() {
+        let devices = [
+            dev(0, "vulkan", DeviceKind::Gpu, 12 * GB),
+            dev(1, "cuda", DeviceKind::Gpu, 12 * GB),
+        ];
+        assert_eq!(select_gpu(&devices).unwrap().index, 1);
+    }
+}

--- a/server-rs/crates/lrg-llama/src/lib.rs
+++ b/server-rs/crates/lrg-llama/src/lib.rs
@@ -19,6 +19,7 @@
 //! work ever runs on a tokio worker. Dropping the [`LlamaEngine`] closes the
 //! channel, the thread returns, and every native resource is freed in order.
 
+mod device;
 mod engine;
 mod worker;
 

--- a/server-rs/crates/lrg-llama/src/worker.rs
+++ b/server-rs/crates/lrg-llama/src/worker.rs
@@ -35,6 +35,7 @@ use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::token::LlamaToken;
 use tokio::sync::oneshot;
 
+use crate::device;
 use crate::engine::{EngineInfo, GenerationOutput, GenerationRequest, LlamaEngineConfig};
 use crate::LlamaError;
 
@@ -68,7 +69,33 @@ pub(crate) fn run(
         }
     };
 
-    let model_params = LlamaModelParams::default().with_n_gpu_layers(config.n_gpu_layers);
+    // Pick one GPU explicitly rather than letting llama.cpp split the model
+    // across every registered device — on a laptop that means splitting it
+    // between the discrete card and the integrated one. See
+    // `device::select_gpu`.
+    let mut model_params = LlamaModelParams::default().with_n_gpu_layers(config.n_gpu_layers);
+    let devices = device::available();
+    if let Some(gpu) = device::select_gpu(&devices) {
+        log::info!(
+            "llama: using {} via {} ({} MiB VRAM), out of {} registered device(s)",
+            gpu.description,
+            gpu.backend,
+            gpu.memory_total / (1024 * 1024),
+            devices.len()
+        );
+        match model_params.with_devices(&[gpu.index]) {
+            Ok(p) => model_params = p,
+            Err(e) => {
+                // Not fatal: llama.cpp's own device choice is still workable,
+                // it just may be the slower duplicate.
+                log::warn!("llama: could not pin device {}: {e}", gpu.index);
+                model_params = LlamaModelParams::default().with_n_gpu_layers(config.n_gpu_layers);
+            }
+        }
+    } else {
+        log::info!("llama: no GPU backend registered, running on CPU");
+    }
+
     let model = match LlamaModel::load_from_file(&backend, &config.model_path, &model_params) {
         Ok(m) => m,
         Err(e) => {


### PR DESCRIPTION
Fixes the Windows release build, which has been failing since the llamacpp feature landed, plus three packaging defects found along the way.

Rebased onto `main` after #236 merged; retargeted from `feat/llamacpp-in-process-provider` to `main`. The description below replaces an auto-generated one that described #236's feature work rather than this diff.

## The build error

[Run 31254608481](https://github.com/LrGenius/LrGeniusAI/actions/runs/31254608481), job **Build LrGeniusAI - windows-x64**:

```
thread 'main' panicked at llama-cpp-sys-2-0.1.154/build.rs:886:58:
Please install Vulkan SDK and ensure that VULKAN_SDK env variable is set: NotPresent
```

`crates/lrg-llama/Cargo.toml` enables llama-cpp-2's `vulkan` + `dynamic-backends` features on Windows, but the release job installed only LLVM, cmake and ninja. `build.rs` hard-requires `VULKAN_SDK` on Windows MSVC — it links `$VULKAN_SDK\Lib\vulkan-1.lib`, and ggml's CMake needs the SDK's `glslc` for the compute shaders. macOS and Linux were unaffected because neither enables `vulkan`, which is why one of eight jobs failed.

## Changes

**Install the Vulkan SDK on the Windows runner.** Downloads a pinned LunarG SDK, installs it silently, exports `VULKAN_SDK` and its `Bin` to `GITHUB_PATH`. Two details: the installer is a Qt Installer Framework GUI binary, so a plain invocation returns before the install completes (hence `Start-Process -Wait`), and the step then asserts `vulkan-1.lib` and `glslc.exe` exist so a partial install fails loudly rather than as a confusing CMake error later. If the pinned version has been retired from LunarG's CDN, it falls back to their current release and warns with the variable to bump.

**Stage the loadable ggml backend modules.** The Windows artifact would have shipped with no compute backend at all, GPU or CPU. `llama-cpp-sys-2` hard-links the shared libs from `OUT_DIR/bin` into `target/release`, but under `dynamic-backends` the loadable modules — `ggml-vulkan` and the `ggml-cpu-*` variants, the ones that actually compute — install to `OUT_DIR/backends` and stay there. The old `find -maxdepth 2 -name 'ggml*.dll'` matched `ggml.dll` and `ggml-base.dll`, reported a non-zero count and passed while dropping every real backend. Since `llama_backend_init()` calls `ggml_backend_load_all()`, which only searches next to the executable, that binary would have failed to run any model.

**Ship `llama.dll`.** Same root cause, worse symptom: under `dynamic-backends` llama.cpp builds as shared libraries and the exe imports `llama.dll` directly, but both the staging step and `installers/windows/setup.iss` only globbed `ggml*.dll`. The packaged binary would not have started at all.

**Run on one GPU instead of splitting across every device.** llama.cpp's default layer split spreads a model over every registered ggml device. That suits a rack of matched cards, not a laptop that reports its integrated GPU next to the discrete one — the default splits the model between a fast card and a slow one sharing system RAM. `lrg-llama/src/device.rs` ranks devices and pins exactly one via `LlamaModelParams::with_devices`.

## On CUDA

Considered and deliberately deferred; `crates/lrg-llama/Cargo.toml` records the reasoning and what enabling it would take. Briefly: CUDA is faster than Vulkan on NVIDIA, and by more than the ~10-20% previously noted in that file — that figure describes token generation, while a vision model spends nearly all its time in prompt processing, where CUDA's lead is largest. Against that, nvcc across the default architecture list is a long CI step, and the cuBLAS redistributables would add hundreds of megabytes to the installer for a backend that does nothing for the AMD and Intel GPUs Vulkan also covers. Users wanting maximum NVIDIA speed can already point the plugin at Ollama or LM Studio.

The device ranking keeps `CUDA > Metal > Vulkan` even though only Vulkan ships today. That costs nothing now and matters later: with both backends loaded, one NVIDIA card registers twice, as `CUDA0` and `Vulkan0`, and llama.cpp does not deduplicate — the default would split a model across two views of a single card and count its VRAM twice.

## Verification

- `cargo clippy -p lrg-llama --all-targets`, `cargo fmt` clean; 12/12 crate tests pass, including 10 new ones covering the device ranking (duplicate card, Vulkan fallback, discrete vs integrated, CPU-only, tie-breaks). The ranking is a pure function over a small struct, so it needs neither a GPU nor a llama.cpp build.
- The staging step was extracted from the workflow and run against a mock of the real build layout: 6 ggml DLLs plus `llama.dll` stage correctly, and each guard was confirmed to fire by removing its file.

**Not verified: anything Windows-specific.** The release workflow only triggers on `v*` tags and manual dispatch, so no CI check on this PR builds the Windows binary — a green PR here does not prove the original error is fixed. This needs a manual **Build and Release LrGeniusAI** dispatch on this branch. Two things to watch in that run: the `Staged N ggml backend DLL(s)` line and the `ls -lh` after it, which show exactly which modules landed; and a `::warning::` about the pinned SDK, which would mean `VULKAN_SDK_VERSION` needs bumping.