### PR TITLE
docs: document the built-in llama.cpp and MLX local engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,21 @@ cd server-rs
 cargo build --release -p lrg-server
 ```
 
+The two **local inference engines** are opt-in for exactly this reason — nobody
+working on an unrelated crate should pay for their toolchains:
+
+- **llama.cpp** sits behind the `llamacpp` cargo feature (off by default), since
+  it compiles llama.cpp from source: needs `cmake` + `libclang`, and the Vulkan
+  SDK on Windows. Build with `--features llamacpp`, and keep
+  `cargo clippy --workspace --all-targets --features llamacpp` clean when you
+  touch that path.
+- **MLX** (Apple silicon) needs no cargo feature, but does need the
+  `lrgenius-mlx` sidecar built with `xcodebuild` plus the Metal toolchain.
+
+See [`server-rs/README.md`](server-rs/README.md) and
+[`native/mlx-sidecar/README.md`](native/mlx-sidecar/README.md) for the exact
+commands and the environment variables that point the server at models.
+
 #### Plugin (Lua)
 - The plugin code is located in the `plugin/LrGeniusAI.lrdevplugin` directory.
 - To test changes, you can link this directory into your Lightroom `Modules` folder or add it via the Lightroom **Plug-in Manager**.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 - **📸 Image Culling *(beta)*:** Group similar photos into bursts or near-duplicate stacks, automatically pick the strongest frames, and create Lightroom collections for picks, alternates, reject candidates, and optional duplicates.
 - **👥 People & Faces:** Detect and cluster faces, assign names to persons, browse person collections, and find similar faces across your catalog.
 - **🔎 Find Similar Images:** Find near-duplicate or visually similar photos for any selected image using perceptual hash or semantic CLIP comparison.
-- **☁️ Local & Cloud Models:** Full support for local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI**, **Google Gemini**, and **Vertex AI**.
+- **🏠 Built-In Local AI (no external app):** The backend runs vision models itself — **llama.cpp** in-process (GGUF, all platforms; Metal on macOS, Vulkan on Windows) and **MLX** on Apple silicon via a small Metal helper process. Pick a model in the Plug-in Manager, click *Download*, and analysis runs entirely on your machine. Models you already have in LM Studio (or the Hugging Face cache) are picked up without a second copy.
+- **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI**, **Google Gemini**, and **Vertex AI**.
 - **🎨 Customizable Prompts & Temperature Control:** System prompts for the AI can be added, edited, and deleted directly within the Lightroom Plug-In Manager. Use the temperature slider to control whether the AI should be highly creative or strictly consistent.
 - **📝 Photo Context (Contextual Info):** Provide manual hints to the AI before analysis (e.g., names of people or specific background details) that aren't immediately obvious from the image itself. This can be done via a popup dialog or directly in Lightroom's metadata panel.
 - **🗂️ Keyword Management:** Interactive synonym deduplication and automatic de-clutter during indexing to keep your keyword catalog clean.
@@ -51,7 +52,8 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
      - **Windows:** Click *More info* -> *Run anyway*.
      - **macOS:** Right-click the `.pkg` -> *Open* -> *Open anyway*.
    - Optional troubleshooting: if you want to start it manually, run `lrgenius-server/lrgenius-server.cmd` on Windows or `lrgenius-server/lrgenius-server` on macOS.
-4. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
+4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** sections offer a curated list of vision models (Gemma 4, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. On Apple silicon use the **MLX** section, elsewhere the llama.cpp one. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
+5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
    - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
    - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits
    - **Advanced Search...** — semantic free-text search
@@ -59,7 +61,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
    - **People...** — face clusters and named person collections
    - **Find Similar Images...** — find near-duplicates or visually similar photos
    - **Deduplicate Keyword Synonyms...** — clean up synonym sprawl in your catalog
-5. For AI Edit, start with defaults, keep **Review each proposed edit before applying it** enabled, and tune style via **Overall look** + **Style strength**.
+6. For AI Edit, start with defaults, keep **Review each proposed edit before applying it** enabled, and tune style via **Overall look** + **Style strength**.
 
 *For comprehensive details, model setup guides, and tips, please visit [lrgenius.com/help](http://lrgenius.com/help/).*
 
@@ -80,8 +82,9 @@ This project is built on the belief that AI tooling for creatives should remain 
 - **Backend / Server:** `geniusai-server` — Rust (axum) for deterministic memory behavior
 - **AI & Embedding:** SigLIP2 via ONNX Runtime (`ort` crate)
 - **Identity & Faces:** InsightFace (ONNX)
+- **Local Inference:** llama.cpp compiled into the backend (Metal / Vulkan / CPU), plus an MLX Swift helper (`lrgenius-mlx`) for Apple silicon
 - **Database:** LanceDB
-- **Supported Interfaces:** Google Gemini, Vertex AI, ChatGPT/OpenAI, Ollama, LM-Studio
+- **Supported Interfaces:** built-in llama.cpp, built-in MLX (Apple silicon), Google Gemini, Vertex AI, ChatGPT/OpenAI, Ollama, LM-Studio
 
 
 ---
@@ -99,6 +102,6 @@ Developed with a passion for photography and IT by:
 - **Community** – *Special thanks to all contributors and testers for your valuable input and support.*
 - **Various AI agents** - *For the great support in developing this project.*
 
-This project leverages many incredible open-source libraries, including **InsightFace**, **ONNX Runtime**, and **LanceDB**. 
+This project leverages many incredible open-source libraries, including **InsightFace**, **ONNX Runtime**, **LanceDB**, **llama.cpp**, and **MLX / mlx-swift-lm**. 
 
 A huge thank you to the open-source community and the developers of the underlying AI frameworks that make this integration possible!

--- a/docs/wiki/Credits.md
+++ b/docs/wiki/Credits.md
@@ -3,14 +3,18 @@
 LrGeniusAI is made possible by these amazing open-source projects and AI frameworks.
 
 ## Core Backend Dependencies
-- **InsightFace**: State-of-the-art face analysis and recognition. [GitHub](https://github.com/deepinsight/insightface)
-- **OpenCLIP**: Open-source implementation of OpenAI's CLIP. [GitHub](https://github.com/mlfoundations/open_clip)
-- **PyTorch**: Tensors and Dynamic neural networks in Python with strong GPU acceleration. [Website](https://pytorch.org/)
-- **ChromaDB**: The AI-native open-source embedding database. [Website](https://www.trychroma.com/)
-- **Transformers (Hugging Face)**: State-of-the-art Machine Learning for Pytorch, TensorFlow, and JAX. [Website](https://huggingface.co/transformers/)
-- **Flask / Waitress**: Lightweight WSGI web application framework and production-grade server.
-- **ONNX Runtime**: Cross-platform, high performance ML inferencing and training accelerator. [Website](https://onnxruntime.ai/)
-- **Scikit-learn**: Simple and efficient tools for predictive data analysis. [Website](https://scikit-learn.org/)
+- **InsightFace**: State-of-the-art face analysis and recognition; the `buffalo_l` models power face detection and recognition. [GitHub](https://github.com/deepinsight/insightface)
+- **SigLIP2 / OpenCLIP**: The vision-language models behind semantic search. [GitHub](https://github.com/mlfoundations/open_clip)
+- **ONNX Runtime**: Cross-platform, high performance ML inferencing, used via the `ort` crate for SigLIP2 and InsightFace. [Website](https://onnxruntime.ai/)
+- **LanceDB**: Embedded vector database storing embeddings and metadata. [Website](https://lancedb.com/)
+- **axum / tokio**: Async HTTP server and runtime for `geniusai-server`. [GitHub](https://github.com/tokio-rs/axum)
+- **Hugging Face Tokenizers**: Fast tokenizers used for the SigLIP2 text tower. [GitHub](https://github.com/huggingface/tokenizers)
+
+## Local Inference Engines
+- **llama.cpp**: Runs GGUF vision models in-process (Metal on macOS, Vulkan on Windows), via the `llama-cpp-2` bindings. [GitHub](https://github.com/ggml-org/llama.cpp)
+- **llguidance**: Turns JSON Schemas into decode-time constraints, so local models return valid structured output. [GitHub](https://github.com/guidance-ai/llguidance)
+- **MLX & mlx-swift-lm**: Apple's array framework and its language-model package, powering the `lrgenius-mlx` sidecar on Apple silicon. [GitHub](https://github.com/ml-explore/mlx-swift-lm)
+- **Gemma, Qwen-VL and SmolVLM**: The open-weights vision models offered in the built-in model catalogs.
 
 ## AI Model Providers & Interfaces
 - **Google Gemini**: Large language models for multimodal analysis.
@@ -21,10 +25,8 @@ LrGeniusAI is made possible by these amazing open-source projects and AI framewo
 
 ## Utilities & SDKs
 - **JSON.lua**: A complete JSON encoder/decoder in Lua by Jeffrey Friedl.
-- **Pillow**: The friendly PIL fork for Python image processing.
-- **NumPy & Pandas**: Fundamental packages for scientific computing and data manipulation.
-- **Psutil**: Cross-platform library for process and system monitoring.
-- **Requests**: Elegant and simple HTTP library for Python built for human beings.
+- **Adobe Lightroom Classic SDK**: The Lua API the plugin frontend is built on.
+- **Hugging Face Hub**: Distribution for the downloadable local models.
 
 ---
 Developed by **Bastian Machek (LrGenius / Fokuspunk)** and **AI agents**.

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -24,7 +24,7 @@ Checks whether the backend version is compatible with the plugin version passed 
 Called by the Lightroom plugin on first connect. Accepts catalog/configuration parameters and initializes per-catalog state.
 
 ### `GET /models` / `POST /models`
-Returns the list of available AI models grouped by provider (Gemini, OpenAI, Ollama, LM Studio). Filters out providers that are not configured or not reachable.
+Returns the list of available AI models grouped by provider (`gemini`, `chatgpt`, `ollama`, `lmstudio`, `llamacpp`, `mlx`). Filters out providers that are not configured or not reachable; the two local backends report what is installed on disk, so they are empty when no local model has been downloaded.
 
 ### `GET /logs`
 Returns recent log lines from the server log.
@@ -57,8 +57,11 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 |---|---|---|
 | `photo_id` | string | Stable file-based photo identifier |
 | `catalog_id` | string | Lightroom catalog identifier |
-| `provider` | string | LLM provider (`gemini`, `chatgpt`, `ollama`, `lmstudio`) |
-| `model` | string | Model name within the provider |
+| `provider` | string | LLM provider (`gemini`, `chatgpt`, `ollama`, `lmstudio`, `llamacpp`, `mlx`) |
+| `model` | string | Model name within the provider (for `llamacpp` the GGUF file name, for `mlx` the model directory name) |
+| `llm_n_ctx` | int | `llamacpp` only: context window override (0/absent = default) |
+| `llm_n_parallel` | int | `llamacpp` only: photos decoded concurrently |
+| `llm_gpu_layers` | int | `llamacpp` only: layers offloaded to the GPU (`0` = CPU only) |
 | `generate_metadata` | bool | Generate keywords/title/caption/alt_text |
 | `create_embeddings` | bool | Create SigLIP2 semantic embeddings |
 | `detect_faces` | bool | Run InsightFace detection on the photo |
@@ -241,6 +244,42 @@ Triggers a background download of the CLIP model.
 
 ### `GET /clip/download/status`
 Returns the current progress of an ongoing CLIP model download.
+
+---
+
+## Local LLM Management (llama.cpp & MLX)
+
+The backend hosts two local inference engines: `llamacpp` (in-process llama.cpp, GGUF models, present only in builds compiled with the `llamacpp` cargo feature) and `mlx` (an `lrgenius-mlx` helper process, Apple silicon only, no cargo feature). Both are exposed through the same routes — the MLX half is nested under an `mlx` key so that older plugins reading the top-level fields still see the llama.cpp engine.
+
+### `GET /llm/catalog`
+Lists local models that are installed and those offered for download.
+
+```json
+{
+  "installed":    [{ "name": "...", "model_path": "...", "mmproj_path": "...", "source": "downloaded|env|lmstudio" }],
+  "downloadable": [{ "id": "gemma4-e4b", "label": "...", "approx_bytes": 0, "min_ram_gb": 16, "installed": false }],
+  "supported":    true,
+  "model_dir":    "~/.cache/lrgenius/models/llm",
+  "mlx": {
+    "installed":    [{ "name": "gemma-4-e4b-it-4bit", "model_dir": "...", "source": "downloaded|env|lmstudio|huggingface" }],
+    "downloadable": [{ "id": "mlx-gemma4-e4b", "label": "...", "approx_bytes": 0, "min_ram_gb": 16, "installed": false }],
+    "supported":    false,
+    "reason":       "MLX runs only on Apple silicon Macs. …",
+    "model_dir":    "~/.cache/lrgenius/models/mlx"
+  }
+}
+```
+
+`supported: false` always carries a `reason` for MLX; for llama.cpp it means the binary was built without the `llamacpp` feature.
+
+### `GET /llm/status`
+Engine state (`status`, loaded `model_name`, …) for the llama.cpp engine, with the MLX engine's equivalent nested under `mlx`.
+
+### `POST /llm/download/start`
+Starts a background download of a catalog entry. Body: `{ "id": "gemma4-e4b" }`. The id space is shared across both catalogs and the id alone selects the backend, so there is a single download queue: a GGUF pair is fetched as two files, an MLX entry as a repo snapshot staged into a `.part` directory and renamed on success.
+
+### `GET /llm/download/status`
+Progress of the current local-model download (same shape as the CLIP download status).
 
 ---
 

--- a/docs/wiki/Dev-Plugin-README.md
+++ b/docs/wiki/Dev-Plugin-README.md
@@ -144,8 +144,14 @@ If strict cross-catalog identity is important for your workflow, plan for re-ind
 In the plugin settings dialog you can configure:
 
 - Backend server URL
-- Ollama base URL
+- Ollama and LM Studio base URLs
 - API keys and Vertex settings
+- **Local AI Model (no external app)** — browse, download and select GGUF vision
+  models run in-process by the backend's llama.cpp engine, plus the advanced
+  knobs (context size, photos in parallel, layers on the GPU)
+- **Local AI Model — MLX (Apple silicon)** — the same, for models run through
+  Apple's MLX stack; the section reports why it is unavailable on hosts that
+  cannot use it
 - Export size and quality used for AI processing
 - Prompt presets
 - Optional CLIP model download for advanced search

--- a/docs/wiki/Dev-Project-README.md
+++ b/docs/wiki/Dev-Project-README.md
@@ -10,6 +10,8 @@
   [![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)]()
   [![Website](https://img.shields.io/badge/Website-lrgenius.com-00B2FF?style=for-the-badge)]()
   [![Downloads](https://img.shields.io/github/downloads/LrGenius/LrGeniusAI/total?style=for-the-badge&label=Downloads)](https://github.com/LrGenius/LrGeniusAI/releases)
+
+  [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/W7X2240HF4)
 </div>
 
 ---
@@ -34,7 +36,8 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 - **📸 Image Culling *(beta)*:** Group similar photos into bursts or near-duplicate stacks, automatically pick the strongest frames, and create Lightroom collections for picks, alternates, reject candidates, and optional duplicates.
 - **👥 People & Faces:** Detect and cluster faces, assign names to persons, browse person collections, and find similar faces across your catalog.
 - **🔎 Find Similar Images:** Find near-duplicate or visually similar photos for any selected image using perceptual hash or semantic CLIP comparison.
-- **☁️ Local & Cloud Models:** Full support for local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI**, **Google Gemini**, and **Vertex AI**.
+- **🏠 Built-In Local AI (no external app):** The backend runs vision models itself — **llama.cpp** in-process (GGUF, all platforms; Metal on macOS, Vulkan on Windows) and **MLX** on Apple silicon via a small Metal helper process. Pick a model in the Plug-in Manager, click *Download*, and analysis runs entirely on your machine. Models you already have in LM Studio (or the Hugging Face cache) are picked up without a second copy.
+- **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI**, **Google Gemini**, and **Vertex AI**.
 - **🎨 Customizable Prompts & Temperature Control:** System prompts for the AI can be added, edited, and deleted directly within the Lightroom Plug-In Manager. Use the temperature slider to control whether the AI should be highly creative or strictly consistent.
 - **📝 Photo Context (Contextual Info):** Provide manual hints to the AI before analysis (e.g., names of people or specific background details) that aren't immediately obvious from the image itself. This can be done via a popup dialog or directly in Lightroom's metadata panel.
 - **🗂️ Keyword Management:** Interactive synonym deduplication and automatic de-clutter during indexing to keep your keyword catalog clean.
@@ -53,7 +56,8 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
      - **Windows:** Click *More info* -> *Run anyway*.
      - **macOS:** Right-click the `.pkg` -> *Open* -> *Open anyway*.
    - Optional troubleshooting: if you want to start it manually, run `lrgenius-server/lrgenius-server.cmd` on Windows or `lrgenius-server/lrgenius-server` on macOS.
-4. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
+4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** sections offer a curated list of vision models (Gemma 4, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. On Apple silicon use the **MLX** section, elsewhere the llama.cpp one. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
+5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
    - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
    - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits
    - **Advanced Search...** — semantic free-text search
@@ -61,7 +65,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
    - **People...** — face clusters and named person collections
    - **Find Similar Images...** — find near-duplicates or visually similar photos
    - **Deduplicate Keyword Synonyms...** — clean up synonym sprawl in your catalog
-5. For AI Edit, start with defaults, keep **Review each proposed edit before applying it** enabled, and tune style via **Overall look** + **Style strength**.
+6. For AI Edit, start with defaults, keep **Review each proposed edit before applying it** enabled, and tune style via **Overall look** + **Style strength**.
 
 *For comprehensive details, model setup guides, and tips, please visit [lrgenius.com/help](http://lrgenius.com/help/).*
 
@@ -82,8 +86,9 @@ This project is built on the belief that AI tooling for creatives should remain 
 - **Backend / Server:** `geniusai-server` — Rust (axum) for deterministic memory behavior
 - **AI & Embedding:** SigLIP2 via ONNX Runtime (`ort` crate)
 - **Identity & Faces:** InsightFace (ONNX)
+- **Local Inference:** llama.cpp compiled into the backend (Metal / Vulkan / CPU), plus an MLX Swift helper (`lrgenius-mlx`) for Apple silicon
 - **Database:** LanceDB
-- **Supported Interfaces:** Google Gemini, Vertex AI, ChatGPT/OpenAI, Ollama, LM-Studio
+- **Supported Interfaces:** built-in llama.cpp, built-in MLX (Apple silicon), Google Gemini, Vertex AI, ChatGPT/OpenAI, Ollama, LM-Studio
 
 
 ---
@@ -101,6 +106,6 @@ Developed with a passion for photography and IT by:
 - **Community** – *Special thanks to all contributors and testers for your valuable input and support.*
 - **Various AI agents** - *For the great support in developing this project.*
 
-This project leverages many incredible open-source libraries, including **InsightFace**, **ONNX Runtime**, and **LanceDB**. 
+This project leverages many incredible open-source libraries, including **InsightFace**, **ONNX Runtime**, **LanceDB**, **llama.cpp**, and **MLX / mlx-swift-lm**. 
 
 A huge thank you to the open-source community and the developers of the underlying AI frameworks that make this integration possible!

--- a/docs/wiki/Dev-Server-README.md
+++ b/docs/wiki/Dev-Server-README.md
@@ -12,7 +12,15 @@ endpoint reference.
 
 Workspace layout: `crates/lrg-common`, `lrg-store` (LanceDB), `lrg-imaging`,
 `lrg-ml` (ONNX Runtime via `ort`), `lrg-analysis`, `lrg-providers` (LLM
-clients), `lrg-api` (axum routers), `lrg-server` (the binary).
+clients), `lrg-llama` (in-process llama.cpp, behind the `llamacpp` feature),
+`lrg-mlx` (supervises the Apple silicon MLX sidecar), `lrg-api` (axum
+routers), `lrg-server` (the binary).
+
+There are two *local* LLM backends, selected as the `llamacpp` and `mlx`
+providers. They are independent — a build can have either, both, or neither —
+and both are served by the same `LocalEngine` trait in
+`lrg-providers/src/local_provider.rs`. Their build requirements differ, so they
+are covered separately below.
 
 ## Build & run locally
 
@@ -25,22 +33,93 @@ cargo build --release -p lrg-server
 `cargo test --workspace` and `cargo clippy --workspace --all-targets` should
 both be clean before sending changes.
 
+### Optional feature: `llamacpp`
+
+The in-process local LLM is behind a cargo feature that is **off by default**.
+Without it the `llamacpp` provider reports that the build has no local-model
+support and `/llm/catalog` returns `supported: false`, so the plugin's "Local AI
+Model" settings have nothing to work with. It is opt-in because it compiles
+llama.cpp from source: that needs `cmake` and `libclang` (for bindgen) and adds
+minutes to a cold build, which nobody working on an unrelated crate should pay.
+
+```bash
+# macOS: libclang ships with the Xcode command line tools; brew install cmake
+# Linux: apt install cmake libclang-dev
+# Windows: cmake + LLVM, plus the Vulkan SDK (VULKAN_SDK must be set — the build
+#   panics without it). Vulkan, deliberately not CUDA: see crates/lrg-llama/Cargo.toml
+cargo build --release -p lrg-server --features llamacpp
+cargo clippy --workspace --all-targets --features llamacpp
+```
+
+Then point it at a model — see [Local LLM](#local-llm-in-process-llamacpp) below
+for the env vars — or download one from the plugin's settings. The release
+workflow builds with this feature enabled, so shipped binaries have it.
+
+Tests that exercise a real model are `#[ignore]`d, since they need a multi-GB
+GGUF on disk:
+
+```bash
+export LRG_TEST_MODEL_GGUF=/path/to/model-Q4_K_M.gguf
+export LRG_TEST_MMPROJ_GGUF=/path/to/mmproj-BF16.gguf
+cargo test -p lrg-llama --test engine_smoke -- --ignored
+```
+
+One gotcha when testing through Lightroom: the plugin auto-launches the
+*installed* binary, not your dev build. `startServer` pings port 19819 first and
+short-circuits when something already answers, so start your feature-enabled
+build by hand and the plugin will use that instead.
+
+### Optional native helper: the MLX sidecar (Apple silicon)
+
+`mlx` is the second local backend, and it is **not** behind a cargo feature:
+`lrg-mlx` only spawns and talks to a helper process, so it costs nothing to
+compile and availability is a runtime question (Apple silicon + an installed
+helper). What it does need is that helper built, and `swift build` will not do
+— SwiftPM on the command line cannot compile MLX's Metal shaders, and the
+binary it produces dies on the first inference with "Failed to load the default
+metallib":
+
+```bash
+xcodebuild -downloadComponent MetalToolchain          # ~690 MB, once per machine
+cd native/mlx-sidecar
+xcodebuild build -scheme lrgenius-mlx -destination 'platform=macOS,arch=arm64' \
+  -configuration Release -derivedDataPath .build/xcode \
+  -skipPackagePluginValidation -skipMacroValidation
+export LRG_MLX_SIDECAR=$PWD/.build/xcode/Build/Products/Release/lrgenius-mlx
+```
+
+Without it, `/llm/catalog` reports `mlx.supported: false` with a reason naming
+what is missing (wrong architecture, or no helper found). The sidecar is
+resolved from `LRG_MLX_SIDECAR`, then from next to the running server, which is
+how the shipped `.pkg` finds it. See
+[`native/mlx-sidecar/README.md`](../native/mlx-sidecar/README.md) for the
+JSON-lines protocol, why it is a separate process, and the model layout.
+
+```bash
+export LRG_TEST_MLX_MODEL_DIR=/path/to/mlx-community/gemma-4-e4b-it-4bit
+cargo test -p lrg-mlx --test sidecar_smoke -- --ignored
+```
+
 ## Model files
 
 ### SigLIP2 (semantic embeddings)
 
 `POST /clip/download/start` + `GET /clip/download/status` fetch the fp16
 ONNX assets (`siglip2_image_fp16.onnx`, `siglip2_text_fp16.onnx`,
-`tokenizer.json`) from this running binary's own matching GitHub release
-(`LRG_BACKEND_RELEASE_TAG`) and place them at the `LRG_SIGLIP_*` paths
-below, pulling CI-exported ONNX assets from a release instead of the fp32
+`tokenizer.json`) and place them at the `LRG_SIGLIP_*` paths below,
+pulling CI-exported ONNX assets from a release instead of the fp32
 checkpoint from Hugging Face.
 
