### PR TITLE
Cut tagging output tokens: leaner schema, positional keywords, and the instrumentation to prove it

### DIFF
--- a/native/mlx-sidecar/Sources/lrgenius-mlx/Engine.swift
+++ b/native/mlx-sidecar/Sources/lrgenius-mlx/Engine.swift
@@ -363,6 +363,17 @@ final class Engine {
 
             let (constraint, vocabSize, grammarMs) = grammar
             let whitespace = self.whitespace(for: context)
+            // Splits the answer into what the model chose and what the grammar
+            // forced. Both cost the same: `GuidedGenerationLoop` runs a forward
+            // pass per fast-forward token just as it does per sampled one, so a
+            // high `ff` share is JSON punctuation being decoded at full price.
+            // That is the number that says whether a leaner response *shape*
+            // would pay off, as opposed to a shorter answer.
+            //
+            // The sink is the library's own injection point and every recording
+            // site is nil-guarded, so binding it costs two array appends per
+            // token and changes nothing about the generation.
+            let telemetry = GuidedGenerationDiagnosticSink()
             var output = ""
             // Marks the end of vision-encode + prefill: everything after the
             // first token is pure decode.
@@ -373,40 +384,46 @@ final class Engine {
             // enough of a tally to say which one happened.
             let produced: Int
             do {
-                produced = try GuidedGenerationLoop.run(
-                    input: input,
-                    context: context,
-                    constraint: constraint,
-                    maxTokens: spec.maxTokens,
-                    vocabSize: vocabSize,
-                    // Soft zone only (the library's default 64-token reserve).
-                    // Deliberately no `hardReserve`: the hard zone suppresses
-                    // every token that is not "closing", and `ClosingTokenBias`
-                    // counts the digits 0-9 as closing (they finish a JSON
-                    // *number*). Inside a string that forces digits, which
-                    // yields structurally valid, semantically worthless output
-                    // -- a measured `{"title": "19001", "caption": "19002"}`.
-                    // Junk written into someone's catalog is worse than a photo
-                    // that failed, so the budget only ever nudges here and a
-                    // genuine overrun stays an error.
-                    //
-                    // The reserve is clamped rather than left at the library's
-                    // flat 64 because the zone is defined as
-                    // `tokenCount >= maxTokens - completionReserve`: at a
-                    // budget of 64 or less that is true from the very first
-                    // token, so the bias -- which lifts digits by +100, they
-                    // being how a JSON *number* ends -- drives the whole
-                    // answer. Measured at `max_tokens: 64`, the model emitted
-                    // `{"keywords": ["19000000000...`. A quarter of the budget
-                    // keeps the nudge to the tail where it belongs.
-                    completionReserve: min(64, max(1, spec.maxTokens / 4)),
-                    closingBias: self.bias(for: context),
-                    whitespaceBias: whitespace.bias,
-                    whitespaceTokenIDs: whitespace.tokenIDs
-                ) { delta in
-                    if firstTokenNs == nil { firstTokenNs = DispatchTime.now().uptimeNanoseconds }
-                    output += delta
-                    return true
+                produced = try GuidedGenerationDiagnosticSink.$current.withValue(telemetry) {
+                    try GuidedGenerationLoop.run(
+                        input: input,
+                        context: context,
+                        constraint: constraint,
+                        maxTokens: spec.maxTokens,
+                        vocabSize: vocabSize,
+                        // Soft zone only (the library's default 64-token
+                        // reserve). Deliberately no `hardReserve`: the hard zone
+                        // suppresses every token that is not "closing", and
+                        // `ClosingTokenBias` counts the digits 0-9 as closing
+                        // (they finish a JSON *number*). Inside a string that
+                        // forces digits, which yields structurally valid,
+                        // semantically worthless output -- a measured
+                        // `{"title": "19001", "caption": "19002"}`. Junk written
+                        // into someone's catalog is worse than a photo that
+                        // failed, so the budget only ever nudges here and a
+                        // genuine overrun stays an error.
+                        //
+                        // The reserve is clamped rather than left at the
+                        // library's flat 64 because the zone is defined as
+                        // `tokenCount >= maxTokens - completionReserve`: at a
+                        // budget of 64 or less that is true from the very first
+                        // token, so the bias -- which lifts digits by +100, they
+                        // being how a JSON *number* ends -- drives the whole
+                        // answer. Measured at `max_tokens: 64`, the model
+                        // emitted `{"keywords": ["19000000000...`. A quarter of
+                        // the budget keeps the nudge to the tail where it
+                        // belongs.
+                        completionReserve: min(64, max(1, spec.maxTokens / 4)),
+                        closingBias: self.bias(for: context),
+                        whitespaceBias: whitespace.bias,
+                        whitespaceTokenIDs: whitespace.tokenIDs
+                    ) { delta in
+                        if firstTokenNs == nil {
+                            firstTokenNs = DispatchTime.now().uptimeNanoseconds
+                        }
+                        output += delta
+                        return true
+                    }
                 }
             } catch {
                 Log.info(
@@ -418,7 +435,9 @@ final class Engine {
             Self.logStages(
                 prepareMs: prepareMs, grammarMs: grammarMs, genStart: genStart,
                 firstTokenNs: firstTokenNs, textTokens: textOnlyTokens,
-                promptTokens: promptTokens, produced: produced)
+                promptTokens: promptTokens, produced: produced,
+                sampled: telemetry.sampledTokenIDs.count,
+                forced: telemetry.fastForwardTokenIDs.count)
             return .success(
                 text: output, promptTokens: promptTokens, completionTokens: produced)
         }
@@ -443,9 +462,16 @@ final class Engine {
     /// cost to compile. The compile still runs per photo (see
     /// `grammarTokenizer`), but off the critical path, so anything above a
     /// millisecond or two here means the prefetch did not land in time.
+    ///
+    /// `sampled`/`forced` split `out` into what the model chose and what the
+    /// grammar forced. They cost the same wall-clock, so a large `ff` share is
+    /// the signal that the *shape* of the response is expensive rather than its
+    /// content — punctuation and field names decoded one forward pass at a time.
+    /// Omitted on the unconstrained path, where nothing is forced.
     static func logStages(
         prepareMs: Double, grammarMs: Double?, genStart: UInt64, firstTokenNs: UInt64?,
-        textTokens: Int, promptTokens: Int, produced: Int
+        textTokens: Int, promptTokens: Int, produced: Int,
+        sampled: Int? = nil, forced: Int? = nil
     ) {
         let totalMs = msSince(genStart)
         let ttftMs = firstTokenNs.map { Double($0 &- genStart) / 1_000_000 }
@@ -462,6 +488,10 @@ final class Engine {
         if let grammarMs { line += " grammar=\(fmt(grammarMs))ms" }
         line += " ttft=\(fmt(ttftMs))ms decode=\(fmt(decodeMs))ms"
         line += " | tokens: text=\(textTokens) image=\(promptTokens - textTokens) out=\(produced)"
+        if let sampled, let forced {
+            let share = produced > 0 ? Int((Double(forced) / Double(produced) * 100).rounded()) : 0
+            line += " (sampled=\(sampled) ff=\(forced), \(share)% forced)"
+        }
         if let decodeRate { line += " | decode \(fmt(decodeRate)) tok/s" }
         Log.info(line)
     }

--- a/native/mlx-sidecar/Sources/lrgenius-mlx/Engine.swift
+++ b/native/mlx-sidecar/Sources/lrgenius-mlx/Engine.swift
@@ -247,28 +247,72 @@ final class Engine {
 
         let userInput = UserInput(chat: messages)
 
+        // The same turns without the photo. Used only to price the image half
+        // of the prompt — see `textOnlyTokens` below.
+        var textOnlyMessages: [Chat.Message] = []
+        if !spec.systemPrompt.isEmpty {
+            textOnlyMessages.append(.system(spec.systemPrompt))
+        }
+        textOnlyMessages.append(.user(userText))
+        let textOnlyInput = UserInput(chat: textOnlyMessages)
+
         return try await loaded.container.perform { context in
+            let tStart = DispatchTime.now().uptimeNanoseconds
             let input = try await context.processor.prepare(input: userInput)
             let promptTokens = input.text.tokens.size
+            let prepareMs = Self.msSince(tStart)
+
+            // The processor splices the image's placeholder tokens straight
+            // into `input.text.tokens`, so `promptTokens` already counts them
+            // and no separate image-token tally is missing. What it hides is
+            // the *split*: Gemma 4 spends a fixed budget per photo regardless
+            // of pixel size (measured: 262 tokens for both a 187x125 and a
+            // 2048x1365 input), so a prompt that looks large may be mostly
+            // picture, or mostly keyword taxonomy, and those have very
+            // different fixes. Re-rendering the turns without the photo is a
+            // template render plus a tokenize — no model forward — and it is
+            // the only way to tell the two apart. Best effort: a failure here
+            // must never cost the photo its answer.
+            var textOnlyTokens = promptTokens
+            if image != nil,
+                let textOnly = try? await context.processor.prepare(input: textOnlyInput)
+            {
+                textOnlyTokens = textOnly.text.tokens.size
+            }
 
             guard let schema = spec.schema, !schema.isEmpty else {
                 let parameters = GenerateParameters(
                     maxTokens: spec.maxTokens, temperature: spec.temperature)
+                let genStart = DispatchTime.now().uptimeNanoseconds
+                var firstTokenNs: UInt64?
                 // The closure parameter is spelled out because `generate` is
                 // overloaded on `([Int]) -> _` and `(Int) -> _`, and only the
                 // former hands back the full token list this needs.
                 let result = try MLXLMCommon.generate(
                     input: input, parameters: parameters, context: context
-                ) { (_: [Int]) -> GenerateDisposition in .more }
+                ) { (_: [Int]) -> GenerateDisposition in
+                    if firstTokenNs == nil { firstTokenNs = DispatchTime.now().uptimeNanoseconds }
+                    return .more
+                }
+                Self.logStages(
+                    prepareMs: prepareMs, grammarMs: nil, genStart: genStart,
+                    firstTokenNs: firstTokenNs, textTokens: textOnlyTokens,
+                    promptTokens: promptTokens, produced: result.tokenIds.count)
                 return .success(
                     text: result.output,
                     promptTokens: promptTokens,
                     completionTokens: result.tokenIds.count)
             }
 
+            let tGrammar = DispatchTime.now().uptimeNanoseconds
             let (constraint, vocabSize) = try self.constraint(for: schema, context: context)
             let whitespace = self.whitespace(for: context)
+            let grammarMs = Self.msSince(tGrammar)
             var output = ""
+            // Marks the end of vision-encode + prefill: everything after the
+            // first token is pure decode.
+            var firstTokenNs: UInt64?
+            let genStart = DispatchTime.now().uptimeNanoseconds
             // `run` throws away everything it generated when it throws, which
             // makes an overrun impossible to tell apart from a stall. Keep
             // enough of a tally to say which one happened.
@@ -305,6 +349,7 @@ final class Engine {
                     whitespaceBias: whitespace.bias,
                     whitespaceTokenIDs: whitespace.tokenIDs
                 ) { delta in
+                    if firstTokenNs == nil { firstTokenNs = DispatchTime.now().uptimeNanoseconds }
                     output += delta
                     return true
                 }
@@ -315,9 +360,53 @@ final class Engine {
                         + "\(spec.maxTokens) tokens); tail: \(String(output.suffix(120)))")
                 throw error
             }
+            Self.logStages(
+                prepareMs: prepareMs, grammarMs: grammarMs, genStart: genStart,
+                firstTokenNs: firstTokenNs, textTokens: textOnlyTokens,
+                promptTokens: promptTokens, produced: produced)
             return .success(
                 text: output, promptTokens: promptTokens, completionTokens: produced)
         }
+    }
+
+    /// Milliseconds since a `DispatchTime.now().uptimeNanoseconds` reading.
+    /// Monotonic, so a clock adjustment mid-run cannot skew it.
+    @inline(__always)
+    static func msSince(_ startNanos: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds &- startNanos) / 1_000_000
+    }
+
+    /// One line per photo, splitting a generation into the stages that have
+    /// different fixes.
+    ///
+    /// `ttft` (time to first token) is vision-encode plus prefill: everything
+    /// the model does before it can emit anything. What follows is pure
+    /// decode, which is memory-bandwidth bound and scales with the number of
+    /// output tokens. Reading the two against each other is what says whether
+    /// a slow run wants a shorter prompt or a shorter answer — and `grammar`
+    /// prices the constraint compile this backend pays per photo, because
+    /// `GrammarConstraint` cannot be cloned in this build.
+    static func logStages(
+        prepareMs: Double, grammarMs: Double?, genStart: UInt64, firstTokenNs: UInt64?,
+        textTokens: Int, promptTokens: Int, produced: Int
+    ) {
+        let totalMs = msSince(genStart)
+        let ttftMs = firstTokenNs.map { Double($0 &- genStart) / 1_000_000 }
+        let decodeMs = ttftMs.map { totalMs - $0 }
+        // The first token is charged to ttft, so the rate covers the rest;
+        // with one token or none there is no rate worth printing.
+        let decodeRate: Double? = decodeMs.flatMap { elapsed in
+            produced > 1 && elapsed > 0 ? Double(produced - 1) / (elapsed / 1000) : nil
+        }
+        func fmt(_ value: Double?) -> String {
+            value.map { String(format: "%.1f", $0) } ?? "n/a"
+        }
+        var line = "stages: prepare=\(fmt(prepareMs))ms"
+        if let grammarMs { line += " grammar=\(fmt(grammarMs))ms" }
+        line += " ttft=\(fmt(ttftMs))ms decode=\(fmt(decodeMs))ms"
+        line += " | tokens: text=\(textTokens) image=\(promptTokens - textTokens) out=\(produced)"
+        if let decodeRate { line += " | decode \(fmt(decodeRate)) tok/s" }
+        Log.info(line)
     }
 
     /// Percentage of `text` that is whitespace, rounded to a whole number.

--- a/native/mlx-sidecar/Sources/lrgenius-mlx/Engine.swift
+++ b/native/mlx-sidecar/Sources/lrgenius-mlx/Engine.swift
@@ -79,16 +79,38 @@ final class Engine {
     /// depends only on the loaded model — so it is rebuilt on `load` and never
     /// per request.
     ///
-    /// Note what is *not* cached: the `GrammarConstraint` itself.
-    /// `GrammarConstraint` carries mutable matcher state, so reusing one across
-    /// photos would need `clone()` — and `clone()` (xgrammar's
-    /// `GrammarMatcher::Fork()`) fails with `forkFailed` in this build. So each
-    /// request compiles its own constraint. That costs a grammar compile per
-    /// photo, which the README warns is hundreds of milliseconds; it is still
-    /// small against a VLM prefill, and correctness beats the saving. If fork
-    /// starts working upstream, caching a pristine template and cloning it is
-    /// the optimization to make here.
+    /// Note what is *not* cached: the `GrammarConstraint` itself. It carries
+    /// mutable matcher state, so one cannot be shared across photos, and the
+    /// two ways to get a pristine one are both closed here. `clone()`
+    /// (xgrammar's `GrammarMatcher::Fork()`) fails with `forkFailed` in this
+    /// build. Rewinding a used constraint with `rollback` is worse than it
+    /// looks: the loop's token count is not the matcher's acceptance count
+    /// (truncated fast-forward tokens are accepted but never counted), and the
+    /// obvious guard — compare the rewound mask against the pristine one — has
+    /// real collisions, because in an array-of-objects schema the state after
+    /// `"keywords": [` admits exactly the same tokens as the very start.
+    ///
+    /// So every request compiles its own constraint, at a measured ~450ms.
+    /// What removes that from the clock is `pendingGrammar`: the compile is
+    /// pure CPU work in xgrammar with no MLX involvement, so it runs for the
+    /// *next* photo while the current one decodes on the GPU.
     private var grammarTokenizer: GrammarTokenizer?
+
+    /// The model's own tokenizer, kept so a grammar compile can be started
+    /// from outside `ModelContainer.perform`.
+    ///
+    /// `GrammarConstraint` only stores this (it encodes fast-forward strings
+    /// during generation, long after construction), so holding the reference
+    /// here adds no concurrent use of the tokenizer.
+    /// (`Tokenizer` is spelled out because `Tokenizers` exports one too.)
+    private var hostTokenizer: (any MLXLMCommon.Tokenizer)?
+
+    /// A grammar compile started ahead of the photo that will use it.
+    ///
+    /// At most one is ever in flight: the compile for photo *i+1* is started
+    /// only once photo *i* has taken its own constraint, so two threads never
+    /// sit in xgrammar at the same time.
+    private var pendingGrammar: (schema: String, task: Task<GrammarConstraint, Error>)?
 
     /// Logit bias favouring the tokens that *close* a JSON value (`"`, `}`,
     /// `]`, digits, EOS), cached for the same reason as `grammarTokenizer`:
@@ -169,7 +191,7 @@ final class Engine {
 
         loaded = Loaded(
             container: container, directory: directory, supportsVision: supportsVision)
-        grammarTokenizer = nil
+        dropGrammarState()
         closingBias = nil
         whitespacePenalty = nil
 
@@ -185,13 +207,25 @@ final class Engine {
     func unload() {
         guard loaded != nil else { return }
         loaded = nil
-        grammarTokenizer = nil
+        dropGrammarState()
         closingBias = nil
         whitespacePenalty = nil
         // MLX keeps freed blocks in its own allocator pool, so dropping the
         // container is not by itself enough to return the weights to the OS.
         MLX.GPU.clearCache()
         Log.info("Unloaded MLX model")
+    }
+
+    /// Forget everything tied to the outgoing model's vocabulary.
+    ///
+    /// A grammar in flight is cancelled and dropped rather than awaited: it was
+    /// compiled against a tokenizer that is going away, so its only remaining
+    /// use would be to produce masks over the wrong vocabulary.
+    private func dropGrammarState() {
+        pendingGrammar?.task.cancel()
+        pendingGrammar = nil
+        grammarTokenizer = nil
+        hostTokenizer = nil
     }
 
     // MARK: - Generation
@@ -207,11 +241,23 @@ final class Engine {
     func generate(specs: [GenerationSpec]) async throws -> [GenerationResultPayload] {
         guard let loaded else { throw EngineError.noModelLoaded }
 
+        // Only pay for the vocabulary walk when something in this batch is
+        // actually schema-constrained; `generate_text` callers are not.
+        if specs.contains(where: { !($0.schema ?? "").isEmpty }) {
+            try await prepareGrammarVocabulary(loaded)
+        }
+
         var results: [GenerationResultPayload] = []
         results.reserveCapacity(specs.count)
-        for spec in specs {
+        startGrammarCompile(for: specs.first?.schema)
+        for (index, spec) in specs.enumerated() {
             do {
-                results.append(try await generateOne(spec: spec, loaded: loaded))
+                let grammar = try await takeConstraint(for: spec.schema)
+                // Started before the photo runs, so the compile overlaps this
+                // photo's prefill and decode instead of preceding the next one.
+                startGrammarCompile(for: index + 1 < specs.count ? specs[index + 1].schema : nil)
+                results.append(
+                    try await generateOne(spec: spec, loaded: loaded, grammar: grammar))
             } catch {
                 results.append(.failure(describe(error)))
             }
@@ -219,7 +265,12 @@ final class Engine {
         return results
     }
 
-    private func generateOne(spec: GenerationSpec, loaded: Loaded) async throws
+    /// A constraint, the vocabulary size the decode loop needs, and the
+    /// milliseconds this photo actually spent waiting for the compile — near
+    /// zero whenever the prefetch landed in time.
+    private typealias Grammar = (constraint: GrammarConstraint, vocabSize: Int, waitMs: Double)
+
+    private func generateOne(spec: GenerationSpec, loaded: Loaded, grammar: Grammar?) async throws
         -> GenerationResultPayload
     {
         if spec.image != nil && !loaded.supportsVision {
@@ -230,8 +281,14 @@ final class Engine {
 
         // Ordering matters: the run-constant half goes first so that whatever
         // prefix reuse the stack can manage has the longest possible common
-        // head. It buys nothing today (a fresh cache per call), but putting the
-        // volatile half first would make it impossible later.
+        // head. It buys nothing today, and on Gemma it would buy nothing even
+        // with a warm cache: `Gemma4MessageGenerator` builds the user turn as
+        // image parts *then* the text part, so the photo — the one thing that
+        // changes every request — sits ahead of all of this. llama.cpp puts its
+        // media marker last for exactly that reason (`worker.rs::split_render`),
+        // but the ordering inside an MLX chat turn is the model's to decide.
+        // Reusing the taxonomy prefix here would mean moving it into the
+        // *system* message, which renders before the user turn.
         var userText = spec.stablePrompt
         if !spec.perPhotoPrompt.isEmpty {
             if !userText.isEmpty { userText += "\n\n" }
@@ -280,7 +337,7 @@ final class Engine {
                 textOnlyTokens = textOnly.text.tokens.size
             }
 
-            guard let schema = spec.schema, !schema.isEmpty else {
+            guard let grammar else {
                 let parameters = GenerateParameters(
                     maxTokens: spec.maxTokens, temperature: spec.temperature)
                 let genStart = DispatchTime.now().uptimeNanoseconds
@@ -304,10 +361,8 @@ final class Engine {
                     completionTokens: result.tokenIds.count)
             }
 
-            let tGrammar = DispatchTime.now().uptimeNanoseconds
-            let (constraint, vocabSize) = try self.constraint(for: schema, context: context)
+            let (constraint, vocabSize, grammarMs) = grammar
             let whitespace = self.whitespace(for: context)
-            let grammarMs = Self.msSince(tGrammar)
             var output = ""
             // Marks the end of vision-encode + prefill: everything after the
             // first token is pure decode.
@@ -384,8 +439,10 @@ final class Engine {
     /// decode, which is memory-bandwidth bound and scales with the number of
     /// output tokens. Reading the two against each other is what says whether
     /// a slow run wants a shorter prompt or a shorter answer — and `grammar`
-    /// prices the constraint compile this backend pays per photo, because
-    /// `GrammarConstraint` cannot be cloned in this build.
+    /// is what this photo *waited* for its constraint, not what the constraint
+    /// cost to compile. The compile still runs per photo (see
+    /// `grammarTokenizer`), but off the critical path, so anything above a
+    /// millisecond or two here means the prefetch did not land in time.
     static func logStages(
         prepareMs: Double, grammarMs: Double?, genStart: UInt64, firstTokenNs: UInt64?,
         textTokens: Int, promptTokens: Int, produced: Int
@@ -422,32 +479,87 @@ final class Engine {
         return Int((Double(spaces) / Double(text.count) * 100).rounded())
     }
 
-    /// A fresh constraint for `schema` plus the vocabulary size the decode loop
-    /// needs.
+    /// Build the grammar vocabulary once per loaded model.
     ///
-    /// The size comes back alongside the constraint because `GrammarConstraint`
-    /// keeps its own copy private; only the tokenizer exposes one.
-    private func constraint(for schema: String, context: ModelContext) throws
-        -> (GrammarConstraint, Int)
-    {
-        let tokenizer: GrammarTokenizer
-        if let existing = grammarTokenizer {
-            tokenizer = existing
-        } else {
+    /// Taken out of the per-photo path so a compile can be started without
+    /// holding `ModelContainer.perform` — the container is busy generating for
+    /// the whole time the prefetch wants to run.
+    private func prepareGrammarVocabulary(_ loaded: Loaded) async throws {
+        if grammarTokenizer != nil, hostTokenizer != nil { return }
+        try await loaded.container.perform { context in
+            let tVocab = DispatchTime.now().uptimeNanoseconds
             let vocab = TokenizerVocabExtractor.extractForGrammar(from: context.tokenizer)
-            tokenizer = try GrammarTokenizer(
+            self.grammarTokenizer = try GrammarTokenizer(
                 vocab: vocab.vocab,
                 vocabType: vocab.vocabType,
                 eosTokenId: Int32(context.tokenizer.eosTokenId ?? 0))
-            grammarTokenizer = tokenizer
-        }
+            self.hostTokenizer = context.tokenizer
+            let vocabMs = Self.msSince(tVocab)
 
+            // Warmed here rather than on first use so the whole one-time cost
+            // lands in this line instead of inflating the first photo's stage
+            // timings. Each of these walks the model's full vocabulary, which
+            // is where the ~450ms once attributed to "grammar compile per
+            // photo" actually went — see the numbers this logs.
+            let tBias = DispatchTime.now().uptimeNanoseconds
+            _ = self.bias(for: context)
+            _ = self.whitespace(for: context)
+            Log.info(
+                String(
+                    format: "grammar vocabulary ready: extract=%.1fms bias=%.1fms (%d tokens)",
+                    vocabMs, Self.msSince(tBias), vocab.vocab.count))
+        }
+    }
+
+    /// Start compiling `schema` in the background, to be picked up by
+    /// `takeConstraint` when the photo that needs it comes round.
+    ///
+    /// Silently does nothing when there is no schema or no vocabulary yet;
+    /// `takeConstraint` then compiles inline, which is exactly the old
+    /// behaviour. Nothing here can make a photo fail — a compile error is
+    /// stored in the task and surfaces at the point that photo asks for it.
+    private func startGrammarCompile(for schema: String?) {
+        guard let schema, !schema.isEmpty,
+            let tokenizer = grammarTokenizer, let host = hostTokenizer
+        else { return }
+        if let pending = pendingGrammar, pending.schema == schema { return }
+        pendingGrammar?.task.cancel()
+        pendingGrammar = (
+            schema,
+            Task.detached(priority: .userInitiated) {
+                try GrammarConstraint(
+                    tokenizer: tokenizer,
+                    jsonSchema: schema,
+                    fastForward: true,
+                    hostTokenizer: host)
+            }
+        )
+    }
+
+    /// The constraint for `schema`, from the prefetch when it matches and from
+    /// a fresh compile otherwise.
+    ///
+    /// The vocabulary size comes back alongside because `GrammarConstraint`
+    /// keeps its own copy private; only the tokenizer exposes one.
+    private func takeConstraint(for schema: String?) async throws -> Grammar? {
+        guard let schema, !schema.isEmpty else { return nil }
+        guard let tokenizer = grammarTokenizer, let host = hostTokenizer else {
+            throw EngineError.noModelLoaded
+        }
+        let start = DispatchTime.now().uptimeNanoseconds
+        if let pending = pendingGrammar, pending.schema == schema {
+            pendingGrammar = nil
+            return (try await pending.task.value, tokenizer.vocabSize, Self.msSince(start))
+        }
+        // A different schema than the one queued: that compile is now waste.
+        pendingGrammar?.task.cancel()
+        pendingGrammar = nil
         let constraint = try GrammarConstraint(
             tokenizer: tokenizer,
             jsonSchema: schema,
             fastForward: true,
-            hostTokenizer: context.tokenizer)
-        return (constraint, tokenizer.vocabSize)
+            hostTokenizer: host)
+        return (constraint, tokenizer.vocabSize, Self.msSince(start))
     }
 
     /// The cached closing-token bias for the loaded model, computed on first use.

--- a/native/mlx-sidecar/Sources/lrgenius-mlx/Protocol.swift
+++ b/native/mlx-sidecar/Sources/lrgenius-mlx/Protocol.swift
@@ -109,9 +109,20 @@ struct GenerationResultPayload: Encodable {
     let text: String?
     let promptTokens: Int?
     let completionTokens: Int?
-    /// Always false on this backend. `GuidedGenerationLoop.run` allocates a
-    /// fresh KV cache per call (`model.newCache`) with no seam to hand it a
-    /// pre-filled one, so the stable prefix is re-prefilled for every photo.
+    /// Always false on this backend, for two reasons that both have to be
+    /// fixed before it could ever be true.
+    ///
+    /// `GuidedGenerationLoop.run` allocates a fresh KV cache per call
+    /// (`model.newCache`) and neither accepts nor returns one, so there is no
+    /// seam to hand it a pre-filled cache. Still true at mlx-swift-lm HEAD as
+    /// of 2026-08-13; the prompt-cache work in #475 landed in MLXLMCommon, not
+    /// in the guided loop.
+    ///
+    /// And even with that seam there would be almost nothing to reuse: Gemma's
+    /// message generator orders the user turn as image-then-text, so the photo
+    /// precedes the run-constant prompt and only the system turn is common
+    /// across photos. See the ordering note in `Engine.generateOne`.
+    ///
     /// Reported honestly rather than optimistically: the llama.cpp backend
     /// really does pin its prefix, and conflating the two would make the
     /// `--debug` logs lie about where the time goes.

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -631,6 +631,17 @@ pub(crate) async fn process_batch(
         .collect();
 
     if !llm_indices.is_empty() {
+        // Token accounting for the run. The per-photo lines are `debug` — a
+        // few thousand photos would drown the log — but the aggregate below
+        // is `info`, because it is the number to compare across changes to
+        // the prompt or the response schema. Output tokens are the expensive
+        // ones: each costs a full pass over the model weights, so the
+        // out-tokens-per-second figure is what says whether decode dominates.
+        let mut llm_photos: u64 = 0;
+        let mut total_in: u64 = 0;
+        let mut total_out: u64 = 0;
+        let mut total_llm_secs: f64 = 0.0;
+
         match provider_for_batch(&state, &options).await {
             Ok(provider) => {
                 let batch_size = options
@@ -644,13 +655,24 @@ pub(crate) async fn process_batch(
                         .collect();
                     let t0 = Instant::now();
                     let responses = provider.generate_metadata_batch(&requests).await;
+                    let elapsed = t0.elapsed();
+                    total_llm_secs += elapsed.as_secs_f64();
                     log::debug!(
                         "LLM batch of {} photo(s) via {} took {:?}",
                         group.len(),
                         provider.name(),
-                        t0.elapsed()
+                        elapsed
                     );
                     for (&i, response) in group.iter().zip(responses) {
+                        log::debug!(
+                            "Photo {}: LLM tokens in={} out={}",
+                            prepared[i].photo_id,
+                            response.input_tokens,
+                            response.output_tokens
+                        );
+                        llm_photos += 1;
+                        total_in += u64::from(response.input_tokens);
+                        total_out += u64::from(response.output_tokens);
                         llm_responses[i] = Some(response);
                     }
                 }
@@ -667,6 +689,22 @@ pub(crate) async fn process_batch(
                     });
                 }
             }
+        }
+
+        if llm_photos > 0 {
+            let photos = llm_photos as f64;
+            log::info!(
+                "LLM tokens over {llm_photos} photo(s): in={total_in} out={total_out} \
+                 (mean per photo: in={:.0} out={:.0}); {:.1}s total, {:.1} output tok/s",
+                total_in as f64 / photos,
+                total_out as f64 / photos,
+                total_llm_secs,
+                if total_llm_secs > 0.0 {
+                    total_out as f64 / total_llm_secs
+                } else {
+                    0.0
+                }
+            );
         }
     }
 

--- a/server-rs/crates/lrg-llama/src/worker.rs
+++ b/server-rs/crates/lrg-llama/src/worker.rs
@@ -457,6 +457,17 @@ impl WorkerState<'_> {
         let mut slots: Vec<Slot> = Vec::new();
         let mut prefix_reused = false;
 
+        // Stage timing, batch-level because that is the unit that is real
+        // here: every live sequence decodes together, one token per sequence
+        // per step, so per-photo decode time does not exist to be measured.
+        // `prefill` covers vision-encode, prompt evaluation, the grammar
+        // setup in `build_sampler` and the first sampled token — everything
+        // before the decode loop. Splitting the grammar out separately is
+        // worth it on the MLX backend, where the constraint compile runs into
+        // hundreds of milliseconds; llguidance builds its parser here and has
+        // not shown up as a cost worth its own timer.
+        let t_prefill = std::time::Instant::now();
+
         for (idx, request) in requests.iter().enumerate() {
             let seq_id = i32::try_from(idx).unwrap_or(i32::MAX) + 1;
             match self.prefill_one(ctx, request, idx, seq_id, &mut prefix_reused) {
@@ -473,6 +484,10 @@ impl WorkerState<'_> {
             }
         }
 
+        let prefill_ms = t_prefill.elapsed().as_secs_f64() * 1000.0;
+        let photos = slots.len();
+
+        let t_decode = std::time::Instant::now();
         if !slots.is_empty() {
             if let Err(e) = self.decode(ctx, &mut slots) {
                 for slot in &slots {
@@ -480,12 +495,17 @@ impl WorkerState<'_> {
                 }
             }
         }
+        let decode_ms = t_decode.elapsed().as_secs_f64() * 1000.0;
 
+        let mut total_prompt: u32 = 0;
+        let mut total_completion: u32 = 0;
         let prefix_len = self.prefix.as_ref().map_or(0, |p| p.len);
         for slot in slots {
             // Release only this photo's tail; sequence 0 keeps the prefix.
             let _ = ctx.kv_cache_seq_rm(slot.seq_id, Some(prefix_len.cast_unsigned()), None);
             if results[slot.idx].is_ok() {
+                total_prompt = total_prompt.saturating_add(slot.prompt_tokens);
+                total_completion = total_completion.saturating_add(slot.completion_tokens);
                 results[slot.idx] = Ok(GenerationOutput {
                     text: slot.text,
                     prompt_tokens: slot.prompt_tokens,
@@ -493,6 +513,24 @@ impl WorkerState<'_> {
                     prefix_reused,
                 });
             }
+        }
+
+        if photos > 0 {
+            // Tokens per second is over the batch: with `n_parallel > 1` the
+            // weights are read once per step for every sequence at once, so
+            // the rate rises with batch width while per-photo latency does
+            // not. That is the whole point of batching, and reading the rate
+            // as a per-photo figure would misread it.
+            let rate = if decode_ms > 0.0 {
+                f64::from(total_completion) / (decode_ms / 1000.0)
+            } else {
+                0.0
+            };
+            log::debug!(
+                "stages: photos={photos} prefill={prefill_ms:.1}ms decode={decode_ms:.1}ms | \
+                 tokens: prompt={total_prompt} out={total_completion} | \
+                 decode {rate:.1} tok/s (batch) | prefix_reused={prefix_reused}"
+            );
         }
         results
     }

--- a/server-rs/crates/lrg-mlx/src/engine.rs
+++ b/server-rs/crates/lrg-mlx/src/engine.rs
@@ -394,11 +394,23 @@ pub fn resolve_sidecar() -> Result<PathBuf, MlxError> {
 
             // A cargo dev build lives at server-rs/target/<profile>/, so the
             // sidecar's build directory is three levels up plus native/.
-            let from_target = dir.ancestors().nth(3).map(|root| {
-                root.join("native/mlx-sidecar/.build/release")
-                    .join(SIDECAR_BIN)
+            //
+            // The xcodebuild output comes first because it is the only one
+            // that runs: `swift build` cannot compile MLX's Metal shaders, so
+            // the binary it produces dies at load with "Failed to load the
+            // default metallib". Its path is still checked second, because a
+            // stale one being found is better than no sidecar at all — it
+            // fails with a message naming metallib rather than one naming
+            // nothing.
+            let roots = dir.ancestors().nth(3).map(|root| {
+                [
+                    root.join("native/mlx-sidecar/.build/xcode/Build/Products/Release")
+                        .join(SIDECAR_BIN),
+                    root.join("native/mlx-sidecar/.build/release")
+                        .join(SIDECAR_BIN),
+                ]
             });
-            if let Some(candidate) = from_target {
+            for candidate in roots.into_iter().flatten() {
                 if candidate.is_file() {
                     return Ok(candidate);
                 }
@@ -409,7 +421,9 @@ pub fn resolve_sidecar() -> Result<PathBuf, MlxError> {
 
     Err(MlxError::SidecarMissing(format!(
         "The MLX helper '{SIDECAR_BIN}' was not found. Looked in: {}. Build it with \
-         `cd native/mlx-sidecar && swift build -c release`, or set LRG_MLX_SIDECAR.",
+         `cd native/mlx-sidecar && xcodebuild build -scheme lrgenius-mlx -destination \
+         'platform=macOS,arch=arm64' -configuration Release -derivedDataPath .build/xcode` \
+         (plain `swift build` cannot compile the Metal shaders), or set LRG_MLX_SIDECAR.",
         tried
             .iter()
             .map(|p| p.display().to_string())

--- a/server-rs/crates/lrg-providers/src/gemini.rs
+++ b/server-rs/crates/lrg-providers/src/gemini.rs
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 use crate::edit_recipe::{gemini_edit_recipe_schema, normalize_edit_recipe};
 use crate::gemini_schema::prepare_gemini_response_schema;
 use crate::image_encode::image_to_base64;
-use crate::normalize::normalize_keywords_structure;
+use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -290,20 +290,24 @@ impl GeminiProvider {
             Err(e) => return fail(&request.uuid, format!("JSON parsing error: {e}")),
         };
 
-        let keywords =
-            normalize_keywords_structure(&parsed.get("keywords").cloned().unwrap_or(json!([])));
+        let keywords = normalize_keywords(
+            &parsed.get("keywords").cloned().unwrap_or(json!([])),
+            request.keyword_categories.as_ref(),
+        );
+        let caption = if request.generate_caption {
+            parsed
+                .get("caption")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
-            caption: if request.generate_caption {
-                parsed
-                    .get("caption")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            caption,
             title: if request.generate_title {
                 parsed
                     .get("title")
@@ -312,14 +316,7 @@ impl GeminiProvider {
             } else {
                 None
             },
-            alt_text: if request.generate_alt_text {
-                parsed
-                    .get("alt_text")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            alt_text,
             input_tokens,
             output_tokens,
             error: None,

--- a/server-rs/crates/lrg-providers/src/gemini.rs
+++ b/server-rs/crates/lrg-providers/src/gemini.rs
@@ -15,6 +15,7 @@ use tokio::sync::Mutex;
 use crate::edit_recipe::{gemini_edit_recipe_schema, normalize_edit_recipe};
 use crate::gemini_schema::prepare_gemini_response_schema;
 use crate::image_encode::image_to_base64;
+use crate::keyword_taxonomy::KeywordLeafEncoding;
 use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
@@ -293,6 +294,7 @@ impl GeminiProvider {
         let keywords = normalize_keywords(
             &parsed.get("keywords").cloned().unwrap_or(json!([])),
             request.keyword_categories.as_ref(),
+            KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases),
         );
         let caption = if request.generate_caption {
             parsed

--- a/server-rs/crates/lrg-providers/src/gemini_schema.rs
+++ b/server-rs/crates/lrg-providers/src/gemini_schema.rs
@@ -1,16 +1,23 @@
-//! Port of `providers/gemini.py`'s dedicated Gemini response-schema
-//! builder (`_prepare_gemini_response_schema` / `_build_nested_gemini_keyword_schema`
-//! / `_gemini_keyword_leaf_item_schema`). Kept separate from `schema.rs`
-//! (the OpenAI-flavor builder) because Gemini's structured-output schema
-//! uses uppercase type names and omits `additionalProperties`/top-level
-//! `required` — it is not simply a mechanical case change of the OpenAI
-//! shape, so it is built fresh rather than derived via `edit_recipe`'s
+//! Gemini's dedicated response-schema builder. Kept separate from
+//! `schema.rs` (the OpenAI-flavor builder) because Gemini's structured-output
+//! schema uses uppercase type names and omits `additionalProperties`/
+//! top-level `required` — it is not simply a mechanical case change of the
+//! OpenAI shape, so it is built fresh rather than derived via `edit_recipe`'s
 //! generic OpenAI->Gemini converter.
+//!
+//! The response *shape* mirrors `schema.rs` exactly — flat `{category, items}`
+//! keyword groups, lean `required` — so a photo produces the same JSON
+//! whichever provider answered. See `schema.rs` for why the shape is what it
+//! is.
 
 use serde_json::{json, Map, Value};
 
-use crate::types::{KeywordCategories, MetadataGenerationRequest};
+use crate::keyword_taxonomy::CategoryLabels;
+use crate::types::MetadataGenerationRequest;
 
+/// See `schema.rs::keyword_leaf_item_schema` — `aliases` and
+/// `synonym_aliases` stay optional so the prompt's "omit when absent"
+/// guidance can actually be followed.
 fn gemini_keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
     if !bilingual && !aliases {
         return json!({"type": "STRING"});
@@ -23,7 +30,6 @@ fn gemini_keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
             "aliases".into(),
             json!({"type": "ARRAY", "items": {"type": "STRING"}}),
         );
-        required.push("aliases".to_string());
     }
     if bilingual {
         properties.insert(
@@ -36,30 +42,30 @@ fn gemini_keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
                 "synonym_aliases".into(),
                 json!({"type": "ARRAY", "items": {"type": "STRING"}}),
             );
-            required.push("synonym_aliases".to_string());
         }
     }
     json!({"type": "OBJECT", "properties": properties, "required": required})
 }
 
-fn build_nested_gemini_keyword_schema(
-    tree: &crate::types::KeywordTree,
-    bilingual: bool,
-    aliases: bool,
-) -> Value {
-    let mut properties = Map::new();
-    for (name, children) in tree.iter() {
-        let field = if !children.is_empty() {
-            build_nested_gemini_keyword_schema(children, bilingual, aliases)
-        } else {
-            json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(bilingual, aliases)})
-        };
-        properties.insert(name.clone(), field);
-    }
-    json!({"type": "OBJECT", "properties": properties})
+/// The flat `{category, items}` group list, Gemini-flavored.
+fn gemini_keyword_groups_schema(labels: &CategoryLabels, bilingual: bool, aliases: bool) -> Value {
+    let categories: Vec<&str> = labels.labels().collect();
+    json!({
+        "type": "ARRAY",
+        "items": {
+            "type": "OBJECT",
+            "properties": {
+                "category": {"type": "STRING", "enum": categories},
+                "items": {
+                    "type": "ARRAY",
+                    "items": gemini_keyword_leaf_item_schema(bilingual, aliases),
+                },
+            },
+            "required": ["category", "items"],
+        }
+    })
 }
 
-/// Port of `_prepare_gemini_response_schema`.
 pub fn prepare_gemini_response_schema(request: &MetadataGenerationRequest) -> Value {
     let mut properties = Map::new();
 
@@ -69,25 +75,23 @@ pub fn prepare_gemini_response_schema(request: &MetadataGenerationRequest) -> Va
     if request.generate_caption {
         properties.insert("caption".into(), json!({"type": "STRING"}));
     }
-    if request.generate_alt_text {
+    // Derived from `caption` when both are requested — see `schema.rs`.
+    if request.generate_alt_text && !request.generate_caption {
         properties.insert("alt_text".into(), json!({"type": "STRING"}));
     }
     if request.generate_keywords {
         let keywords_schema = match &request.keyword_categories {
-            Some(KeywordCategories::Nested(tree)) => build_nested_gemini_keyword_schema(
-                tree,
-                request.bilingual_keywords,
-                request.generate_aliases,
-            ),
-            Some(KeywordCategories::Flat(list)) => {
-                let mut props = Map::new();
-                for category in list {
-                    props.insert(
-                        category.clone(),
-                        json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)}),
-                    );
+            Some(categories) => {
+                let labels = CategoryLabels::from_categories(categories);
+                if labels.is_empty() {
+                    json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
+                } else {
+                    gemini_keyword_groups_schema(
+                        &labels,
+                        request.bilingual_keywords,
+                        request.generate_aliases,
+                    )
                 }
-                json!({"type": "OBJECT", "properties": props})
             }
             None => {
                 json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
@@ -102,7 +106,7 @@ pub fn prepare_gemini_response_schema(request: &MetadataGenerationRequest) -> Va
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::KeywordTree;
+    use crate::types::{KeywordCategories, KeywordTree};
 
     fn base_request() -> MetadataGenerationRequest {
         MetadataGenerationRequest::default()
@@ -128,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    fn bilingual_and_aliases_add_required_leaf_fields() {
+    fn optional_alias_fields_are_not_required() {
         let mut req = base_request();
         req.generate_keywords = true;
         req.bilingual_keywords = true;
@@ -136,20 +140,13 @@ mod tests {
         let schema = prepare_gemini_response_schema(&req);
         let item = &schema["properties"]["keywords"]["items"];
         assert_eq!(item["type"], "OBJECT");
-        let required: Vec<&str> = item["required"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|v| v.as_str().unwrap())
-            .collect();
-        assert_eq!(
-            required,
-            vec!["name", "aliases", "synonyms", "synonym_aliases"]
-        );
+        assert_eq!(item["required"], json!(["name", "synonyms"]));
+        assert!(item["properties"].get("aliases").is_some());
+        assert!(item["properties"].get("synonym_aliases").is_some());
     }
 
     #[test]
-    fn nested_categories_recurse_without_additional_properties() {
+    fn nested_categories_flatten_to_a_group_list_with_an_enum() {
         let mut req = base_request();
         req.generate_keywords = true;
         let tree: KeywordTree = KeywordTree(vec![(
@@ -158,9 +155,22 @@ mod tests {
         )]);
         req.keyword_categories = Some(KeywordCategories::Nested(tree));
         let schema = prepare_gemini_response_schema(&req);
-        let people = &schema["properties"]["keywords"]["properties"]["People"];
-        assert_eq!(people["type"], "OBJECT");
-        assert!(people.get("additionalProperties").is_none());
-        assert_eq!(people["properties"]["Family"]["type"], "ARRAY");
+        let kw = &schema["properties"]["keywords"];
+        assert_eq!(kw["type"], "ARRAY");
+        assert_eq!(
+            kw["items"]["properties"]["category"]["enum"],
+            json!(["Family"])
+        );
+        assert!(kw.get("properties").is_none());
+    }
+
+    #[test]
+    fn alt_text_is_derived_from_caption_when_both_are_requested() {
+        let mut req = base_request();
+        req.generate_caption = true;
+        req.generate_alt_text = true;
+        let schema = prepare_gemini_response_schema(&req);
+        assert!(schema["properties"].get("caption").is_some());
+        assert!(schema["properties"].get("alt_text").is_none());
     }
 }

--- a/server-rs/crates/lrg-providers/src/gemini_schema.rs
+++ b/server-rs/crates/lrg-providers/src/gemini_schema.rs
@@ -12,43 +12,29 @@
 
 use serde_json::{json, Map, Value};
 
-use crate::keyword_taxonomy::CategoryLabels;
+use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
 use crate::types::MetadataGenerationRequest;
 
-/// See `schema.rs::keyword_leaf_item_schema` — `aliases` and
-/// `synonym_aliases` stay optional so the prompt's "omit when absent"
-/// guidance can actually be followed.
-fn gemini_keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
-    if !bilingual && !aliases {
-        return json!({"type": "STRING"});
+/// See `schema.rs::keyword_leaf_item_schema` for the positional layout and
+/// what it saves. `minItems`/`maxItems` are part of the OpenAPI subset Gemini
+/// accepts, so the two-group bound survives here — unlike on the OpenAI path,
+/// where `schema_strict` has to drop it.
+fn gemini_keyword_leaf_item_schema(encoding: KeywordLeafEncoding) -> Value {
+    let string_list = json!({"type": "ARRAY", "minItems": 1, "items": {"type": "STRING"}});
+    match encoding {
+        KeywordLeafEncoding::Plain => json!({"type": "STRING"}),
+        KeywordLeafEncoding::Aliased => string_list,
+        KeywordLeafEncoding::Translated => json!({
+            "type": "ARRAY", "minItems": 2, "maxItems": 2, "items": {"type": "STRING"}
+        }),
+        KeywordLeafEncoding::TranslatedAliased => json!({
+            "type": "ARRAY", "minItems": 2, "maxItems": 2, "items": string_list
+        }),
     }
-    let mut properties = Map::new();
-    let mut required = vec!["name".to_string()];
-    properties.insert("name".into(), json!({"type": "STRING"}));
-    if aliases {
-        properties.insert(
-            "aliases".into(),
-            json!({"type": "ARRAY", "items": {"type": "STRING"}}),
-        );
-    }
-    if bilingual {
-        properties.insert(
-            "synonyms".into(),
-            json!({"type": "ARRAY", "items": {"type": "STRING"}}),
-        );
-        required.push("synonyms".to_string());
-        if aliases {
-            properties.insert(
-                "synonym_aliases".into(),
-                json!({"type": "ARRAY", "items": {"type": "STRING"}}),
-            );
-        }
-    }
-    json!({"type": "OBJECT", "properties": properties, "required": required})
 }
 
 /// The flat `{category, items}` group list, Gemini-flavored.
-fn gemini_keyword_groups_schema(labels: &CategoryLabels, bilingual: bool, aliases: bool) -> Value {
+fn gemini_keyword_groups_schema(labels: &CategoryLabels, encoding: KeywordLeafEncoding) -> Value {
     let categories: Vec<&str> = labels.labels().collect();
     json!({
         "type": "ARRAY",
@@ -58,7 +44,7 @@ fn gemini_keyword_groups_schema(labels: &CategoryLabels, bilingual: bool, aliase
                 "category": {"type": "STRING", "enum": categories},
                 "items": {
                     "type": "ARRAY",
-                    "items": gemini_keyword_leaf_item_schema(bilingual, aliases),
+                    "items": gemini_keyword_leaf_item_schema(encoding),
                 },
             },
             "required": ["category", "items"],
@@ -80,22 +66,20 @@ pub fn prepare_gemini_response_schema(request: &MetadataGenerationRequest) -> Va
         properties.insert("alt_text".into(), json!({"type": "STRING"}));
     }
     if request.generate_keywords {
+        let encoding =
+            KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases);
+        let flat_list =
+            || json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(encoding)});
         let keywords_schema = match &request.keyword_categories {
             Some(categories) => {
                 let labels = CategoryLabels::from_categories(categories);
                 if labels.is_empty() {
-                    json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
+                    flat_list()
                 } else {
-                    gemini_keyword_groups_schema(
-                        &labels,
-                        request.bilingual_keywords,
-                        request.generate_aliases,
-                    )
+                    gemini_keyword_groups_schema(&labels, encoding)
                 }
             }
-            None => {
-                json!({"type": "ARRAY", "items": gemini_keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
-            }
+            None => flat_list(),
         };
         properties.insert("keywords".into(), keywords_schema);
     }
@@ -132,17 +116,45 @@ mod tests {
     }
 
     #[test]
-    fn optional_alias_fields_are_not_required() {
+    fn translation_with_aliases_is_two_positional_groups() {
         let mut req = base_request();
         req.generate_keywords = true;
         req.bilingual_keywords = true;
         req.generate_aliases = true;
         let schema = prepare_gemini_response_schema(&req);
         let item = &schema["properties"]["keywords"]["items"];
-        assert_eq!(item["type"], "OBJECT");
-        assert_eq!(item["required"], json!(["name", "synonyms"]));
-        assert!(item["properties"].get("aliases").is_some());
-        assert!(item["properties"].get("synonym_aliases").is_some());
+        assert_eq!(item["type"], "ARRAY");
+        // Gemini takes minItems/maxItems, so the two-group bound survives here
+        // even though `schema_strict` has to drop it on the OpenAI path.
+        assert_eq!(
+            (&item["minItems"], &item["maxItems"]),
+            (&json!(2), &json!(2))
+        );
+        assert_eq!(item["items"]["type"], "ARRAY");
+        assert_eq!(item["items"]["items"]["type"], "STRING");
+    }
+
+    #[test]
+    fn gemini_leaf_shape_matches_the_openai_builder() {
+        // The two builders differ only in dialect. A photo must come back the
+        // same shape whichever provider answered it, or `normalize` would need
+        // to know who was asked.
+        for (bilingual, aliases) in [(false, false), (false, true), (true, false), (true, true)] {
+            let mut req = base_request();
+            req.generate_keywords = true;
+            req.bilingual_keywords = bilingual;
+            req.generate_aliases = aliases;
+            let gemini = &prepare_gemini_response_schema(&req)["properties"]["keywords"];
+            let openai = &crate::schema::prepare_response_structure(&req)["properties"]["keywords"];
+            assert_eq!(
+                gemini["items"]["minItems"], openai["items"]["minItems"],
+                "bilingual={bilingual} aliases={aliases}"
+            );
+            assert_eq!(
+                gemini["items"]["maxItems"], openai["items"]["maxItems"],
+                "bilingual={bilingual} aliases={aliases}"
+            );
+        }
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/keyword_taxonomy.rs
+++ b/server-rs/crates/lrg-providers/src/keyword_taxonomy.rs
@@ -1,0 +1,244 @@
+//! Hybrid category labels for the flat keyword-group response shape.
+//!
+//! The old schema mirrored the whole category tree as nested objects with
+//! every category in `required`, so a model had to emit every branch —
+//! including the empty ones — for every photo. Those empty containers are
+//! pure output tokens, and output tokens are the most expensive thing a
+//! local engine does.
+//!
+//! The response shape is now a flat list of `{category, items}` groups, so
+//! only categories that actually apply show up. `category` is constrained to
+//! the labels built here, which are *hybrid*: a leaf category is named by its
+//! bare name when that name is unique in the taxonomy, and by its full
+//! `Parent/Child` path only when the bare name would be ambiguous. That keeps
+//! the common case short without ever losing which branch was meant.
+//!
+//! The taxonomy is known input, so the tree is rebuilt server-side in
+//! [`crate::normalize`] rather than asked back from the model.
+
+use std::collections::HashMap;
+
+use crate::types::{KeywordCategories, KeywordTree};
+
+/// Separator between path segments in a full-path label. Also the character
+/// a model is most likely to reach for unprompted, which makes the lenient
+/// lookups in [`CategoryLabels::path_for`] more forgiving.
+pub const PATH_SEPARATOR: &str = "/";
+
+/// The leaf categories of a taxonomy plus the label each is addressed by.
+#[derive(Debug, Clone, Default)]
+pub struct CategoryLabels {
+    /// Label plus its full path, in taxonomy order. Order matters: it drives
+    /// the schema `enum` and the prompt listing, and a stable order keeps the
+    /// grammar cache keyed the same way across photos.
+    entries: Vec<(String, Vec<String>)>,
+    /// Lowercased lookup key -> index into `entries`. Holds both the hybrid
+    /// label and the full path, so a model that volunteers the long form when
+    /// the short one was offered still resolves.
+    lookup: HashMap<String, usize>,
+}
+
+impl CategoryLabels {
+    /// Build labels for `categories`. A flat category list is treated as a
+    /// tree of depth one, which is exactly what it is.
+    pub fn from_categories(categories: &KeywordCategories) -> Self {
+        let mut paths: Vec<Vec<String>> = Vec::new();
+        match categories {
+            KeywordCategories::Flat(list) => {
+                for name in list {
+                    let name = name.trim();
+                    if !name.is_empty() {
+                        paths.push(vec![name.to_string()]);
+                    }
+                }
+            }
+            KeywordCategories::Nested(tree) => collect_leaves(tree, &mut Vec::new(), &mut paths),
+        }
+
+        // A bare leaf name is only usable when nothing else in the taxonomy
+        // carries it. Count first, decide second.
+        let mut leaf_name_counts: HashMap<String, usize> = HashMap::new();
+        for path in &paths {
+            if let Some(leaf) = path.last() {
+                *leaf_name_counts.entry(leaf.to_lowercase()).or_insert(0) += 1;
+            }
+        }
+
+        let mut entries: Vec<(String, Vec<String>)> = Vec::new();
+        let mut used: HashMap<String, usize> = HashMap::new();
+        for path in paths {
+            let Some(leaf) = path.last() else { continue };
+            let unique = leaf_name_counts
+                .get(&leaf.to_lowercase())
+                .copied()
+                .unwrap_or(0)
+                == 1;
+            let mut label = if unique {
+                leaf.clone()
+            } else {
+                path.join(PATH_SEPARATOR)
+            };
+            // A short label can still collide with another entry's full path
+            // (a category literally named "Natur/Landschaft", say). Falling
+            // back to the full path is enough because two leaves with the
+            // same full path are the same leaf.
+            if used.contains_key(&label.to_lowercase()) {
+                label = path.join(PATH_SEPARATOR);
+                if used.contains_key(&label.to_lowercase()) {
+                    continue;
+                }
+            }
+            used.insert(label.to_lowercase(), entries.len());
+            entries.push((label, path));
+        }
+
+        let mut lookup: HashMap<String, usize> = HashMap::new();
+        for (idx, (label, path)) in entries.iter().enumerate() {
+            lookup.insert(label.to_lowercase(), idx);
+            // The full path is always accepted, even when the short label was
+            // the one offered. Never let it shadow an existing entry.
+            lookup
+                .entry(path.join(PATH_SEPARATOR).to_lowercase())
+                .or_insert(idx);
+        }
+
+        CategoryLabels { entries, lookup }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The labels a model may emit, in taxonomy order.
+    pub fn labels(&self) -> impl Iterator<Item = &str> {
+        self.entries.iter().map(|(label, _)| label.as_str())
+    }
+
+    /// Resolve whatever the model emitted back to a full category path.
+    ///
+    /// Accepts the hybrid label, the full path, and either with stray
+    /// whitespace or separator padding — models are not reliable about those
+    /// and a near-miss should not cost the photo its keywords.
+    pub fn path_for(&self, label: &str) -> Option<&[String]> {
+        let trimmed = label.trim().trim_matches('/').trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if let Some(idx) = self.lookup.get(&trimmed.to_lowercase()) {
+            return Some(&self.entries[*idx].1);
+        }
+        // Tolerate alternative separators (" > ", " / ", "\") by normalizing
+        // to the canonical one before a second lookup.
+        let normalized = normalize_separators(trimmed);
+        self.lookup
+            .get(&normalized.to_lowercase())
+            .map(|idx| self.entries[*idx].1.as_slice())
+    }
+}
+
+/// Depth-first walk collecting the path to every leaf (a node with no
+/// children), preserving taxonomy order.
+fn collect_leaves(tree: &KeywordTree, prefix: &mut Vec<String>, out: &mut Vec<Vec<String>>) {
+    for (name, children) in tree.iter() {
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        prefix.push(name.to_string());
+        if children.is_empty() {
+            out.push(prefix.clone());
+        } else {
+            collect_leaves(children, prefix, out);
+        }
+        prefix.pop();
+    }
+}
+
+/// Collapse the separators a model plausibly emits into [`PATH_SEPARATOR`].
+fn normalize_separators(label: &str) -> String {
+    // Segments are trimmed below, so " > " needs no separate pass.
+    let unified = label.replace(['>', '\\'], "/");
+    unified
+        .split('/')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join(PATH_SEPARATOR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nested() -> KeywordCategories {
+        // Natur/Landschaft, Natur/Wasser, Reise/Landschaft, Menschen
+        KeywordCategories::Nested(KeywordTree(vec![
+            (
+                "Natur".to_string(),
+                KeywordTree(vec![
+                    ("Landschaft".to_string(), KeywordTree(vec![])),
+                    ("Wasser".to_string(), KeywordTree(vec![])),
+                ]),
+            ),
+            (
+                "Reise".to_string(),
+                KeywordTree(vec![("Landschaft".to_string(), KeywordTree(vec![]))]),
+            ),
+            ("Menschen".to_string(), KeywordTree(vec![])),
+        ]))
+    }
+
+    #[test]
+    fn unique_leaf_names_stay_bare_ambiguous_ones_get_the_full_path() {
+        let labels = CategoryLabels::from_categories(&nested());
+        let got: Vec<&str> = labels.labels().collect();
+        assert_eq!(
+            got,
+            vec!["Natur/Landschaft", "Wasser", "Reise/Landschaft", "Menschen"]
+        );
+    }
+
+    #[test]
+    fn resolves_short_label_full_path_and_alternative_separators() {
+        let labels = CategoryLabels::from_categories(&nested());
+        assert_eq!(labels.path_for("Wasser").unwrap(), &["Natur", "Wasser"]);
+        // The long form is accepted even though "Wasser" was what we offered.
+        assert_eq!(
+            labels.path_for("Natur/Wasser").unwrap(),
+            &["Natur", "Wasser"]
+        );
+        assert_eq!(
+            labels.path_for(" natur > landschaft ").unwrap(),
+            &["Natur", "Landschaft"]
+        );
+        assert!(labels.path_for("Erfunden").is_none());
+    }
+
+    #[test]
+    fn flat_categories_are_a_depth_one_tree() {
+        let categories = KeywordCategories::Flat(vec!["People".to_string(), "Places".to_string()]);
+        let labels = CategoryLabels::from_categories(&categories);
+        let got: Vec<&str> = labels.labels().collect();
+        assert_eq!(got, vec!["People", "Places"]);
+        assert_eq!(labels.path_for("places").unwrap(), &["Places"]);
+    }
+
+    #[test]
+    fn duplicate_flat_categories_collapse_instead_of_duplicating_the_enum() {
+        let categories = KeywordCategories::Flat(vec![
+            "People".to_string(),
+            "People".to_string(),
+            "Places".to_string(),
+        ]);
+        let labels = CategoryLabels::from_categories(&categories);
+        let got: Vec<&str> = labels.labels().collect();
+        assert_eq!(got, vec!["People", "Places"]);
+    }
+
+    #[test]
+    fn empty_and_blank_names_are_skipped() {
+        let categories = KeywordCategories::Flat(vec!["  ".to_string(), "Real".to_string()]);
+        let labels = CategoryLabels::from_categories(&categories);
+        assert_eq!(labels.labels().collect::<Vec<_>>(), vec!["Real"]);
+    }
+}

--- a/server-rs/crates/lrg-providers/src/keyword_taxonomy.rs
+++ b/server-rs/crates/lrg-providers/src/keyword_taxonomy.rs
@@ -25,6 +25,46 @@ use crate::types::{KeywordCategories, KeywordTree};
 /// lookups in [`CategoryLabels::path_for`] more forgiving.
 pub const PATH_SEPARATOR: &str = "/";
 
+/// How one keyword is encoded in the model's answer.
+///
+/// Named field are readable but expensive: a keyword with a translation and
+/// aliases costs 93 characters as an object and 39 as positional arrays, and
+/// the difference is decoded one forward pass at a time. Measured on
+/// gemma-4-e4b (same photo, same nine keywords): 546 output tokens for the
+/// object form against 344 for the arrays — 2.4 seconds of decode on a single
+/// photo. What the field names carried is explained once in the prompt
+/// instead, where it rides along in the run-constant prefix and is prefilled
+/// rather than decoded.
+///
+/// [`crate::schema`] builds the matching schema and [`crate::normalize`]
+/// decodes the answer back into the named form; both derive the variant from
+/// the same request flags via [`Self::for_request`], so neither has to guess
+/// the shape from the data. That matters because `Aliased` and `Translated`
+/// are both flat string arrays and are told apart only by which was asked for.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum KeywordLeafEncoding {
+    /// `"Berg"` — nothing but the keyword itself.
+    Plain,
+    /// `["Berg", "Gipfel"]` — the keyword, then any further terms for it.
+    Aliased,
+    /// `["Berg", "mountain"]` — the keyword and its translation.
+    Translated,
+    /// `[["Berg", "Gipfel"], ["mountain", "peak"]]` — one group per language,
+    /// each holding the term first and any further terms after it.
+    TranslatedAliased,
+}
+
+impl KeywordLeafEncoding {
+    pub fn for_request(bilingual: bool, aliases: bool) -> Self {
+        match (bilingual, aliases) {
+            (false, false) => Self::Plain,
+            (false, true) => Self::Aliased,
+            (true, false) => Self::Translated,
+            (true, true) => Self::TranslatedAliased,
+        }
+    }
+}
+
 /// The leaf categories of a taxonomy plus the label each is addressed by.
 #[derive(Debug, Clone, Default)]
 pub struct CategoryLabels {

--- a/server-rs/crates/lrg-providers/src/lib.rs
+++ b/server-rs/crates/lrg-providers/src/lib.rs
@@ -7,6 +7,7 @@ pub mod edit_recipe;
 pub mod gemini;
 pub mod gemini_schema;
 pub mod image_encode;
+pub mod keyword_taxonomy;
 pub mod lmstudio;
 pub mod local;
 pub mod local_provider;

--- a/server-rs/crates/lrg-providers/src/lmstudio.rs
+++ b/server-rs/crates/lrg-providers/src/lmstudio.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
+use crate::keyword_taxonomy::KeywordLeafEncoding;
 use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
@@ -236,6 +237,7 @@ impl LmStudioProvider {
         let keywords = normalize_keywords(
             &parsed.get("keywords").cloned().unwrap_or(json!([])),
             request.keyword_categories.as_ref(),
+            KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases),
         );
         let caption = if request.generate_caption {
             parsed

--- a/server-rs/crates/lrg-providers/src/lmstudio.rs
+++ b/server-rs/crates/lrg-providers/src/lmstudio.rs
@@ -16,7 +16,7 @@ use serde_json::{json, Value};
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
-use crate::normalize::normalize_keywords_structure;
+use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -233,20 +233,24 @@ impl LmStudioProvider {
             }
         };
 
-        let keywords =
-            normalize_keywords_structure(&parsed.get("keywords").cloned().unwrap_or(json!([])));
+        let keywords = normalize_keywords(
+            &parsed.get("keywords").cloned().unwrap_or(json!([])),
+            request.keyword_categories.as_ref(),
+        );
+        let caption = if request.generate_caption {
+            parsed
+                .get("caption")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
-            caption: if request.generate_caption {
-                parsed
-                    .get("caption")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            caption,
             title: if request.generate_title {
                 parsed
                     .get("title")
@@ -255,14 +259,7 @@ impl LmStudioProvider {
             } else {
                 None
             },
-            alt_text: if request.generate_alt_text {
-                parsed
-                    .get("alt_text")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            alt_text,
             input_tokens,
             output_tokens,
             error: None,

--- a/server-rs/crates/lrg-providers/src/local_provider.rs
+++ b/server-rs/crates/lrg-providers/src/local_provider.rs
@@ -193,12 +193,28 @@ impl LlmProvider for LocalProvider {
                     return fail(&request.uuid, e);
                 }
                 match engine_results.next() {
-                    Some(Ok(output)) => Self::metadata_from_text(
-                        request,
-                        &output.text,
-                        output.prompt_tokens,
-                        output.completion_tokens,
-                    ),
+                    Some(Ok(output)) => {
+                        // `prefix_reused` exists only here — it is not part of
+                        // `MetadataGenerationResponse`. It is the one signal
+                        // that says whether the run-constant half of the
+                        // prompt (system prompt, keyword taxonomy) is being
+                        // re-prefilled for every photo, which silently turns
+                        // prefill into the dominant per-photo cost. The MLX
+                        // sidecar always reports false; llama.cpp reporting
+                        // false means its prefix cache did not engage.
+                        log::debug!(
+                            "local engine: prompt={} completion={} prefix_reused={}",
+                            output.prompt_tokens,
+                            output.completion_tokens,
+                            output.prefix_reused
+                        );
+                        Self::metadata_from_text(
+                            request,
+                            &output.text,
+                            output.prompt_tokens,
+                            output.completion_tokens,
+                        )
+                    }
                     Some(Err(e)) => fail(&request.uuid, e),
                     None => fail(
                         &request.uuid,

--- a/server-rs/crates/lrg-providers/src/local_provider.rs
+++ b/server-rs/crates/lrg-providers/src/local_provider.rs
@@ -26,6 +26,7 @@ use serde_json::{json, Value};
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_rgb;
+use crate::keyword_taxonomy::KeywordLeafEncoding;
 use crate::local::{LocalImage, LocalRequest, SharedLocalEngine};
 use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
@@ -113,6 +114,7 @@ impl LocalProvider {
         let keywords = normalize_keywords(
             &parsed.get("keywords").cloned().unwrap_or(json!([])),
             request.keyword_categories.as_ref(),
+            KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases),
         );
         let field = |name: &str, wanted: bool| {
             wanted

--- a/server-rs/crates/lrg-providers/src/local_provider.rs
+++ b/server-rs/crates/lrg-providers/src/local_provider.rs
@@ -27,7 +27,7 @@ use serde_json::{json, Value};
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_rgb;
 use crate::local::{LocalImage, LocalRequest, SharedLocalEngine};
-use crate::normalize::normalize_keywords_structure;
+use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt_split, prepare_system_prompt,
     prepare_user_prompt_split,
@@ -110,20 +110,24 @@ impl LocalProvider {
             }
         };
 
-        let keywords =
-            normalize_keywords_structure(&parsed.get("keywords").cloned().unwrap_or(json!([])));
+        let keywords = normalize_keywords(
+            &parsed.get("keywords").cloned().unwrap_or(json!([])),
+            request.keyword_categories.as_ref(),
+        );
         let field = |name: &str, wanted: bool| {
             wanted
                 .then(|| parsed.get(name).and_then(Value::as_str).map(str::to_string))
                 .flatten()
         };
+        let caption = field("caption", request.generate_caption);
+        let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
-            caption: field("caption", request.generate_caption),
+            caption,
             title: field("title", request.generate_title),
-            alt_text: field("alt_text", request.generate_alt_text),
+            alt_text,
             input_tokens: prompt_tokens,
             output_tokens: completion_tokens,
             error: None,

--- a/server-rs/crates/lrg-providers/src/normalize.rs
+++ b/server-rs/crates/lrg-providers/src/normalize.rs
@@ -9,6 +9,9 @@ use std::collections::HashSet;
 
 use serde_json::{Map, Value};
 
+use crate::keyword_taxonomy::CategoryLabels;
+use crate::types::KeywordCategories;
+
 /// Port of `_clean_string_list`: trims, drops empties, de-dupes
 /// case-insensitively (seeded with `reserved_lower`, e.g. the keyword's
 /// own name so a keyword can't list itself as a synonym).
@@ -137,10 +140,216 @@ pub fn normalize_keywords_structure(value: &Value) -> Value {
     }
 }
 
+/// Insert `items` at `path`, creating intermediate objects and merging into
+/// an array that is already there.
+fn insert_at_path(root: &mut Map<String, Value>, path: &[String], items: Vec<Value>) {
+    let Some((leaf, parents)) = path.split_last() else {
+        return;
+    };
+    let mut cursor = root;
+    for segment in parents {
+        let slot = cursor
+            .entry(segment.clone())
+            .or_insert_with(|| Value::Object(Map::new()));
+        // A taxonomy where one path is both a leaf and a parent is malformed;
+        // preferring the parent keeps the deeper keywords rather than the
+        // shallower ones.
+        if !slot.is_object() {
+            *slot = Value::Object(Map::new());
+        }
+        cursor = slot.as_object_mut().expect("set to an object just above");
+    }
+    match cursor
+        .entry(leaf.clone())
+        .or_insert_with(|| Value::Array(Vec::new()))
+    {
+        Value::Array(existing) => existing.extend(items),
+        other => *other = Value::Array(items),
+    }
+}
+
+/// Rebuild the nested category tree from the flat `[{category, items}]`
+/// groups the model now returns.
+///
+/// The taxonomy is known input, so the model is asked only *which* category
+/// applies, never to re-emit the tree around it — that redundancy was pure
+/// output tokens. See [`crate::keyword_taxonomy`].
+///
+/// Anything that is not the group shape passes through untouched: a bare
+/// keyword list (no taxonomy configured), or an older nested object from a
+/// model that ignored the schema. A category that does not resolve keeps its
+/// keywords under its own name rather than dropping them — the same thing
+/// that used to happen when a model invented a category.
+pub fn rebuild_keyword_groups(value: &Value, labels: &CategoryLabels) -> Value {
+    let Value::Array(groups) = value else {
+        return value.clone();
+    };
+    // A bare keyword list is an array too. Only treat this as groups when the
+    // entries actually look like groups.
+    let looks_like_groups = groups.iter().any(|g| {
+        g.as_object()
+            .is_some_and(|o| o.contains_key("category") && o.contains_key("items"))
+    });
+    if !looks_like_groups {
+        return value.clone();
+    }
+
+    let mut root = Map::new();
+    for group in groups {
+        let Some(obj) = group.as_object() else {
+            continue;
+        };
+        let Some(category) = obj.get("category").and_then(Value::as_str) else {
+            continue;
+        };
+        let items = match obj.get("items") {
+            Some(Value::Array(items)) => items.clone(),
+            _ => continue,
+        };
+        if items.is_empty() {
+            continue;
+        }
+        match labels.path_for(category) {
+            Some(path) => insert_at_path(&mut root, path, items),
+            None => {
+                let fallback = category.trim();
+                if !fallback.is_empty() {
+                    insert_at_path(&mut root, &[fallback.to_string()], items);
+                }
+            }
+        }
+    }
+    Value::Object(root)
+}
+
+/// Alt text for the response, derived from the caption when the model was
+/// not asked for it separately.
+///
+/// Alt text and caption are near-identical prose about the same photo, and
+/// prose is the most expensive thing a model emits. When both are requested
+/// the schema asks only for `caption` (see `schema.rs`) and the caption is
+/// reused here. An explicitly returned `alt_text` still wins, so a model that
+/// volunteers one — or a provider that ignored the schema — loses nothing.
+pub fn alt_text_from(
+    parsed: &Value,
+    generate_alt_text: bool,
+    caption: Option<&String>,
+) -> Option<String> {
+    if !generate_alt_text {
+        return None;
+    }
+    parsed
+        .get("alt_text")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| caption.cloned())
+}
+
+/// The one entry point providers should call for the `keywords` field:
+/// rebuild the tree from flat groups (when a taxonomy was requested), then
+/// normalize.
+pub fn normalize_keywords(value: &Value, categories: Option<&KeywordCategories>) -> Value {
+    match categories {
+        Some(categories) => {
+            let labels = CategoryLabels::from_categories(categories);
+            if labels.is_empty() {
+                return normalize_keywords_structure(value);
+            }
+            normalize_keywords_structure(&rebuild_keyword_groups(value, &labels))
+        }
+        None => normalize_keywords_structure(value),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::KeywordTree;
     use serde_json::json;
+
+    fn taxonomy() -> KeywordCategories {
+        KeywordCategories::Nested(KeywordTree(vec![
+            (
+                "Natur".to_string(),
+                KeywordTree(vec![
+                    ("Landschaft".to_string(), KeywordTree(vec![])),
+                    ("Wasser".to_string(), KeywordTree(vec![])),
+                ]),
+            ),
+            (
+                "Reise".to_string(),
+                KeywordTree(vec![("Landschaft".to_string(), KeywordTree(vec![]))]),
+            ),
+        ]))
+    }
+
+    #[test]
+    fn groups_rebuild_into_the_nested_tree() {
+        let raw = json!([
+            {"category": "Wasser", "items": ["See", "Fluss"]},
+            {"category": "Natur/Landschaft", "items": ["Berg"]},
+        ]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(
+            out,
+            json!({"Natur": {"Wasser": ["See", "Fluss"], "Landschaft": ["Berg"]}})
+        );
+    }
+
+    #[test]
+    fn ambiguous_leaf_names_land_in_the_right_branch() {
+        let raw = json!([
+            {"category": "Natur/Landschaft", "items": ["Berg"]},
+            {"category": "Reise/Landschaft", "items": ["Hotel"]},
+        ]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(out["Natur"]["Landschaft"], json!(["Berg"]));
+        assert_eq!(out["Reise"]["Landschaft"], json!(["Hotel"]));
+    }
+
+    #[test]
+    fn repeated_categories_merge_and_empty_groups_vanish() {
+        let raw = json!([
+            {"category": "Wasser", "items": ["See"]},
+            {"category": "Wasser", "items": ["Fluss"]},
+            {"category": "Natur/Landschaft", "items": []},
+        ]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(out, json!({"Natur": {"Wasser": ["See", "Fluss"]}}));
+    }
+
+    #[test]
+    fn an_unknown_category_keeps_its_keywords() {
+        let raw = json!([{"category": "Erfunden", "items": ["Etwas"]}]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(out, json!({"Erfunden": ["Etwas"]}));
+    }
+
+    #[test]
+    fn a_bare_keyword_list_passes_through_untouched() {
+        let raw = json!(["Berg", "See"]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(out, json!(["Berg", "See"]));
+    }
+
+    #[test]
+    fn a_model_that_returns_the_old_nested_shape_still_works() {
+        let raw = json!({"Natur": {"Wasser": ["See"]}});
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(out, json!({"Natur": {"Wasser": ["See"]}}));
+    }
+
+    #[test]
+    fn leaf_objects_inside_groups_are_normalized() {
+        let raw = json!([
+            {"category": "Wasser", "items": [{"name": "See", "synonyms": ["lake", "See"]}]},
+        ]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        assert_eq!(out["Natur"]["Wasser"][0]["name"], "See");
+        assert_eq!(out["Natur"]["Wasser"][0]["synonyms"], json!(["lake"]));
+    }
 
     #[test]
     fn plain_string_list_normalizes_trimmed() {

--- a/server-rs/crates/lrg-providers/src/normalize.rs
+++ b/server-rs/crates/lrg-providers/src/normalize.rs
@@ -9,8 +9,90 @@ use std::collections::HashSet;
 
 use serde_json::{Map, Value};
 
-use crate::keyword_taxonomy::CategoryLabels;
+use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
 use crate::types::KeywordCategories;
+
+/// Turn one positional keyword leaf back into the named form the rest of this
+/// module works in (`{name, synonyms, aliases, synonym_aliases}`).
+///
+/// This has to run *before* [`normalize_keywords_structure`], which treats
+/// every array as a container and would otherwise scatter one keyword's terms
+/// across several keywords.
+///
+/// Deliberately lenient in both directions. A model that ignored the schema
+/// and sent the old named object, or a bare string, is passed straight
+/// through — and it has to be, because `schema_strict` strips the
+/// `minItems`/`maxItems` bound for OpenAI, so on that path nothing enforces
+/// the group count. Under-filled shapes degrade to the next simpler reading
+/// rather than being dropped: half an answer beats none.
+fn expand_leaf(value: &Value, encoding: KeywordLeafEncoding) -> Value {
+    let Value::Array(slots) = value else {
+        // A string, or an object from a model that answered in the old shape.
+        return value.clone();
+    };
+    if encoding == KeywordLeafEncoding::Plain {
+        return value.clone();
+    }
+
+    // `[["Berg","Gipfel"],["mountain","peak"]]` — one group per language.
+    if encoding == KeywordLeafEncoding::TranslatedAliased
+        && slots.iter().any(|s| matches!(s, Value::Array(_)))
+    {
+        let group = |i: usize| match slots.get(i) {
+            Some(Value::Array(terms)) => terms.clone(),
+            _ => Vec::new(),
+        };
+        let (primary, secondary) = (group(0), group(1));
+        let Some(name) = primary.first() else {
+            return Value::Null;
+        };
+        let mut out = Map::new();
+        out.insert("name".into(), name.clone());
+        if primary.len() > 1 {
+            out.insert("aliases".into(), Value::Array(primary[1..].to_vec()));
+        }
+        if let Some((first, rest)) = secondary.split_first() {
+            out.insert("synonyms".into(), Value::Array(vec![first.clone()]));
+            if !rest.is_empty() {
+                out.insert("synonym_aliases".into(), Value::Array(rest.to_vec()));
+            }
+        }
+        return Value::Object(out);
+    }
+
+    // A flat string list. Which field the tail belongs to is not visible in
+    // the data — `["Berg","Gipfel"]` and `["Berg","mountain"]` are the same
+    // JSON — so it is decided by what was asked for, never by inspection.
+    let Some((name, rest)) = slots.split_first() else {
+        return Value::Null;
+    };
+    let mut out = Map::new();
+    out.insert("name".into(), name.clone());
+    if !rest.is_empty() {
+        let field = match encoding {
+            KeywordLeafEncoding::Aliased => "aliases",
+            // Includes a `TranslatedAliased` answer that arrived flat: the
+            // translation is the one thing that must not be lost.
+            _ => "synonyms",
+        };
+        out.insert(field.into(), Value::Array(rest.to_vec()));
+    }
+    Value::Object(out)
+}
+
+/// `expand_leaf` across a list of keywords, dropping what it could not read.
+fn expand_leaf_list(value: &Value, encoding: KeywordLeafEncoding) -> Value {
+    let Value::Array(items) = value else {
+        return value.clone();
+    };
+    Value::Array(
+        items
+            .iter()
+            .map(|item| expand_leaf(item, encoding))
+            .filter(|item| !item.is_null())
+            .collect(),
+    )
+}
 
 /// Port of `_clean_string_list`: trims, drops empties, de-dupes
 /// case-insensitively (seeded with `reserved_lower`, e.g. the keyword's
@@ -180,7 +262,11 @@ fn insert_at_path(root: &mut Map<String, Value>, path: &[String], items: Vec<Val
 /// model that ignored the schema. A category that does not resolve keeps its
 /// keywords under its own name rather than dropping them — the same thing
 /// that used to happen when a model invented a category.
-pub fn rebuild_keyword_groups(value: &Value, labels: &CategoryLabels) -> Value {
+pub fn rebuild_keyword_groups(
+    value: &Value,
+    labels: &CategoryLabels,
+    encoding: KeywordLeafEncoding,
+) -> Value {
     let Value::Array(groups) = value else {
         return value.clone();
     };
@@ -203,7 +289,10 @@ pub fn rebuild_keyword_groups(value: &Value, labels: &CategoryLabels) -> Value {
             continue;
         };
         let items = match obj.get("items") {
-            Some(Value::Array(items)) => items.clone(),
+            Some(items @ Value::Array(_)) => match expand_leaf_list(items, encoding) {
+                Value::Array(items) => items,
+                _ => continue,
+            },
             _ => continue,
         };
         if items.is_empty() {
@@ -248,18 +337,26 @@ pub fn alt_text_from(
 }
 
 /// The one entry point providers should call for the `keywords` field:
-/// rebuild the tree from flat groups (when a taxonomy was requested), then
-/// normalize.
-pub fn normalize_keywords(value: &Value, categories: Option<&KeywordCategories>) -> Value {
+/// expand the positional leaves, rebuild the tree from flat groups (when a
+/// taxonomy was requested), then normalize.
+///
+/// `encoding` must be the one `schema.rs` built the request with — it is what
+/// says whether the tail of `["Berg","Gipfel"]` is an alias or a translation,
+/// and no amount of looking at the value can tell.
+pub fn normalize_keywords(
+    value: &Value,
+    categories: Option<&KeywordCategories>,
+    encoding: KeywordLeafEncoding,
+) -> Value {
     match categories {
         Some(categories) => {
             let labels = CategoryLabels::from_categories(categories);
             if labels.is_empty() {
-                return normalize_keywords_structure(value);
+                return normalize_keywords_structure(&expand_leaf_list(value, encoding));
             }
-            normalize_keywords_structure(&rebuild_keyword_groups(value, &labels))
+            normalize_keywords_structure(&rebuild_keyword_groups(value, &labels, encoding))
         }
-        None => normalize_keywords_structure(value),
+        None => normalize_keywords_structure(&expand_leaf_list(value, encoding)),
     }
 }
 
@@ -291,7 +388,7 @@ mod tests {
             {"category": "Wasser", "items": ["See", "Fluss"]},
             {"category": "Natur/Landschaft", "items": ["Berg"]},
         ]);
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(
             out,
             json!({"Natur": {"Wasser": ["See", "Fluss"], "Landschaft": ["Berg"]}})
@@ -304,7 +401,7 @@ mod tests {
             {"category": "Natur/Landschaft", "items": ["Berg"]},
             {"category": "Reise/Landschaft", "items": ["Hotel"]},
         ]);
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(out["Natur"]["Landschaft"], json!(["Berg"]));
         assert_eq!(out["Reise"]["Landschaft"], json!(["Hotel"]));
     }
@@ -316,28 +413,28 @@ mod tests {
             {"category": "Wasser", "items": ["Fluss"]},
             {"category": "Natur/Landschaft", "items": []},
         ]);
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(out, json!({"Natur": {"Wasser": ["See", "Fluss"]}}));
     }
 
     #[test]
     fn an_unknown_category_keeps_its_keywords() {
         let raw = json!([{"category": "Erfunden", "items": ["Etwas"]}]);
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(out, json!({"Erfunden": ["Etwas"]}));
     }
 
     #[test]
     fn a_bare_keyword_list_passes_through_untouched() {
         let raw = json!(["Berg", "See"]);
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(out, json!(["Berg", "See"]));
     }
 
     #[test]
     fn a_model_that_returns_the_old_nested_shape_still_works() {
         let raw = json!({"Natur": {"Wasser": ["See"]}});
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(out, json!({"Natur": {"Wasser": ["See"]}}));
     }
 
@@ -346,9 +443,112 @@ mod tests {
         let raw = json!([
             {"category": "Wasser", "items": [{"name": "See", "synonyms": ["lake", "See"]}]},
         ]);
-        let out = normalize_keywords(&raw, Some(&taxonomy()));
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Plain);
         assert_eq!(out["Natur"]["Wasser"][0]["name"], "See");
         assert_eq!(out["Natur"]["Wasser"][0]["synonyms"], json!(["lake"]));
+    }
+
+    #[test]
+    fn positional_leaf_expands_into_both_languages() {
+        let raw = json!([{
+            "category": "Wasser",
+            "items": [[["See", "Gewässer"], ["lake", "pond"]]],
+        }]);
+        let out = normalize_keywords(
+            &raw,
+            Some(&taxonomy()),
+            KeywordLeafEncoding::TranslatedAliased,
+        );
+        let leaf = &out["Natur"]["Wasser"][0];
+        assert_eq!(leaf["name"], "See");
+        assert_eq!(leaf["aliases"], json!(["Gewässer"]));
+        assert_eq!(leaf["synonyms"], json!(["lake"]));
+        assert_eq!(leaf["synonym_aliases"], json!(["pond"]));
+    }
+
+    #[test]
+    fn the_same_flat_pair_reads_differently_per_encoding() {
+        // `["See","lake"]` carries no hint of what its tail is. Only the
+        // encoding the request was built with can say, which is why it is
+        // threaded through rather than sniffed.
+        let raw = json!([{"category": "Wasser", "items": [["See", "lake"]]}]);
+        let aliased = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Aliased);
+        assert_eq!(aliased["Natur"]["Wasser"][0]["aliases"], json!(["lake"]));
+        assert!(aliased["Natur"]["Wasser"][0].get("synonyms").is_none());
+
+        let translated =
+            normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Translated);
+        assert_eq!(
+            translated["Natur"]["Wasser"][0]["synonyms"],
+            json!(["lake"])
+        );
+        assert!(translated["Natur"]["Wasser"][0].get("aliases").is_none());
+    }
+
+    #[test]
+    fn a_leaf_that_lost_its_second_group_keeps_the_translation() {
+        // `schema_strict` drops minItems/maxItems for OpenAI, so a flat answer
+        // where two groups were asked for is possible. The translation is the
+        // thing that must not be misfiled as an alias.
+        let raw = json!([{"category": "Wasser", "items": [["See", "lake"]]}]);
+        let out = normalize_keywords(
+            &raw,
+            Some(&taxonomy()),
+            KeywordLeafEncoding::TranslatedAliased,
+        );
+        assert_eq!(out["Natur"]["Wasser"][0]["synonyms"], json!(["lake"]));
+    }
+
+    #[test]
+    fn a_model_answering_in_the_old_named_shape_is_still_understood() {
+        // Nothing forces a cloud model to follow the positional layout.
+        let raw = json!([{
+            "category": "Wasser",
+            "items": [{"name": "See", "synonyms": ["lake"]}],
+        }]);
+        let out = normalize_keywords(
+            &raw,
+            Some(&taxonomy()),
+            KeywordLeafEncoding::TranslatedAliased,
+        );
+        assert_eq!(out["Natur"]["Wasser"][0]["name"], "See");
+        assert_eq!(out["Natur"]["Wasser"][0]["synonyms"], json!(["lake"]));
+    }
+
+    #[test]
+    fn positional_leaves_dedupe_like_the_named_ones() {
+        // Models pad the alias slot by repeating the keyword — measured on
+        // gemma-4 with `[["Astronautin","Astronaut"],["astronaut","astronaut"]]`.
+        let raw = json!([{
+            "category": "Wasser",
+            "items": [[["See", "see"], ["lake", "lake"]]],
+        }]);
+        let out = normalize_keywords(
+            &raw,
+            Some(&taxonomy()),
+            KeywordLeafEncoding::TranslatedAliased,
+        );
+        let leaf = &out["Natur"]["Wasser"][0];
+        assert!(leaf.get("aliases").is_none(), "self-repeat is not an alias");
+        assert_eq!(leaf["synonyms"], json!(["lake"]));
+        assert!(leaf.get("synonym_aliases").is_none());
+    }
+
+    #[test]
+    fn positional_leaves_survive_without_a_taxonomy() {
+        let raw = json!([["Berg", "mountain"], ["See", "lake"]]);
+        let out = normalize_keywords(&raw, None, KeywordLeafEncoding::Translated);
+        assert_eq!(out[0]["name"], "Berg");
+        assert_eq!(out[0]["synonyms"], json!(["mountain"]));
+        assert_eq!(out[1]["name"], "See");
+    }
+
+    #[test]
+    fn an_empty_positional_leaf_is_dropped_not_kept_as_a_blank() {
+        let raw = json!([{"category": "Wasser", "items": [[], ["See", "lake"]]}]);
+        let out = normalize_keywords(&raw, Some(&taxonomy()), KeywordLeafEncoding::Translated);
+        assert_eq!(out["Natur"]["Wasser"].as_array().map(Vec::len), Some(1));
+        assert_eq!(out["Natur"]["Wasser"][0]["name"], "See");
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/ollama.rs
+++ b/server-rs/crates/lrg-providers/src/ollama.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
-use crate::normalize::normalize_keywords_structure;
+use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -299,19 +299,21 @@ fn build_success(
     parsed: &Value,
 ) -> MetadataGenerationResponse {
     let keywords_raw = parsed.get("keywords").cloned().unwrap_or(json!([]));
-    let keywords = normalize_keywords_structure(&keywords_raw);
+    let keywords = normalize_keywords(&keywords_raw, request.keyword_categories.as_ref());
+    let caption = if request.generate_caption {
+        parsed
+            .get("caption")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    } else {
+        None
+    };
+    let alt_text = alt_text_from(parsed, request.generate_alt_text, caption.as_ref());
     MetadataGenerationResponse {
         uuid: request.uuid.clone(),
         success: true,
         keywords: Some(keywords),
-        caption: if request.generate_caption {
-            parsed
-                .get("caption")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        } else {
-            None
-        },
+        caption,
         title: if request.generate_title {
             parsed
                 .get("title")
@@ -320,14 +322,7 @@ fn build_success(
         } else {
             None
         },
-        alt_text: if request.generate_alt_text {
-            parsed
-                .get("alt_text")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        } else {
-            None
-        },
+        alt_text,
         input_tokens: 0,
         output_tokens: 0,
         error: None,

--- a/server-rs/crates/lrg-providers/src/ollama.rs
+++ b/server-rs/crates/lrg-providers/src/ollama.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
+use crate::keyword_taxonomy::KeywordLeafEncoding;
 use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
@@ -299,7 +300,11 @@ fn build_success(
     parsed: &Value,
 ) -> MetadataGenerationResponse {
     let keywords_raw = parsed.get("keywords").cloned().unwrap_or(json!([]));
-    let keywords = normalize_keywords(&keywords_raw, request.keyword_categories.as_ref());
+    let keywords = normalize_keywords(
+        &keywords_raw,
+        request.keyword_categories.as_ref(),
+        KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases),
+    );
     let caption = if request.generate_caption {
         parsed
             .get("caption")

--- a/server-rs/crates/lrg-providers/src/openai.rs
+++ b/server-rs/crates/lrg-providers/src/openai.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
-use crate::normalize::normalize_keywords_structure;
+use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -225,20 +225,24 @@ impl OpenAiProvider {
             Err(e) => return fail(&request.uuid, format!("JSON parsing error: {e}")),
         };
 
-        let keywords =
-            normalize_keywords_structure(&parsed.get("keywords").cloned().unwrap_or(json!([])));
+        let keywords = normalize_keywords(
+            &parsed.get("keywords").cloned().unwrap_or(json!([])),
+            request.keyword_categories.as_ref(),
+        );
+        let caption = if request.generate_caption {
+            parsed
+                .get("caption")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
-            caption: if request.generate_caption {
-                parsed
-                    .get("caption")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            caption,
             title: if request.generate_title {
                 parsed
                     .get("title")
@@ -247,14 +251,7 @@ impl OpenAiProvider {
             } else {
                 None
             },
-            alt_text: if request.generate_alt_text {
-                parsed
-                    .get("alt_text")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            alt_text,
             input_tokens,
             output_tokens,
             error: None,

--- a/server-rs/crates/lrg-providers/src/openai.rs
+++ b/server-rs/crates/lrg-providers/src/openai.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
+use crate::keyword_taxonomy::KeywordLeafEncoding;
 use crate::normalize::{alt_text_from, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
@@ -228,6 +229,7 @@ impl OpenAiProvider {
         let keywords = normalize_keywords(
             &parsed.get("keywords").cloned().unwrap_or(json!([])),
             request.keyword_categories.as_ref(),
+            KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases),
         );
         let caption = if request.generate_caption {
             parsed

--- a/server-rs/crates/lrg-providers/src/prompts.rs
+++ b/server-rs/crates/lrg-providers/src/prompts.rs
@@ -13,6 +13,7 @@
 
 use lrg_imaging::location::format_location_for_prompt;
 
+use crate::keyword_taxonomy::CategoryLabels;
 use crate::types::{EditGenerationRequest, KeywordCategories, MetadataGenerationRequest};
 
 pub const DEFAULT_SYSTEM_PROMPT: &str = "You are a professional photography analyst with expertise in object recognition and computer-generated image description. \nYou also try to identify famous buildings and landmarks as well as the location where the photo was taken. \nFurthermore, you aim to specify animal and plant species as accurately as possible. \nYou also describe objects—such as vehicle types and manufacturers—as specifically as you can.";
@@ -145,20 +146,17 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
 
     if request.generate_keywords {
         if let Some(categories) = &request.keyword_categories {
-            match categories {
-                KeywordCategories::Nested(_) => {
-                    let flat = flatten_keyword_categories(categories);
-                    context_additions.push(format!(
-                        "Please organize keywords into these categories: {}. Use the hierarchical structure to organize keywords logically.",
-                        flat.join(", ")
-                    ));
-                }
-                KeywordCategories::Flat(list) => {
-                    context_additions.push(format!(
-                        "Please organize keywords into these categories: {}",
-                        list.join(", ")
-                    ));
-                }
+            let labels = CategoryLabels::from_categories(categories);
+            if !labels.is_empty() {
+                // These are exactly the strings the schema's `category` enum
+                // permits, so the prompt and the grammar cannot drift apart.
+                let joined = labels.labels().collect::<Vec<_>>().join(", ");
+                context_additions.push(format!(
+                    "Return keywords as a list of groups, each with a `category` and its \
+                     `items`. Use exactly these category names: {joined}. Include a group \
+                     ONLY for categories that genuinely apply to this photo — omit every \
+                     other category entirely rather than returning it with an empty list."
+                ));
             }
         }
     }
@@ -623,7 +621,7 @@ mod tests {
         for run_constant in [
             "Existing catalog vocabulary",
             "Landschaft, Portrait",
-            "Please organize keywords into these categories",
+            "Use exactly these category names",
             "Context: client shoot",
         ] {
             assert!(
@@ -667,6 +665,37 @@ mod tests {
         let split = prepare_user_prompt_split(&req);
         assert!(split.per_photo.is_empty());
         assert_eq!(split.joined(), split.stable);
+    }
+
+    /// The schema lets a model omit categories that do not apply; without
+    /// this instruction it will keep emitting every one of them with an empty
+    /// list, which is exactly the output-token waste the flat group shape
+    /// exists to remove.
+    #[test]
+    fn category_prompt_permits_omitting_categories_and_lists_the_enum_labels() {
+        use crate::types::KeywordTree;
+        let mut req = base_request();
+        req.generate_keywords = true;
+        // "Landschaft" is ambiguous, so the prompt must offer the full paths —
+        // the same strings the schema's `category` enum permits.
+        req.keyword_categories = Some(KeywordCategories::Nested(KeywordTree(vec![
+            (
+                "Natur".to_string(),
+                KeywordTree(vec![("Landschaft".to_string(), KeywordTree(vec![]))]),
+            ),
+            (
+                "Reise".to_string(),
+                KeywordTree(vec![("Landschaft".to_string(), KeywordTree(vec![]))]),
+            ),
+        ])));
+
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("Natur/Landschaft"));
+        assert!(prompt.contains("Reise/Landschaft"));
+        assert!(
+            prompt.contains("omit every other category entirely"),
+            "the prompt must tell the model that omission is expected"
+        );
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/prompts.rs
+++ b/server-rs/crates/lrg-providers/src/prompts.rs
@@ -13,7 +13,7 @@
 
 use lrg_imaging::location::format_location_for_prompt;
 
-use crate::keyword_taxonomy::CategoryLabels;
+use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
 use crate::types::{EditGenerationRequest, KeywordCategories, MetadataGenerationRequest};
 
 pub const DEFAULT_SYSTEM_PROMPT: &str = "You are a professional photography analyst with expertise in object recognition and computer-generated image description. \nYou also try to identify famous buildings and landmarks as well as the location where the photo was taken. \nFurthermore, you aim to specify animal and plant species as accurately as possible. \nYou also describe objects—such as vehicle types and manufacturers—as specifically as you can.";
@@ -161,7 +161,11 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
         }
     }
 
-    if request.generate_keywords && request.bilingual_keywords {
+    // The layout of one keyword. Positional rather than named, because field
+    // names are decoded one token at a time on every keyword of every photo
+    // while this explanation is prefilled once per run — see
+    // `keyword_taxonomy::KeywordLeafEncoding` for the measurement.
+    if request.generate_keywords {
         let secondary = request
             .keyword_secondary_language
             .as_deref()
@@ -172,25 +176,65 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
         } else {
             secondary
         };
-        if secondary.to_lowercase() != request.language.to_lowercase() {
-            context_additions.push(format!(
-                "For keywords only, return each keyword as an object with fields `name` (in {}) and `synonyms` (array in {}). Include only true language equivalents; avoid duplicates and inflected-only variants.",
-                request.language, secondary
-            ));
-        } else {
-            context_additions.push(
-                "For keywords, return each keyword as an object with fields `name` and `synonyms`. Use `synonyms` only for meaningful alternate terms and avoid duplicates."
+        let primary = request.language.as_str();
+        // When both languages are the same, the second slot is not a
+        // translation but a second way of saying it. Saying "translate to
+        // German" to a German-language request produces echoes.
+        let same_language = secondary.to_lowercase() == primary.to_lowercase();
+
+        match KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases)
+        {
+            KeywordLeafEncoding::Plain => {}
+            KeywordLeafEncoding::Aliased => context_additions.push(
+                "Return each keyword as an array of strings: the keyword itself first, then any \
+                 further terms for it. Example: [\"Auto\", \"Pkw\"]. Return a single-element \
+                 array like [\"Auto\"] when there is no further term."
                     .to_string(),
-            );
+            ),
+            KeywordLeafEncoding::Translated => context_additions.push(if same_language {
+                "Return each keyword as a two-element array: the keyword first, then one \
+                 meaningful alternate term for it. Example: [\"Auto\", \"Wagen\"]. Avoid \
+                 duplicates."
+                    .to_string()
+            } else {
+                format!(
+                    "Return each keyword as a two-element array: the keyword in {primary} first, \
+                     then its {secondary} equivalent. Example: [\"Berg\", \"mountain\"]. Include \
+                     only true language equivalents; avoid duplicates and inflected-only variants."
+                )
+            }),
+            KeywordLeafEncoding::TranslatedAliased => context_additions.push(if same_language {
+                "Return each keyword as two arrays: the first holds the keyword followed by any \
+                 further terms for it, the second holds one meaningful alternate term followed by \
+                 any further terms for that. Example: [[\"Auto\", \"Pkw\"], [\"Wagen\", \
+                 \"Kraftfahrzeug\"]]. Use [[\"Auto\"], [\"Wagen\"]] when there are no further \
+                 terms."
+                    .to_string()
+            } else {
+                format!(
+                    "Return each keyword as two arrays: the first holds the {primary} keyword \
+                     followed by any further {primary} terms for it, the second holds its \
+                     {secondary} equivalent followed by any further {secondary} terms. Example: \
+                     [[\"Auto\", \"Pkw\"], [\"car\", \"automobile\"]]. Use [[\"Auto\"], \
+                     [\"car\"]] when there are no further terms. Include only true language \
+                     equivalents; avoid duplicates and inflected-only variants."
+                )
+            }),
         }
     }
 
     if request.generate_keywords && request.generate_aliases {
-        let mut alias_instruction = "For each keyword, you may return an `aliases` array of at most 3 same-language linguistic synonyms of `name` — words that share the exact same core meaning and are interchangeable in any context, not just this photo (e.g. 'Kraftfahrzeug' / 'Pkw' for 'Auto'). Aliases serve as search deduplication: a user searching for either term must expect identical results. Do NOT include: related concepts, scene attributes, co-occurring elements, hypernyms, or hyponyms. Counter-example: 'Abendhimmel' is NOT a valid alias for 'Wolkenlos' — they may co-occur in this photo but describe different concepts. Omit the field entirely if no genuine linguistic synonym exists.".to_string();
-        if request.bilingual_keywords {
-            alias_instruction.push_str(" When `synonyms` is present, also return `synonym_aliases` with the same rules applied to each entry of `synonyms` (same secondary language as the translation).");
-        }
-        context_additions.push(alias_instruction);
+        context_additions.push(
+            "At most 3 further terms per keyword, and only true linguistic synonyms — words that \
+             share the exact same core meaning and are interchangeable in any context, not just \
+             this photo (e.g. 'Kraftfahrzeug' / 'Pkw' for 'Auto'). They serve as search \
+             deduplication: a user searching for either term must expect identical results. Do \
+             NOT include: related concepts, scene attributes, co-occurring elements, hypernyms, \
+             or hyponyms. Counter-example: 'Abendhimmel' is NOT a valid further term for \
+             'Wolkenlos' — they may co-occur in this photo but describe different concepts. Never \
+             pad by repeating a term you have already given; leave the list short instead."
+                .to_string(),
+        );
     }
 
     // --- per-photo context: everything below changes from photo to photo ---
@@ -587,13 +631,46 @@ mod tests {
         req.generate_keywords = true;
         req.bilingual_keywords = true;
         req.keyword_secondary_language = Some("English".to_string());
-        // language == secondary -> the "same synonyms" instruction
+        // language == secondary: asking for a translation into the language
+        // already in use just produces echoes, so the second slot is described
+        // as an alternate term instead.
         let prompt = prepare_user_prompt(&req);
-        assert!(prompt.contains("Use `synonyms` only for meaningful alternate terms"));
+        assert!(prompt.contains("then one meaningful alternate term"));
+        assert!(!prompt.contains("equivalent"));
 
         req.keyword_secondary_language = Some("German".to_string());
         let prompt2 = prepare_user_prompt(&req);
-        assert!(prompt2.contains("in German"));
+        assert!(prompt2.contains("then its German equivalent"));
+    }
+
+    #[test]
+    fn every_keyword_layout_is_explained_with_an_example() {
+        // The positional layout is only readable if the prompt says what each
+        // slot means — the schema alone conveys none of it.
+        for (bilingual, aliases) in [(false, true), (true, false), (true, true)] {
+            let mut req = base_request();
+            req.generate_keywords = true;
+            req.bilingual_keywords = bilingual;
+            req.generate_aliases = aliases;
+            let prompt = prepare_user_prompt(&req);
+            assert!(
+                prompt.contains("Example: ["),
+                "bilingual={bilingual} aliases={aliases} needs a worked example"
+            );
+        }
+    }
+
+    #[test]
+    fn the_keyword_layout_stays_in_the_run_constant_half() {
+        // It is identical for every photo of a run; in `per_photo` it would
+        // cut the reusable prefix at the first keyword instruction.
+        let mut req = base_request();
+        req.generate_keywords = true;
+        req.bilingual_keywords = true;
+        req.generate_aliases = true;
+        let split = prepare_user_prompt_split(&req);
+        assert!(split.stable.contains("Return each keyword as two arrays"));
+        assert!(!split.per_photo.contains("Return each keyword"));
     }
 
     /// The whole point of the split: run-constant context must sit in

--- a/server-rs/crates/lrg-providers/src/schema.rs
+++ b/server-rs/crates/lrg-providers/src/schema.rs
@@ -22,46 +22,34 @@
 
 use serde_json::{json, Map, Value};
 
-use crate::keyword_taxonomy::CategoryLabels;
+use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
 use crate::types::MetadataGenerationRequest;
 
-/// One keyword: a bare string, or an object when translations/aliases are
-/// requested.
+/// One keyword, positional rather than named once anything beyond the bare
+/// term is asked for. See [`KeywordLeafEncoding`] for what each slot means and
+/// why the field names moved into the prompt.
 ///
-/// `aliases` and `synonym_aliases` are deliberately *not* required: the
-/// prompt tells the model to omit them when no genuine synonym exists
-/// (`prompts.rs`), and a schema that requires them makes that impossible —
-/// the model then emits an empty array per keyword instead, which is the
-/// most expensive way to say nothing.
-fn keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
-    if !bilingual && !aliases {
-        return json!({"type": "string"});
+/// `minItems`/`maxItems` are what make the positional reading safe: they stop
+/// a model from returning one group where two are meant, which would silently
+/// file a translation as an alias. `schema_strict` drops them again for
+/// OpenAI, whose strict mode rejects the keywords outright — the decoder in
+/// `normalize.rs` stays lenient for exactly that reason.
+fn keyword_leaf_item_schema(encoding: KeywordLeafEncoding) -> Value {
+    let string_list = json!({"type": "array", "minItems": 1, "items": {"type": "string"}});
+    match encoding {
+        KeywordLeafEncoding::Plain => json!({"type": "string"}),
+        // The term first, then any further terms for it. No upper bound: how
+        // many alternatives a keyword genuinely has is the model's call.
+        KeywordLeafEncoding::Aliased => string_list,
+        // Exactly the term and its translation.
+        KeywordLeafEncoding::Translated => json!({
+            "type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "string"}
+        }),
+        // One group per language, each shaped like `Aliased`.
+        KeywordLeafEncoding::TranslatedAliased => json!({
+            "type": "array", "minItems": 2, "maxItems": 2, "items": string_list
+        }),
     }
-    let mut properties = Map::new();
-    let mut required = vec!["name".to_string()];
-    properties.insert("name".into(), json!({"type": "string"}));
-    if aliases {
-        properties.insert(
-            "aliases".into(),
-            json!({"type": "array", "items": {"type": "string"}}),
-        );
-    }
-    if bilingual {
-        properties.insert(
-            "synonyms".into(),
-            json!({"type": "array", "items": {"type": "string"}}),
-        );
-        // The bilingual prompt asks for `synonyms` unconditionally, so this
-        // one stays required — schema and prompt agree.
-        required.push("synonyms".to_string());
-        if aliases {
-            properties.insert(
-                "synonym_aliases".into(),
-                json!({"type": "array", "items": {"type": "string"}}),
-            );
-        }
-    }
-    json!({"type": "object", "properties": properties, "required": required, "additionalProperties": false})
 }
 
 /// The flat `{category, items}` group list. Only categories that actually
@@ -69,7 +57,14 @@ fn keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
 ///
 /// `category` is an `enum` of the hybrid labels, so the grammar itself rules
 /// out an invented category — no post-hoc validation needed.
-fn keyword_groups_schema(labels: &CategoryLabels, bilingual: bool, aliases: bool) -> Value {
+///
+/// Keying the object by category name instead would save the `"category"` and
+/// `"items"` labels, but it cannot ship: `schema_strict::make_schema_strict`
+/// forces every property into `required` for OpenAI, so every category in the
+/// taxonomy would become mandatory — the exact failure this flat shape was
+/// introduced to fix. It is worth roughly 9 tokens per group against the
+/// leaf's ~200 per photo, so the trade is not close.
+fn keyword_groups_schema(labels: &CategoryLabels, encoding: KeywordLeafEncoding) -> Value {
     let categories: Vec<&str> = labels.labels().collect();
     json!({
         "type": "array",
@@ -77,7 +72,7 @@ fn keyword_groups_schema(labels: &CategoryLabels, bilingual: bool, aliases: bool
             "type": "object",
             "properties": {
                 "category": {"type": "string", "enum": categories},
-                "items": {"type": "array", "items": keyword_leaf_item_schema(bilingual, aliases)},
+                "items": {"type": "array", "items": keyword_leaf_item_schema(encoding)},
             },
             "required": ["category", "items"],
             "additionalProperties": false,
@@ -107,24 +102,21 @@ pub fn prepare_response_structure(request: &MetadataGenerationRequest) -> Value 
         required.push("alt_text");
     }
     if request.generate_keywords {
+        let encoding =
+            KeywordLeafEncoding::for_request(request.bilingual_keywords, request.generate_aliases);
+        let flat_list = || json!({"type": "array", "items": keyword_leaf_item_schema(encoding)});
         let keywords_schema = match &request.keyword_categories {
             Some(categories) => {
                 let labels = CategoryLabels::from_categories(categories);
                 if labels.is_empty() {
                     // A taxonomy that contains nothing usable is the same as
                     // no taxonomy at all.
-                    json!({"type": "array", "items": keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
+                    flat_list()
                 } else {
-                    keyword_groups_schema(
-                        &labels,
-                        request.bilingual_keywords,
-                        request.generate_aliases,
-                    )
+                    keyword_groups_schema(&labels, encoding)
                 }
             }
-            None => {
-                json!({"type": "array", "items": keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
-            }
+            None => flat_list(),
         };
         properties.insert("keywords".into(), keywords_schema);
         required.push("keywords");
@@ -153,23 +145,51 @@ mod tests {
     }
 
     #[test]
-    fn optional_alias_fields_are_not_required() {
+    fn aliases_alone_are_one_flat_string_list() {
+        let mut req = base_request();
+        req.generate_keywords = true;
+        req.generate_aliases = true;
+        let item = &prepare_response_structure(&req)["properties"]["keywords"]["items"];
+        assert_eq!(item["type"], "array");
+        assert_eq!(item["items"]["type"], "string");
+        // No upper bound: a keyword may have any number of further terms.
+        assert_eq!(item["minItems"], json!(1));
+        assert!(item.get("maxItems").is_none());
+    }
+
+    #[test]
+    fn translation_alone_is_a_pair_of_strings() {
+        let mut req = base_request();
+        req.generate_keywords = true;
+        req.bilingual_keywords = true;
+        let item = &prepare_response_structure(&req)["properties"]["keywords"]["items"];
+        assert_eq!(item["items"]["type"], "string");
+        assert_eq!(
+            (&item["minItems"], &item["maxItems"]),
+            (&json!(2), &json!(2))
+        );
+    }
+
+    #[test]
+    fn translation_with_aliases_is_two_groups_of_strings() {
         let mut req = base_request();
         req.generate_keywords = true;
         req.bilingual_keywords = true;
         req.generate_aliases = true;
-        let schema = prepare_response_structure(&req);
-        let item = &schema["properties"]["keywords"]["items"];
-        assert_eq!(item["type"], "object");
-        // All four fields remain available...
-        for field in ["name", "aliases", "synonyms", "synonym_aliases"] {
-            assert!(
-                item["properties"].get(field).is_some(),
-                "{field} should still be offered"
-            );
-        }
-        // ...but only the two the prompt asks for unconditionally are required.
-        assert_eq!(item["required"], json!(["name", "synonyms"]));
+        let item = &prepare_response_structure(&req)["properties"]["keywords"]["items"];
+        // Exactly two groups — one per language. Without the bound a model
+        // could return a single group and its translation would be read as an
+        // alias of the keyword.
+        assert_eq!(
+            (&item["minItems"], &item["maxItems"]),
+            (&json!(2), &json!(2))
+        );
+        assert_eq!(item["items"]["type"], "array");
+        assert_eq!(item["items"]["items"]["type"], "string");
+        assert_eq!(item["items"]["minItems"], json!(1));
+        // The named form is gone: it cost 546 output tokens where this costs
+        // 344 for the same nine keywords.
+        assert!(item.get("properties").is_none());
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/schema.rs
+++ b/server-rs/crates/lrg-providers/src/schema.rs
@@ -1,12 +1,38 @@
-//! Port of `providers/base.py`'s `_prepare_response_structure` /
-//! `_build_nested_keyword_schema` / `_keyword_leaf_item_schema`: builds
-//! the OpenAI-flavor JSON schema describing the requested metadata
+//! Builds the OpenAI-flavor JSON schema describing the requested metadata
 //! fields, for structured-output prompting.
+//!
+//! Both local engines constrain decoding with this schema — llama.cpp via
+//! llguidance, the MLX sidecar via XGrammar — so its *shape* is a direct
+//! output-token cost on every photo. Two things follow, and they are the
+//! reason this file looks the way it does:
+//!
+//! * Keywords are a flat list of `{category, items}` groups, not a nested
+//!   mirror of the taxonomy. The old shape put every category in `required`,
+//!   so a model had to emit every branch — including the empty ones — for
+//!   every photo. See [`crate::keyword_taxonomy`].
+//! * Only fields the model must genuinely always produce go in `required`.
+//!   An optional field listed as required cannot be omitted, which turns
+//!   "omit this when it does not apply" prompt guidance into a dead letter.
+//!
+//! Note that `openai.rs` runs the result through
+//! [`crate::schema_strict::make_schema_strict`], which forces *every*
+//! property back into `required` because OpenAI's strict mode demands it.
+//! That is intentional and only applies to that one provider; do not
+//! "fix" the leaner `required` here to match it.
 
 use serde_json::{json, Map, Value};
 
-use crate::types::{KeywordCategories, MetadataGenerationRequest};
+use crate::keyword_taxonomy::CategoryLabels;
+use crate::types::MetadataGenerationRequest;
 
+/// One keyword: a bare string, or an object when translations/aliases are
+/// requested.
+///
+/// `aliases` and `synonym_aliases` are deliberately *not* required: the
+/// prompt tells the model to omit them when no genuine synonym exists
+/// (`prompts.rs`), and a schema that requires them makes that impossible —
+/// the model then emits an empty array per keyword instead, which is the
+/// most expensive way to say nothing.
 fn keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
     if !bilingual && !aliases {
         return json!({"type": "string"});
@@ -19,47 +45,46 @@ fn keyword_leaf_item_schema(bilingual: bool, aliases: bool) -> Value {
             "aliases".into(),
             json!({"type": "array", "items": {"type": "string"}}),
         );
-        required.push("aliases".to_string());
     }
     if bilingual {
         properties.insert(
             "synonyms".into(),
             json!({"type": "array", "items": {"type": "string"}}),
         );
+        // The bilingual prompt asks for `synonyms` unconditionally, so this
+        // one stays required — schema and prompt agree.
         required.push("synonyms".to_string());
         if aliases {
             properties.insert(
                 "synonym_aliases".into(),
                 json!({"type": "array", "items": {"type": "string"}}),
             );
-            required.push("synonym_aliases".to_string());
         }
     }
     json!({"type": "object", "properties": properties, "required": required, "additionalProperties": false})
 }
 
-fn build_nested_keyword_schema(
-    tree: &crate::types::KeywordTree,
-    bilingual: bool,
-    aliases: bool,
-) -> Value {
-    let mut properties = Map::new();
-    let mut required = Vec::new();
-    for (name, children) in tree.iter() {
-        let field = if !children.is_empty() {
-            build_nested_keyword_schema(children, bilingual, aliases)
-        } else {
-            json!({"type": "array", "items": keyword_leaf_item_schema(bilingual, aliases)})
-        };
-        properties.insert(name.clone(), field);
-        if !required.contains(name) {
-            required.push(name.clone());
+/// The flat `{category, items}` group list. Only categories that actually
+/// apply appear, because the array's length is the model's to choose.
+///
+/// `category` is an `enum` of the hybrid labels, so the grammar itself rules
+/// out an invented category — no post-hoc validation needed.
+fn keyword_groups_schema(labels: &CategoryLabels, bilingual: bool, aliases: bool) -> Value {
+    let categories: Vec<&str> = labels.labels().collect();
+    json!({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "enum": categories},
+                "items": {"type": "array", "items": keyword_leaf_item_schema(bilingual, aliases)},
+            },
+            "required": ["category", "items"],
+            "additionalProperties": false,
         }
-    }
-    json!({"type": "object", "properties": properties, "additionalProperties": false, "required": required})
+    })
 }
 
-/// Port of `_prepare_response_structure`.
 pub fn prepare_response_structure(request: &MetadataGenerationRequest) -> Value {
     let mut properties = Map::new();
     let mut required = Vec::new();
@@ -72,30 +97,30 @@ pub fn prepare_response_structure(request: &MetadataGenerationRequest) -> Value 
         properties.insert("caption".into(), json!({"type": "string"}));
         required.push("caption");
     }
-    if request.generate_alt_text {
+    // Alt text and caption are near-identical prose for the same photo, and
+    // prose is the most expensive thing the model emits. When both are asked
+    // for, generate the caption once and copy it into `alt_text` after
+    // parsing (see the providers' response assembly). Alt text only gets its
+    // own field when there is no caption to derive it from.
+    if request.generate_alt_text && !request.generate_caption {
         properties.insert("alt_text".into(), json!({"type": "string"}));
         required.push("alt_text");
     }
     if request.generate_keywords {
         let keywords_schema = match &request.keyword_categories {
-            Some(KeywordCategories::Nested(tree)) => build_nested_keyword_schema(
-                tree,
-                request.bilingual_keywords,
-                request.generate_aliases,
-            ),
-            Some(KeywordCategories::Flat(list)) => {
-                let mut props = Map::new();
-                let mut req = Vec::new();
-                for category in list {
-                    props.insert(
-                        category.clone(),
-                        json!({"type": "array", "items": keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)}),
-                    );
-                    if !req.contains(category) {
-                        req.push(category.clone());
-                    }
+            Some(categories) => {
+                let labels = CategoryLabels::from_categories(categories);
+                if labels.is_empty() {
+                    // A taxonomy that contains nothing usable is the same as
+                    // no taxonomy at all.
+                    json!({"type": "array", "items": keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
+                } else {
+                    keyword_groups_schema(
+                        &labels,
+                        request.bilingual_keywords,
+                        request.generate_aliases,
+                    )
                 }
-                json!({"type": "object", "properties": props, "additionalProperties": false, "required": req})
             }
             None => {
                 json!({"type": "array", "items": keyword_leaf_item_schema(request.bilingual_keywords, request.generate_aliases)})
@@ -111,7 +136,7 @@ pub fn prepare_response_structure(request: &MetadataGenerationRequest) -> Value 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::KeywordTree;
+    use crate::types::{KeywordCategories, KeywordTree};
 
     fn base_request() -> MetadataGenerationRequest {
         MetadataGenerationRequest::default()
@@ -128,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    fn bilingual_and_aliases_add_object_fields() {
+    fn optional_alias_fields_are_not_required() {
         let mut req = base_request();
         req.generate_keywords = true;
         req.bilingual_keywords = true;
@@ -136,20 +161,19 @@ mod tests {
         let schema = prepare_response_structure(&req);
         let item = &schema["properties"]["keywords"]["items"];
         assert_eq!(item["type"], "object");
-        let required: Vec<&str> = item["required"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|v| v.as_str().unwrap())
-            .collect();
-        assert_eq!(
-            required,
-            vec!["name", "aliases", "synonyms", "synonym_aliases"]
-        );
+        // All four fields remain available...
+        for field in ["name", "aliases", "synonyms", "synonym_aliases"] {
+            assert!(
+                item["properties"].get(field).is_some(),
+                "{field} should still be offered"
+            );
+        }
+        // ...but only the two the prompt asks for unconditionally are required.
+        assert_eq!(item["required"], json!(["name", "synonyms"]));
     }
 
     #[test]
-    fn flat_categories_produce_per_category_arrays() {
+    fn categories_become_a_flat_group_list_with_an_enum() {
         let mut req = base_request();
         req.generate_keywords = true;
         req.keyword_categories = Some(KeywordCategories::Flat(vec![
@@ -158,28 +182,63 @@ mod tests {
         ]));
         let schema = prepare_response_structure(&req);
         let kw = &schema["properties"]["keywords"];
-        assert_eq!(kw["type"], "object");
-        assert!(kw["properties"]["People"]["type"] == "array");
-        assert!(kw["properties"]["Places"]["type"] == "array");
+        assert_eq!(kw["type"], "array");
+        assert_eq!(
+            kw["items"]["properties"]["category"]["enum"],
+            json!(["People", "Places"])
+        );
+        assert_eq!(kw["items"]["required"], json!(["category", "items"]));
     }
 
     #[test]
-    fn nested_categories_recurse() {
+    fn nested_categories_flatten_to_hybrid_labels() {
         let mut req = base_request();
         req.generate_keywords = true;
+        // "Family" is unique, so it stays bare rather than "People/Family".
         let tree: KeywordTree = KeywordTree(vec![(
             "People".to_string(),
             KeywordTree(vec![("Family".to_string(), KeywordTree(vec![]))]),
         )]);
         req.keyword_categories = Some(KeywordCategories::Nested(tree));
         let schema = prepare_response_structure(&req);
-        let people = &schema["properties"]["keywords"]["properties"]["People"];
-        assert_eq!(people["type"], "object");
-        assert_eq!(people["properties"]["Family"]["type"], "array");
+        let kw = &schema["properties"]["keywords"];
+        assert_eq!(kw["type"], "array");
+        assert_eq!(
+            kw["items"]["properties"]["category"]["enum"],
+            json!(["Family"])
+        );
     }
 
     #[test]
-    fn required_fields_follow_requested_flags() {
+    fn no_empty_category_containers_remain_in_the_schema() {
+        // The regression this whole shape exists to prevent: a taxonomy must
+        // never turn into per-category properties that the model has to fill.
+        let mut req = base_request();
+        req.generate_keywords = true;
+        req.keyword_categories = Some(KeywordCategories::Flat(
+            (0..40).map(|i| format!("Cat{i}")).collect(),
+        ));
+        let schema = prepare_response_structure(&req);
+        let kw = &schema["properties"]["keywords"];
+        assert_eq!(kw["type"], "array");
+        assert!(
+            kw.get("properties").is_none(),
+            "categories must not become required object properties"
+        );
+    }
+
+    #[test]
+    fn alt_text_is_derived_from_caption_when_both_are_requested() {
+        let mut req = base_request();
+        req.generate_caption = true;
+        req.generate_alt_text = true;
+        let schema = prepare_response_structure(&req);
+        assert_eq!(schema["required"], json!(["caption"]));
+        assert!(schema["properties"].get("alt_text").is_none());
+    }
+
+    #[test]
+    fn alt_text_keeps_its_own_field_without_a_caption() {
         let mut req = base_request();
         req.generate_title = true;
         req.generate_alt_text = true;

--- a/server-rs/crates/lrg-providers/src/schema_strict.rs
+++ b/server-rs/crates/lrg-providers/src/schema_strict.rs
@@ -4,11 +4,22 @@
 
 use serde_json::Value;
 
+/// Validation keywords OpenAI's strict mode does not accept. Sending one is
+/// not ignored — the whole request is rejected — so they are stripped here
+/// rather than left out of `schema.rs`, where they do real work: the local
+/// engines and Gemini all enforce them, and they are what stops a positional
+/// keyword leaf from arriving with the wrong number of groups. The decoder in
+/// `normalize.rs` is lenient precisely because this path cannot keep them.
+const UNSUPPORTED_BY_STRICT_MODE: [&str; 2] = ["minItems", "maxItems"];
+
 pub fn make_schema_strict(schema: &Value) -> Value {
     let Value::Object(obj) = schema else {
         return schema.clone();
     };
     let mut out = obj.clone();
+    for key in UNSUPPORTED_BY_STRICT_MODE {
+        out.remove(key);
+    }
     let schema_type = out.get("type").and_then(Value::as_str).map(str::to_string);
     let has_properties = out.contains_key("properties");
     let has_items = out.contains_key("items");
@@ -79,5 +90,49 @@ mod tests {
         let schema = json!({"type": "object", "properties": {"a": {"type": "string"}, "b": {"type": "string"}}, "required": ["a"]});
         let strict = make_schema_strict(&schema);
         assert_eq!(strict["required"], json!(["a", "b"]));
+    }
+
+    #[test]
+    fn item_count_bounds_are_stripped_at_every_depth() {
+        // OpenAI rejects the whole request over an unsupported keyword, so one
+        // survivor anywhere is a failed call, not a loosened constraint.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "keywords": {
+                    "type": "array",
+                    "items": {
+                        "type": "array", "minItems": 2, "maxItems": 2,
+                        "items": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+                    }
+                }
+            }
+        });
+        let strict = make_schema_strict(&schema);
+        let leaf = &strict["properties"]["keywords"]["items"];
+        assert!(leaf.get("minItems").is_none());
+        assert!(leaf.get("maxItems").is_none());
+        assert!(leaf["items"].get("minItems").is_none());
+        // Stripping the bounds must not disturb the shape itself.
+        assert_eq!(leaf["items"]["items"]["type"], "string");
+    }
+
+    #[test]
+    fn the_real_bilingual_schema_survives_strict_mode() {
+        use crate::schema::prepare_response_structure;
+        use crate::types::MetadataGenerationRequest;
+
+        let mut req = MetadataGenerationRequest {
+            generate_keywords: true,
+            bilingual_keywords: true,
+            generate_aliases: true,
+            ..Default::default()
+        };
+        req.generate_title = true;
+        let strict = make_schema_strict(&prepare_response_structure(&req));
+        let json = serde_json::to_string(&strict).expect("schema serializes");
+        for key in UNSUPPORTED_BY_STRICT_MODE {
+            assert!(!json.contains(key), "{key} must not reach OpenAI");
+        }
     }
 }


### PR DESCRIPTION
Output tokens are the dominant cost of AI tagging on a local backend. Decode is memory-bandwidth bound — every token re-reads the whole model — and it runs serially, per photo, while prompt tokens are prefilled in parallel (and, on llama.cpp, only once per run thanks to prefix pinning). This PR moves everything it can out of the answer and into the prompt, and adds the measurements that make the next such decision checkable instead of arguable.

Measured on `gemma-4-e4b-it-4bit` via the MLX sidecar, `astronaut.jpg`, German with English translations and aliases on.

## What changed

**Schema diet.** Keywords became a flat `{category, items}` group list instead of a nested mirror of the taxonomy, which had put every category in `required` so the model had to emit every branch — empty ones included — for every photo. On a 40-category taxonomy with 2 populated, the emitted structure went from 996 to 120 characters. Optional alias fields left `required`, and `alt_text` is now derived from the caption rather than generated twice, since they are near-identical prose about the same photo.

**Positional keyword leaves.** A keyword with a translation and aliases cost 93 characters as `{"name": …, "synonyms": […], "aliases": […], "synonym_aliases": […]}`, of which 24 carried information. Field names are decoded one forward pass at a time on every keyword of every photo, so they moved into the prompt and the answer became `[["Berg", "Gipfel"], ["mountain", "peak"]]`. Same photo, same nine keywords, both forms fully populated: **546 output tokens against 344**, which is 2.4 seconds of decode on a single photo.

**Instrumentation.** Per-photo and per-run token counts, and a stage line splitting a generation into the parts that have different fixes:

```
stages: prepare=44.9ms grammar=16.2ms ttft=1604.6ms decode=4208.0ms
  | tokens: text=443 image=258 out=275 (sampled=261 ff=14, 5% forced) | decode 65.1 tok/s
```

`sampled` vs `ff` separates what the model chose from what the grammar forced — both cost the same wall-clock, so a high forced share is the signal that the response *shape* is expensive rather than its content. Both local backends report their own stage split.

## The part the token count did not show

Running end-to-end through `/index_by_reference` turned up a correctness bug, reproducible across three runs each way. With the named form this model **never filled `aliases` or `synonym_aliases` at all** — they were optional and it skipped them every time — and it answered `synonyms` in German for a German request instead of translating:

```
"Astronautin" → synonyms: ["Flugfahrerin", "Raumfahrtteilnehmerin"]
```

Positionally it fills all four slots and translates correctly, at fewer total tokens:

```
name: "Fluganzug"  aliases: ["Raumanzug"]
synonyms: ["spacesuit"]  synonym_aliases: ["flight suit"]
```

This means the warning in `TaskAnalyzeAndIndex.lua` about local models and synonyms/bilingual may be describing a problem that no longer exists. It is deliberately **not** removed here — that wants re-testing against a real catalog taxonomy first, and removing it touches all three translation files.

## Decisions worth knowing about

- **The `{category, items}` group stays.** Keying the object by category name would save ~9 tokens per group, but `make_schema_strict` forces every property into `required` for OpenAI, so all 40 categories would become mandatory — the exact failure the flat shape was introduced to fix. Against the leaf's ~200 tokens per photo the trade is not close.
- **`minItems`/`maxItems` are stripped for OpenAI only.** They are what make the positional reading safe, and OpenAI's strict mode rejects a request containing them. Kept everywhere else; `expand_leaf` is correspondingly lenient, degrading a flat answer to "the tail is the translation" rather than dropping it.
- **`KeywordLeafEncoding` is threaded, not inferred.** `["Berg","Gipfel"]` and `["Berg","mountain"]` are the same JSON; only the request can say which is which.
- **The wire format toward the plugin is unchanged.** `normalize_keywords` still emits the named form, so `APISearchIndex.lua` and the Lua side need no changes.

## Corrections to earlier claims in this branch

The MLX stage line originally reported `grammar=449.6ms`, read as a per-photo constraint compile. It was not: the timing window opened before the first vocabulary walk, and those run once. Measured on a 262,144-token vocab — `extract=136ms`, `bias+whitespace=368ms`, actual compile **~16ms**. The vocabulary walks moved to a once-per-batch step with their own log line, and the compile now overlaps the previous photo's decode, so `grammar=` reads 0.0ms for every photo after the first *within a batch*. Note the qualifier: with one photo per HTTP request there is nothing to prefetch and it stays ~16ms.

Two things found while looking for a KV-cache seam, both recorded in comments rather than acted on: `GuidedGenerationLoop.run` still owns its cache at mlx-swift-lm HEAD (the prompt-cache work in #475 landed in MLXLMCommon, not the guided loop), and it would not help much anyway — Gemma's message generator orders a user turn image-then-text, so the photo precedes the run-constant prompt and only the system turn is common across photos. llama.cpp puts its media marker last for exactly this reason; MLX does not offer the choice.

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets` clean, full workspace test suite green
- New coverage for all four leaf encodings, the strict-mode stripping (including the real bilingual schema), lenient decoding of malformed and old-shape answers, and prompt/schema agreement between the OpenAI and Gemini builders
- Live-tested against the running release binary through `/index_by_reference` with the MLX provider, verifying stored keywords — not only the schema construction

## Not included

Pulling translations out of the per-photo run into a single text-only pass over the run's unique keywords. It is the one lever that removes work rather than compressing it, but it is a larger change and it needs a persistent cache, because a run spans several HTTP batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNbDo7VEzLj58QAZr6JqjU
