### PR TITLE
docs: record which wiki pages reach the website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,24 @@ This repository uses a docs-as-code workflow for GitHub Wiki publishing.
 - Any file ending with `.md` in that folder is published to the GitHub Wiki
 - `docs/wiki/Home.md` becomes the wiki home page
 - Additional generated pages are created from repository READMEs:
-  - `Project-README.md` from `/README.md`
-  - `Plugin-README.md` from `/plugin/README.md`
-  - `Server-README.md` from `/server-rs/README.md`
+  - `Dev-Project-README.md` from `/README.md`
+  - `Dev-Plugin-README.md` from `/plugin/README.md`
+  - `Dev-Server-README.md` from `/server-rs/README.md`
+
+## What lands on lrgenius.com
+
+The website ([LrGenius/lrgenius.github.io](https://github.com/LrGenius/lrgenius.github.io))
+pulls `docs/wiki/` at build time and publishes **every page except**:
+
+- `Dev-*` — developer documentation, wiki-only
+- `Home` — the site has its own `/help` index
+- `_*` — wiki special pages (`_Sidebar`, `_Footer`)
+
+So a new user-facing page goes live at `lrgenius.com/help/docs/<lowercase-name>`
+by itself, and a page that should *not* be public needs a `Dev-` prefix. Give
+each page an `# H1` — the site uses it as the page title. Pages not placed in a
+curated group in the site's `src/pages/help/index.astro` are listed under "More
+Guides"; moving one into a proper group is a change in that repo.
 
 ## Automated publishing
 


### PR DESCRIPTION
The website now publishes `docs/wiki/` by exclusion rather than from an allowlist (LrGenius/lrgenius.github.io#2), so whether a page is public is decided by its **name in this repo** — no longer by a list in the site repo that nobody remembers to update.

Documents that in `docs/README.md`, where someone adding a wiki page would look:

* every page goes live at `lrgenius.com/help/docs/<lowercase-name>` except `Dev-*`, `Home`, and `_*`
* a page that should stay wiki-only needs a `Dev-` prefix
* give each page an `# H1` — the site uses it as the page title

Also corrects the generated-page names in the same file (`Project-README.md` → `Dev-Project-README.md`, and the other two); they gained the prefix a while ago and the file was never updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)