-**There is no signed release with those assets attached yet**, so right
-now this endpoint fails with a clear "release asset not found" error on
-any build (including released ones, until the first tag with the
-`build-model-assets` CI job runs). Until then, export the model yourself
-with the same script that CI job runs:
+They come from the fixed `model-assets-v1` tag
+(`MODEL_ASSETS_RELEASE_TAG` in `routes/clip.rs`), **not** from the binary's
+own version tag: the assets change far less often than the app, so
+re-uploading them on every release would be wasted. Bumping them means
+bumping that constant and the tag together (e.g. `model-assets-v2`).
+
+That release exists with all three assets attached, so the endpoint works
+on any build. To export the models yourself instead — for a local change,
+or to avoid the download — run the same script the `build-model-assets` CI
+job runs:
 
 ```bash
 cd server-rs
@@ -82,6 +161,92 @@ are already ONNX. Point `INSIGHTFACE_ROOT` at the directory containing
 the same location `insightface`'s own Python library uses, so the files
 are very likely already there if you've used InsightFace before).
 
+### Local LLM (in-process llama.cpp)
+
+Only present in builds compiled with the `llamacpp` cargo feature; without
+it the `llamacpp` provider reports that the build has no local-model
+support and `/llm/catalog` returns `supported: false`.
+
+Models are GGUF pairs — the weights plus an `mmproj` vision projector,
+which is what lets the model see the photo. `GET /llm/catalog` lists what
+is installed and what can be downloaded; `POST /llm/download/start` fetches
+a catalog entry. Discovery looks at, in order: the explicit env overrides,
+`LRG_LLAMA_MODEL_DIR` (default `~/.cache/lrgenius/models/llm/`), and any
+GGUFs already under `~/.lmstudio/models`, so a model you downloaded in LM
+Studio is offered without a second copy.
+
+```bash
+# Point at specific files (wins over any directory scan)
+export LRG_LLAMA_MODEL_GGUF=/path/to/model-Q4_K_M.gguf
+export LRG_LLAMA_MMPROJ_GGUF=/path/to/mmproj-BF16.gguf
+
+# Tuning. The plugin's "Local AI Model" settings send these per request and
+# take precedence; these are the fallback when it does not.
+export LRG_LLAMA_N_CTX=8192       # context window
+export LRG_LLAMA_N_PARALLEL=1     # photos decoded concurrently
+export LRG_LLAMA_GPU_LAYERS=999   # 0 = CPU only; anything that does not fit stays on the CPU
+```
+
+`n_ctx` and `n_parallel` trade against each other: the whole group of
+photos has to fit the context window alongside the shared prompt prefix, and
+the engine reduces `n_parallel` with a warning rather than overrunning it.
+Changing any of these reloads the model on the next request.
+
+A note on chat templates: llama.cpp's C API applies only templates it
+recognises, so a model shipping a modern Jinja template (Gemma 4's is 18 KB
+of macros) is refused outright. The engine therefore picks a built-in
+template from the GGUF's `general.architecture` and confirms it applies
+before use, logging which one it chose. `cargo run -p lrg-llama --example
+probe_template -- model.gguf` prints what a GGUF reports and which
+templates llama.cpp will accept — start there if a new model misbehaves.
+
+### Local LLM (MLX, Apple silicon)
+
+Same role as the section above, different artifacts: **an MLX model is a
+directory, not a file** — a Hugging Face repo snapshot with `config.json`, one
+or more safetensors shards, and the tokenizer files. Discovery therefore looks
+for directories that contain a `config.json` *and* at least one `.safetensors`
+(the config alone would match a half-finished download).
+
+`GET /llm/catalog` reports MLX under a nested `mlx` key alongside the GGUF half,
+including `supported`/`reason`, and `POST /llm/download/start` takes an MLX
+catalog id on the same route — the id alone picks the backend, so there is one
+download queue rather than two competing for the network.
+
+```bash
+# Use exactly this model (wins over any directory scan)
+export LRG_MLX_MODEL_DIR=/path/to/mlx-community/gemma-4-e4b-it-4bit
+
+# Root that downloads land in and discovery scans
+export LRG_MLX_MODEL_ROOT=~/.cache/lrgenius/models/mlx
+```
+
+Discovery also picks up `~/.lmstudio/models` (LM Studio has shipped an MLX
+engine for a long time) and the `huggingface-cli` cache at
+`~/.cache/huggingface/hub`, so a model pulled by hand needs no second copy.
+
+There are no tuning knobs to match llama.cpp's `n_ctx`/`n_parallel`/GPU layers,
+and that is not an oversight: `GuidedGenerationLoop.run` in mlx-swift-lm
+allocates a fresh KV cache per call, so there is no pinned prompt prefix to
+size a context window around, the preferred batch size is 1, and the grammar is
+compiled per request. The prompt is still sent pre-split and stable-first so the
+ordering is right if that changes upstream.
+
+### Troubleshooting: `LRG_DISABLE_KLEIDIAI`
+
+Setting `LRG_DISABLE_KLEIDIAI=1` turns off ONNX Runtime's arm64 KleidiAI
+convolution kernels for every session. It exists only as a field escape
+hatch: onnxruntime 1.24 leaked ~25-31 MB per photo in those kernels (a
+14k-photo indexing run reached a 45 GB footprint), which is fixed in the
+1.28 build we ship. If unbounded memory growth during indexing ever
+reappears on an arm64 machine, set this to confirm the cause before
+digging further.
+
+It costs roughly **3x indexing throughput on Apple Silicon**
+(measured end to end: SigLIP2 316 ms -> 952 ms per photo, face detection
+37 ms -> 60 ms), so leave it unset in normal use. Embeddings are
+unaffected either way — search rankings and distances are identical.
+
 ## Docker
 
 `Dockerfile` here builds and ships the compiled binary (multi-stage:
@@ -99,13 +264,45 @@ docker run -p 19819:19819 -v /path/to/data:/data -v /path/to/models:/models \
 
 Or via Compose: `docker compose -f ../docker-compose-dev.yml up -d --build`.
 
+The image is built **without** the `llamacpp` feature and has no MLX sidecar, so
+neither local backend is available in a container — point the containerized
+server at Ollama or LM Studio, or use a cloud provider. Add
+`--features llamacpp` to the Dockerfile's `cargo build` (plus `cmake` and
+`libclang-dev` in the builder stage) if you want in-process inference there.
+
 Not yet implemented: the periodic face-clustering and database-backup
 schedulers — the `GENIUSAI_FACES_CLUSTER_*` / `GENIUSAI_BACKUP_*` env vars
 are currently no-ops here.
 
+## Memory tuning
+
+LanceDB's defaults are sized for servers: a 6 GiB index cache and a 1 GiB
+file-metadata cache per session. Running next to Lightroom on a desktop,
+that headroom is indistinguishable from a leak, so `lrg-store` opens its
+connection with an explicit, much smaller session. Both caps are pure
+speed/memory tradeoffs (a miss re-reads from disk) and can be overridden,
+in MiB:
+
+| Env var | Default |
+|---|---|
+| `GENIUSAI_LANCE_INDEX_CACHE_MB` | 128 |
+| `GENIUSAI_LANCE_METADATA_CACHE_MB` | 128 |
+
+The other half of memory behaviour during a long indexing run is
+compaction — see `Store::optimize_all` and the constants above it. To
+reproduce and measure the write-path memory profile without Lightroom in
+the loop:
+
+```bash
+cargo run --release -p lrg-store --example memgrow -- 3000
+```
+
+It replays the exact per-photo write pattern `index_one` performs and
+prints RSS plus LanceDB cache size every 100 photos.
+
 ## Status
 
 This is the sole backend implementation (the earlier Python/Flask server
-has been retired). Still under active development on the `rust-rewrite`
-branch — see the plan and progress notes there before assuming a given
-endpoint or feature is fully live.
+has been retired) and it ships on `main`. Still under active development,
+so check `git log` before assuming a given endpoint or feature behaves the
+way an older note describes.

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -8,7 +8,7 @@ LrGeniusAI is an AI extension for Adobe Lightroom Classic. It adds AI-powered me
 
 ### Does it send my photos to the cloud?
 
-Only if you choose a cloud provider (ChatGPT/OpenAI, Google Gemini, Vertex AI). With local providers (Ollama, LM Studio) your photos never leave your machine. For cloud providers, images are sent to the respective API for analysis. Embeddings and all generated metadata are always stored locally.
+Only if you choose a cloud provider (ChatGPT/OpenAI, Google Gemini, Vertex AI). With a local provider — the built-in llama.cpp and MLX engines, or an external Ollama / LM Studio server — your photos never leave your machine. For cloud providers, images are sent to the respective API for analysis. Embeddings and all generated metadata are always stored locally.
 
 ### Which Lightroom version is supported?
 
@@ -16,7 +16,7 @@ Adobe **Lightroom Classic** only. Lightroom CC (cloud) and other Lightroom versi
 
 ### Is it free?
 
-Yes, LrGeniusAI is open source (AGPL-3.0). Cloud API usage (Gemini, OpenAI) incurs costs at the respective provider's standard rates. Local models (Ollama, LM Studio) are completely free to run.
+Yes, LrGeniusAI is open source (AGPL-3.0). Cloud API usage (Gemini, OpenAI) incurs costs at the respective provider's standard rates. Local models are completely free to run — including the ones the backend downloads and runs itself, see [Local AI Models](Help-Local-AI-Models).
 
 ### Is there a more minimalist version?
 
@@ -57,8 +57,12 @@ See [Help: Choosing AI Model](Help-Choosing-AI-Model) for a full breakdown. Quic
 | Cheap bulk keywording | `gemini-2.5-flash-lite` or `gpt-5-nano` |
 | Balanced default | `gemini-2.5-flash` |
 | Best quality | `gemini-2.5-pro` or `gpt-5.4-pro` |
-| Privacy / no API cost | Ollama or LM Studio with `qwen3-vl:8b` |
-| Apple Silicon, local | LM Studio MLX build of `qwen3-vl` |
+| Privacy / no API cost | Built-in `llamacpp` with Gemma 4 E4B |
+| Apple Silicon, local | Built-in `mlx` with Gemma 4 E4B |
+
+### Can I run AI analysis without installing Ollama or LM Studio?
+
+Yes. The backend has two built-in engines — **llama.cpp** (GGUF; macOS, Windows, Linux) and **MLX** (Apple silicon). In *Plug-in Manager → LrGeniusAI* find the **Local AI Model** sections, pick a model, and click **Download**. Nothing else to install or keep running. See [Local AI Models](Help-Local-AI-Models).
 
 ### I don't see any models in the dropdown
 
@@ -66,6 +70,11 @@ The model list is loaded from the backend at runtime. If it's empty:
 1. Make sure the backend server is running and reachable (*Plugin Manager → Status*).
 2. Check that the relevant API key or local server URL is configured.
 3. For Ollama/LM Studio: the local server must be started before Lightroom is opened (or before running a task).
+4. For the built-in local engines: a model must be downloaded first — the **Installed** line in the Plug-in Manager tells you whether one is present.
+
+### Why is the MLX section greyed out?
+
+MLX only runs on Apple silicon Macs. On Windows, Linux, or an Intel Mac use the llama.cpp section instead — the status line names the exact reason.
 
 ### Where do I enter my API key?
 
@@ -90,6 +99,7 @@ Yes. Advanced Search only works on photos that have been indexed (embeddings cre
 ### The AI generated wrong or low-quality keywords
 
 - Try a more capable model (e.g. move from a small local model to `gemini-2.5-flash`).
+- With a local model, turn **off** keyword aliases and bilingual keywords — both make the model emit structured keyword objects, which small models handle badly (often returning no keywords at all).
 - Add **Photo Context** (folder names, capture date, GPS coordinates) to give the AI more information.
 - Write a custom **System Prompt** in *Plug-in Manager → Prompts* to guide the output style.
 - Adjust the **Temperature** slider — lower values produce more consistent output.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -4,7 +4,7 @@ Welcome to LrGeniusAI! This guide will walk you through setting up the plugin, i
 
 ## 1. Install Plugin and Server
 
-To begin, you must install both the Lightroom Classic plugin frontend and the Python backend server. These components communicate locally to process your images without freezing the Lightroom UI. 
+To begin, you must install both the Lightroom Classic plugin frontend and the backend server (`geniusai-server`, a single Rust binary). These components communicate locally to process your images without freezing the Lightroom UI. 
 Please refer to the high-level installation instructions on the [root `README.md`](Dev-Project-README) or the detailed steps in the [`plugin/README.md`](Dev-Plugin-README).
 
 ### ⚠️ Bypassing Security Warnings (Unsigned Installers)
@@ -29,10 +29,24 @@ When you try to open the `.pkg` installer or the backend binary:
 
 Once installed, open the **Lightroom Plug-in Manager** (`File -> Plug-in Manager`) and locate LrGeniusAI. Here you need to:
 - **Set the Backend Server URL:** This defaults to `http://127.0.0.1:19819` but if you're running the backend on a different machine (e.g. via Docker), update the address here.
-- **Configure Provider/API Keys:** If you plan to use cloud providers like OpenAI or Google Gemini, enter your API keys. For local providers like Ollama or LM Studio, ensure their respective base URLs are correctly configured.
+- **Configure Provider/API Keys:** If you plan to use cloud providers like OpenAI or Google Gemini, enter your API keys. For external local servers like Ollama or LM Studio, ensure their respective base URLs are correctly configured.
 - **Set Vertex AI Details:** If using Google Cloud's Vertex AI, provide your project ID and preferred location.
 
 *Having trouble? Refer to the [Troubleshooting](Troubleshooting) guide for connectivity and API issues.*
+
+### Prefer to stay fully local? (no API key, no extra app)
+
+The backend can run vision models itself. In the same settings dialog, scroll to
+the **Local AI Model** sections:
+
+- **Local AI Model — MLX (Apple silicon)** on an Apple silicon Mac.
+- **Local AI Model (no external app)** — the built-in llama.cpp engine — on
+  Windows, Linux, or an Intel Mac.
+
+Pick a model (start with **Gemma 4 E4B**), click **Download**, and wait for the
+**Installed** line to list it. It then appears in the **AI Model** dropdown of
+every task as `mlx: …` or `llamacpp: …`. Full guide:
+[Local AI Models](Help-Local-AI-Models).
 
 ## 3. Index Photos
 
@@ -105,6 +119,7 @@ The `./gcloud:/root/.config/gcloud` bind mount keeps your ADC credentials intact
 - [Help: Find Similar Images](Help-Find-Similar)
 - [Help: Keyword Deduplication and De-Clutter](Help-Keyword-Dedup-and-Declutter)
 - [Help: Choosing AI Model](Help-Choosing-AI-Model)
+- [Help: Local AI Models](Help-Local-AI-Models) — built-in llama.cpp and MLX engines
 - [Help: Ollama Setup](Help-Ollama-Setup)
 - [Help: LM Studio Setup](Help-LM-Studio-Setup)
 - [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Help-Choosing-AI-Model.md
+++ b/docs/wiki/Help-Choosing-AI-Model.md
@@ -2,8 +2,10 @@
 
 > The exact model lists exposed by the plugin come from the backend at runtime.
 > The names below reflect the curated lists shipped with the current backend
-> (`server/src/providers/`). Pricing and availability change over time — verify
-> with each provider before relying on production cost estimates.
+> (`server-rs/crates/lrg-providers/` for cloud providers,
+> `server-rs/crates/lrg-api/src/{llm_models,mlx_models}.rs` for the built-in
+> local ones). Pricing and availability change over time — verify with each
+> provider before relying on production cost estimates.
 
 ## Decision factors
 
@@ -60,6 +62,38 @@ Local providers run on your own machine, so privacy is the strongest argument
 for using them. Quality of small open-weights vision models has improved
 significantly, but cloud frontier models still lead on tricky scenes.
 
+There are two kinds of local option: the engines **built into the backend**
+(nothing else to install), and **external servers** you run yourself (Ollama,
+LM Studio).
+
+### Built-in: llama.cpp and MLX (no external app)
+
+The backend runs vision models itself. Open *Plug-in Manager → LrGeniusAI*,
+find the **Local AI Model** sections, pick a model, and click **Download** —
+it then appears in the model dropdown as `llamacpp: <model>` or `mlx: <model>`.
+
+- **`llamacpp`** — llama.cpp compiled into the backend, using GGUF models.
+  Available on macOS (Metal), Windows (Vulkan, any GPU vendor), and Linux
+  (CPU). Recommended entries: **Gemma 4 E4B** as the default, **Gemma 4 12B
+  (QAT)** if you have 24 GB of RAM, **Qwen3.5 9B** as an alternative,
+  **Qwen2.5-VL 3B** on modest hardware.
+- **`mlx`** — Apple's MLX stack via a small Metal helper process, **Apple
+  silicon only**. Recommended entries: **Gemma 4 E4B** as the default,
+  **Gemma 4 E2B** for speed, **Qwen3-VL 4B** as an alternative.
+
+On an Apple silicon Mac both are available and worth a side-by-side run on the
+same 10–20 photos: MLX is Apple's native inference stack, while llama.cpp reuses
+the shared prompt prefix across the photos in a batch (MLX re-processes it per
+photo), which matters more the larger the batch.
+
+Both reuse models you already have: llama.cpp picks up GGUFs under
+`~/.lmstudio/models`, and MLX picks up LM Studio's MLX models and the
+`huggingface-cli` cache. Full guide: [Local AI Models](Help-Local-AI-Models).
+
+One caveat that applies to both: **do not enable keyword aliases or bilingual
+keywords with a local model.** They turn every keyword into a structured object,
+which small models handle badly — the Analyze & Index dialog warns about it.
+
 ### Ollama
 
 Install and start Ollama from [ollama.com](https://ollama.com/), then pull at
@@ -78,6 +112,10 @@ See [Ollama Setup](Help-Ollama-Setup).
 
 ### LM Studio
 
+Worth running as an external server mainly if you already use it for other
+things, or want its model browser and per-model tuning; otherwise the built-in
+engines above cover the same ground with one fewer app running.
+
 Download from [lmstudio.ai](https://lmstudio.ai/download), enable server mode,
 and download one or more vision models from inside the app. Recommended:
 
@@ -95,8 +133,11 @@ significantly faster than the GGUF builds. See [LM Studio Setup](Help-LM-Studio-
 | Cheap bulk keywording (cloud)         | `gemini-2.5-flash-lite` or `gpt-5-nano`          |
 | Balanced default (cloud)              | `gemini-2.5-flash` or `gpt-5-mini`               |
 | Best description quality (cloud)      | `gemini-2.5-pro`, `gpt-5.4`, or `gpt-5.4-pro`    |
-| Privacy-first / no API billing        | Ollama `qwen3-vl:8b` or LM Studio `qwen3-vl-8b`  |
-| Apple Silicon, local                  | LM Studio MLX build of `qwen3-vl` or `gemma3`    |
+| Privacy-first, simplest setup         | Built-in `llamacpp` with Gemma 4 E4B             |
+| Apple Silicon, local                  | Built-in `mlx` with Gemma 4 E4B (E2B if 8–16 GB) |
+| Windows with any discrete GPU, local  | Built-in `llamacpp` (Vulkan) with Gemma 4 E4B    |
+| Modest hardware / 8 GB RAM            | `mlx` Gemma 4 E2B or `llamacpp` Qwen2.5-VL 3B    |
+| Already running Ollama / LM Studio    | Ollama `qwen3-vl:8b` or LM Studio `qwen3-vl-8b`  |
 
 ## Practical recommendation
 

--- a/docs/wiki/Help-Keyword-Dedup-and-Declutter.md
+++ b/docs/wiki/Help-Keyword-Dedup-and-Declutter.md
@@ -23,7 +23,7 @@ The workflow has five steps:
 
 #### Step 1 — Configuration
 
-- **AI Model** — choose which LLM validates the similarity clusters. Options: ChatGPT, Gemini, Ollama, LM Studio. If no key/server is configured, the task falls back to CLIP-only (no LLM validation).
+- **AI Model** — choose which LLM validates the similarity clusters. Options: ChatGPT, Gemini, Ollama, LM Studio, and the built-in local engines (`llamacpp`, `mlx` — see [Local AI Models](Help-Local-AI-Models)). If no key/server/local model is configured, the task falls back to CLIP-only (no LLM validation).
 - **Matching Strictness** — slider from 0.70 to 0.98.
   - Lower values (0.70) produce more suggestions and may include false positives.
   - Higher values (0.98) are conservative; fewer but more certain matches.

--- a/docs/wiki/Help-Local-AI-Models.md
+++ b/docs/wiki/Help-Local-AI-Models.md
@@ -1,0 +1,154 @@
+# Help: Built-In Local AI Models (llama.cpp & MLX)
+
+The backend can run vision models **itself** — no Ollama, no LM Studio, no
+other app to install or keep running. You pick a model in the Plug-in Manager,
+click *Download*, and analysis happens entirely on your machine.
+
+There are two built-in engines. They do the same job through different
+runtimes, and they use **different model files**, which is why the Plug-in
+Manager shows them as two separate sections:
+
+| Engine | Provider name | Runs on | GPU acceleration |
+|---|---|---|---|
+| llama.cpp (in-process) | `llamacpp` | macOS, Windows, Linux | Metal (macOS), Vulkan (Windows), CPU (Linux) |
+| MLX (helper process) | `mlx` | Apple silicon Macs only | Metal |
+
+**Which one should I use?** On Windows, Linux, or an Intel Mac the question does
+not arise — **llama.cpp** is the only built-in option. On an Apple silicon Mac
+both work, and it is worth running the same 10–20 photos through each: MLX is
+Apple's native inference stack, while llama.cpp reuses the shared prompt prefix
+across the photos in a batch (MLX re-processes it for every photo), which counts
+for more the larger the batch.
+
+---
+
+## 1. Download a model
+
+1. Open `File → Plug-in Manager → LrGeniusAI`.
+2. Scroll to **Local AI Model — MLX (Apple silicon)** or **Local AI Model (no
+   external app)**.
+3. Pick an entry from the dropdown and click **Download**. The list shows the
+   approximate download size; the models are several gigabytes, so this takes a
+   while on a slow connection.
+4. When the download finishes, the **Installed** line lists the model.
+5. In *Analyze & Index Photos* (or *AI Edit*), choose the model from the **AI
+   Model** dropdown — it appears as `mlx: <model>` or `llamacpp: <model>`.
+
+The curated lists are short on purpose: every entry is an ungated repository
+(no Hugging Face token needed) and a **vision** model, since a text-only model
+would look selectable and then fail on the first photo.
+
+### llama.cpp (GGUF)
+
+| Model | Download | Comfortable RAM |
+|---|---|---|
+| Gemma 4 E4B *(recommended)* | ~6.3 GB | 16 GB |
+| Gemma 4 12B (QAT, highest quality) | ~7.2 GB | 24 GB |
+| Qwen3.5 9B (balanced alternative) | ~6.5 GB | 16 GB |
+| Qwen2.5-VL 3B / 7B | ~3.4 / 6.5 GB | 8 / 16 GB |
+| SmolVLM 500M (testing only) | ~0.7 GB | 4 GB |
+
+A GGUF model is always a **pair** of files: the weights plus an `mmproj` vision
+projector, which is what lets the model see the photo. The download fetches
+both.
+
+### MLX (Apple silicon)
+
+| Model | Download | Comfortable RAM |
+|---|---|---|
+| Gemma 4 E4B *(recommended)* | ~5.2 GB | 16 GB |
+| Gemma 4 E2B (faster, lower quality) | ~3.6 GB | 8 GB |
+| Qwen3-VL 4B (balanced alternative) | ~3.1 GB | 8 GB |
+
+An MLX model is a **directory** (config, safetensors shards, tokenizer), not a
+single file — that difference is only visible if you go looking on disk.
+
+---
+
+## 2. Reusing models you already have
+
+Neither engine forces a second copy of a model you already downloaded
+elsewhere:
+
+- **llama.cpp** scans its own model directory plus any GGUFs under
+  `~/.lmstudio/models`.
+- **MLX** scans its own model directory, `~/.lmstudio/models` (LM Studio ships
+  an MLX engine on Apple silicon), and the `huggingface-cli` cache at
+  `~/.cache/huggingface/hub`.
+
+Anything found there shows up in the **Installed** list and the model dropdown.
+
+---
+
+## 3. Advanced settings (llama.cpp only)
+
+Under the llama.cpp section:
+
+- **Context size (tokens)** — how much prompt+photo the model can hold at once.
+- **Photos in parallel** — how many photos are decoded concurrently.
+- **Layers on the GPU** — `0` runs entirely on the CPU; anything that does not
+  fit in VRAM stays on the CPU anyway.
+
+Context size and photos-in-parallel trade against each other: the whole group
+of photos has to fit the context window alongside the shared prompt prefix, and
+the backend reduces the parallel count with a warning rather than overrunning
+it. Leave the fields empty for sensible defaults. Changing any of them reloads
+the model on the next request.
+
+**MLX has no equivalent knobs**, and that is a deliberate limitation rather than
+an oversight: the MLX decoder allocates a fresh cache per request, so there is
+no shared prompt prefix to size a context window around, and it processes one
+photo at a time.
+
+---
+
+## 4. Things worth knowing
+
+- **Local is slower than cloud.** Expect seconds to tens of seconds per photo
+  depending on model size and hardware. Start with a small batch to get a feel
+  for the throughput before queueing thousands of photos.
+- **First request loads the model**, which can take a while for a multi-gigabyte
+  file. Subsequent photos are much faster.
+- **Avoid keyword aliases and bilingual keywords with local models.** Both turn
+  every keyword into an object rather than a plain string, and small local
+  models handle that structure badly — measured on Gemma 4 E4B, the same photo
+  produced 19 keywords with plain strings and *zero* with the object form. The
+  Analyze & Index dialog warns when you combine them.
+- **Quality still trails frontier cloud models** on tricky scenes. If a batch
+  comes back weak, compare against `gemini-2.5-flash` on the same 10–20 photos
+  before tuning anything else.
+
+---
+
+## 5. Troubleshooting
+
+**"This backend does not support MLX" / "MLX runs only on Apple silicon Macs"**
+Expected on Windows, Linux, and Intel Macs — use the llama.cpp section instead.
+
+**MLX says the helper is missing**
+The MLX engine needs the `lrgenius-mlx` helper next to the server binary. Ship
+it by reinstalling the backend with the official macOS `.pkg`; if you build
+from source, see [Server README](Dev-Server-README) for the `xcodebuild` step.
+
+**"This backend build has no local-model support"**
+The backend was compiled without the `llamacpp` feature. Official release
+builds have it; a self-built binary needs
+`cargo build --release -p lrg-server --features llamacpp`.
+
+**The model dropdown shows no local models**
+Nothing is installed yet, or the download did not finish. Check the
+**Installed** line in the Plug-in Manager, and re-run the download if needed —
+an interrupted download is discarded rather than offered as a broken model.
+
+**Analysis is very slow or the machine swaps**
+The model is too large for your RAM. Move down a size (Gemma 4 E2B or
+Qwen2.5-VL 3B), or reduce **Photos in parallel** to 1.
+
+---
+
+## See also
+
+- [Help: Choosing AI Model](Help-Choosing-AI-Model) — cloud vs local comparison
+- [Help: Ollama Setup](Help-Ollama-Setup) — external local server alternative
+- [Help: LM Studio Setup](Help-LM-Studio-Setup) — external local server alternative
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -27,6 +27,7 @@ Welcome to the project wiki.
 ### AI model setup
 
 - [Help: Choosing AI Model](Help-Choosing-AI-Model) — cloud vs local, model comparison table
+- [Help: Local AI Models](Help-Local-AI-Models) — built-in llama.cpp & MLX engines, no external app
 - [Help: Ollama Setup](Help-Ollama-Setup)
 - [Help: LM Studio Setup](Help-LM-Studio-Setup)
 - [Google Vertex AI Login](Google-Vertex-AI-Login)
@@ -57,7 +58,7 @@ Welcome to the project wiki.
 
 LrGeniusAI is an AI extension for Lightroom Classic. It runs a local backend server and connects it to the Lightroom plugin to provide:
 
-- **AI metadata generation** — keywords, titles, captions, alt text
+- **AI metadata generation** — keywords, titles, captions, alt text, via cloud APIs or models the backend runs locally itself
 - **AI develop edits** *(beta)* — per-photo Lightroom develop recipes with style presets
 - **Semantic free-text search** — find photos by describing them in natural language
 - **Image culling** *(beta)* — burst grouping, scoring, Picks/Alternates/Rejects collections

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -66,7 +66,34 @@ If you are using cloud providers (Gemini, ChatGPT), authentication failures bloc
 
 ---
 
-### 6. Ollama Not Responding / Not Invoked
+### 6. Built-In Local Model (llama.cpp / MLX) Not Available
+
+The backend can run models itself, in two independent engines: `llamacpp`
+(GGUF; macOS/Windows/Linux) and `mlx` (Apple silicon only). See
+[Local AI Models](Help-Local-AI-Models) for the full guide.
+
+- **Symptom:** The **Local AI Model** section says *"This backend does not
+  support MLX"* or *"MLX runs only on Apple silicon Macs"*.
+  - **Resolution:** Expected on Windows, Linux, and Intel Macs. Use the
+    llama.cpp section instead — it offers the same model families as GGUF.
+- **Symptom:** MLX is unavailable on an Apple silicon Mac, with a reason naming
+  a missing helper.
+  - **Resolution:** The `lrgenius-mlx` helper ships next to the server binary in
+    the macOS `.pkg`. Reinstall the backend with the official installer; if you
+    build from source, the helper needs `xcodebuild` plus the Metal toolchain
+    (see [Server README](Dev-Server-README)).
+- **Symptom:** *"This backend build has no local-model support"*.
+  - **Resolution:** The binary was compiled without the `llamacpp` feature.
+    Official releases include it — reinstall from the release page, or rebuild
+    with `cargo build --release -p lrg-server --features llamacpp`.
+- **Symptom:** A downloaded model does not appear in the model dropdown.
+  - **Resolution:** Check the **Installed** line in the Plug-in Manager. An
+    interrupted download is discarded rather than offered as a broken model, so
+    simply run the download again.
+
+---
+
+### 7. Ollama Not Responding / Not Invoked
 
 - **Symptom:** Analysis runs but Ollama shows no activity (`ollama ps` is empty), or connection errors to `localhost:11434`.
 - **Resolution:**
@@ -78,7 +105,7 @@ If you are using cloud providers (Gemini, ChatGPT), authentication failures bloc
 
 ---
 
-### 7. LM Studio Not Responding
+### 8. LM Studio Not Responding
 
 - **Symptom:** Errors connecting to LM Studio, or model list shows no LM Studio models.
 - **Resolution:**
@@ -89,19 +116,20 @@ If you are using cloud providers (Gemini, ChatGPT), authentication failures bloc
 
 ---
 
-### 8. Local Model Timeout
+### 9. Local Model Timeout
 
 Local AI models can take significantly longer than cloud APIs, especially without a dedicated GPU.
 
 - **Symptom:** Lightroom displays a timeout error during image analysis.
 - **Resolution:**
-  1. Ensure the model is fully loaded into memory before starting the batch (run a test prompt in Ollama/LM Studio first).
+  1. Ensure the model is fully loaded into memory before starting the batch. With Ollama/LM Studio, run a test prompt first; with the built-in engines, the first request of a session loads a multi-gigabyte model and is always the slowest.
   2. Process smaller batches (10–20 photos at a time) to avoid cumulative timeouts.
   3. Switch to a smaller model (4B instead of 12B) if your hardware can't sustain the load.
+  4. For the built-in llama.cpp engine: lower **Photos in parallel** to 1, and check **Layers on the GPU** — a model that does not fit in VRAM partially runs on the CPU and is far slower.
 
 ---
 
-### 9. No Metadata Generated
+### 10. No Metadata Generated
 
 - **Symptom:** Analysis completes without errors but no keywords/title/caption appear in Lightroom.
 - **Resolution:**
@@ -112,7 +140,7 @@ Local AI models can take significantly longer than cloud APIs, especially withou
 
 ---
 
-### 10. Search Returns No Results
+### 11. Search Returns No Results
 
 - **Symptom:** Advanced Search runs but the results collection is empty or sparse.
 - **Resolution:**
@@ -123,7 +151,7 @@ Local AI models can take significantly longer than cloud APIs, especially withou
 
 ---
 
-### 11. macOS Filesystem Permission Warning After Update
+### 12. macOS Filesystem Permission Warning After Update
 
 - **Symptom:** Lightroom shows a filesystem permissions warning on startup after installing or updating LrGeniusAI.
 - **Resolution:** Run Adobe's permission repair script:
@@ -133,7 +161,7 @@ Local AI models can take significantly longer than cloud APIs, especially withou
 
 ---
 
-### 12. AI Edit Produces 500 Internal Server Error
+### 13. AI Edit Produces 500 Internal Server Error
 
 - **Symptom:** AI Edit fails with "HTTP status: 500" from the backend.
 - **Resolution:**
@@ -144,7 +172,7 @@ Local AI models can take significantly longer than cloud APIs, especially withou
 
 ---
 
-### 13. Database Initialization Failed After Update
+### 14. Database Initialization Failed After Update
 
 - **Symptom:** "Failed to initialize database at the selected path" error when starting the backend or when Lightroom connects.
 - **Resolution:**
@@ -155,7 +183,7 @@ Local AI models can take significantly longer than cloud APIs, especially withou
 
 ---
 
-### 14. Windows: Restart/Update Endpoint Not Working
+### 15. Windows: Restart/Update Endpoint Not Working
 
 - **Symptom:** "Check for Updates" or backend restart from within Lightroom fails on Windows.
 - **Resolution:** This is a known issue on Windows with the `/restart` endpoint. Restart the backend manually:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -140,8 +140,14 @@ If strict cross-catalog identity is important for your workflow, plan for re-ind
 In the plugin settings dialog you can configure:
 
 - Backend server URL
-- Ollama base URL
+- Ollama and LM Studio base URLs
 - API keys and Vertex settings
+- **Local AI Model (no external app)** — browse, download and select GGUF vision
+  models run in-process by the backend's llama.cpp engine, plus the advanced
+  knobs (context size, photos in parallel, layers on the GPU)
+- **Local AI Model — MLX (Apple silicon)** — the same, for models run through
+  Apple's MLX stack; the section reports why it is unavailable on hosts that
+  cannot use it
 - Export size and quality used for AI processing
 - Prompt presets
 - Optional CLIP model download for advanced search

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -8,7 +8,15 @@ endpoint reference.
 
 Workspace layout: `crates/lrg-common`, `lrg-store` (LanceDB), `lrg-imaging`,
 `lrg-ml` (ONNX Runtime via `ort`), `lrg-analysis`, `lrg-providers` (LLM
-clients), `lrg-api` (axum routers), `lrg-server` (the binary).
+clients), `lrg-llama` (in-process llama.cpp, behind the `llamacpp` feature),
+`lrg-mlx` (supervises the Apple silicon MLX sidecar), `lrg-api` (axum
+routers), `lrg-server` (the binary).
+
+There are two *local* LLM backends, selected as the `llamacpp` and `mlx`
+providers. They are independent — a build can have either, both, or neither —
+and both are served by the same `LocalEngine` trait in
+`lrg-providers/src/local_provider.rs`. Their build requirements differ, so they
+are covered separately below.
 
 ## Build & run locally
 
@@ -56,6 +64,37 @@ One gotcha when testing through Lightroom: the plugin auto-launches the
 *installed* binary, not your dev build. `startServer` pings port 19819 first and
 short-circuits when something already answers, so start your feature-enabled
 build by hand and the plugin will use that instead.
+
+### Optional native helper: the MLX sidecar (Apple silicon)
+
+`mlx` is the second local backend, and it is **not** behind a cargo feature:
+`lrg-mlx` only spawns and talks to a helper process, so it costs nothing to
+compile and availability is a runtime question (Apple silicon + an installed
+helper). What it does need is that helper built, and `swift build` will not do
+— SwiftPM on the command line cannot compile MLX's Metal shaders, and the
+binary it produces dies on the first inference with "Failed to load the default
+metallib":
+
+```bash
+xcodebuild -downloadComponent MetalToolchain          # ~690 MB, once per machine
+cd native/mlx-sidecar
+xcodebuild build -scheme lrgenius-mlx -destination 'platform=macOS,arch=arm64' \
+  -configuration Release -derivedDataPath .build/xcode \
+  -skipPackagePluginValidation -skipMacroValidation
+export LRG_MLX_SIDECAR=$PWD/.build/xcode/Build/Products/Release/lrgenius-mlx
+```
+
+Without it, `/llm/catalog` reports `mlx.supported: false` with a reason naming
+what is missing (wrong architecture, or no helper found). The sidecar is
+resolved from `LRG_MLX_SIDECAR`, then from next to the running server, which is
+how the shipped `.pkg` finds it. See
+[`native/mlx-sidecar/README.md`](../native/mlx-sidecar/README.md) for the
+JSON-lines protocol, why it is a separate process, and the model layout.
+
+```bash
+export LRG_TEST_MLX_MODEL_DIR=/path/to/mlx-community/gemma-4-e4b-it-4bit
+cargo test -p lrg-mlx --test sidecar_smoke -- --ignored
+```
 
 ## Model files
 
@@ -157,6 +196,38 @@ before use, logging which one it chose. `cargo run -p lrg-llama --example
 probe_template -- model.gguf` prints what a GGUF reports and which
 templates llama.cpp will accept — start there if a new model misbehaves.
 
+### Local LLM (MLX, Apple silicon)
+
+Same role as the section above, different artifacts: **an MLX model is a
+directory, not a file** — a Hugging Face repo snapshot with `config.json`, one
+or more safetensors shards, and the tokenizer files. Discovery therefore looks
+for directories that contain a `config.json` *and* at least one `.safetensors`
+(the config alone would match a half-finished download).
+
+`GET /llm/catalog` reports MLX under a nested `mlx` key alongside the GGUF half,
+including `supported`/`reason`, and `POST /llm/download/start` takes an MLX
+catalog id on the same route — the id alone picks the backend, so there is one
+download queue rather than two competing for the network.
+
+```bash
+# Use exactly this model (wins over any directory scan)
+export LRG_MLX_MODEL_DIR=/path/to/mlx-community/gemma-4-e4b-it-4bit
+
+# Root that downloads land in and discovery scans
+export LRG_MLX_MODEL_ROOT=~/.cache/lrgenius/models/mlx
+```
+
+Discovery also picks up `~/.lmstudio/models` (LM Studio has shipped an MLX
+engine for a long time) and the `huggingface-cli` cache at
+`~/.cache/huggingface/hub`, so a model pulled by hand needs no second copy.
+
+There are no tuning knobs to match llama.cpp's `n_ctx`/`n_parallel`/GPU layers,
+and that is not an oversight: `GuidedGenerationLoop.run` in mlx-swift-lm
+allocates a fresh KV cache per call, so there is no pinned prompt prefix to
+size a context window around, the preferred batch size is 1, and the grammar is
+compiled per request. The prompt is still sent pre-split and stable-first so the
+ordering is right if that changes upstream.
+
 ### Troubleshooting: `LRG_DISABLE_KLEIDIAI`
 
 Setting `LRG_DISABLE_KLEIDIAI=1` turns off ONNX Runtime's arm64 KleidiAI
@@ -188,6 +259,12 @@ docker run -p 19819:19819 -v /path/to/data:/data -v /path/to/models:/models \
 ```
 
 Or via Compose: `docker compose -f ../docker-compose-dev.yml up -d --build`.
+
+The image is built **without** the `llamacpp` feature and has no MLX sidecar, so
+neither local backend is available in a container — point the containerized
+server at Ollama or LM Studio, or use a cloud provider. Add
+`--features llamacpp` to the Dockerfile's `cargo build` (plus `cmake` and
+`libclang-dev` in the builder stage) if you want in-process inference there.
 
 Not yet implemented: the periodic face-clustering and database-backup
 schedulers — the `GENIUSAI_FACES_CLUSTER_*` / `GENIUSAI_BACKUP_*` env vars
@@ -222,6 +299,6 @@ prints RSS plus LanceDB cache size every 100 photos.
 ## Status
 
 This is the sole backend implementation (the earlier Python/Flask server
-has been retired). Still under active development on the `rust-rewrite`
-branch — see the plan and progress notes there before assuming a given
-endpoint or feature is fully live.
+has been retired) and it ships on `main`. Still under active development,
+so check `git log` before assuming a given endpoint or feature behaves the
+way an older note describes.


### PR DESCRIPTION
The two local inference backends shipped in #236 and #238 were invisible in the docs: every "local model" reference still meant Ollama or LM Studio, so a user reading the README had no way to learn the backend can download and run a vision model itself.

## User docs

* **New wiki page `Help-Local-AI-Models`** — how `llamacpp` and `mlx` differ (runtime, platforms, GPU path), downloading a model from the Plug-in Manager, the curated catalogs with download sizes and RAM floors, reuse of GGUF/MLX models already in `~/.lmstudio/models` or the HF cache, the llama.cpp tuning knobs and why MLX has none, and troubleshooting keyed to the actual "unavailable" reason strings the backend returns.
* **README, Getting Started, FAQ, Choosing an AI Model, Troubleshooting, Home, Keyword Dedup** — local now means built-in first and external servers second; recommendation tables reworked (privacy-first is no longer "install Ollama"). Getting Started also stops calling the backend a Python server.

## Developer docs

* **`server-rs/README.md`** — the MLX sidecar build (`xcodebuild` + Metal toolchain, and why `swift build` produces a binary that dies on the first inference), the MLX model layout and `LRG_MLX_*` env vars, why there is no `n_ctx`/`n_parallel`/GPU-layers equivalent, and that the Docker image ships neither local backend. The Status section no longer points readers at the retired `rust-rewrite` branch.
* **`Dev-Backend-API.md`** — the previously undocumented `/llm/*` routes, the `mlx`-nested `/llm/catalog` shape, and `llamacpp`/`mlx` plus their per-request tuning fields on `/index` and `/models`.
* **`CONTRIBUTING.md`** — the backend section claimed nothing beyond `rustup`/`cargo` was needed; it now names the `llamacpp` feature's toolchain and the sidecar's.
* **Credits** — llama.cpp, llguidance, MLX/mlx-swift-lm added; the backend list no longer describes the retired Python stack (Flask, ChromaDB, PyTorch, Pillow…).

The three `Dev-*-README` wiki pages are regenerated via `scripts/build-wiki-pages.sh`, as intended.

## Claims deliberately not made

* **That MLX is faster than llama.cpp on Apple silicon.** llama.cpp reuses the shared prompt prefix across a batch and MLX allocates a fresh KV cache per call, so which wins depends on batch size. The docs tell users to compare on their own photos instead.
* **That keyword aliases / bilingual keywords work with local models.** They measurably do not (Gemma 4 E4B: 19 keywords with plain strings, zero with the object form), so the docs warn where the plugin already warns.

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)