### PR TITLE
Add Gemma 4 12B QAT to MLX model catalog

### DIFF
--- a/server-rs/crates/lrg-api/src/mlx_models.rs
+++ b/server-rs/crates/lrg-api/src/mlx_models.rs
@@ -68,6 +68,19 @@ pub const CATALOG: &[CatalogEntry] = &[
         min_ram_gb: 16,
     },
     CatalogEntry {
+        id: "mlx-gemma4-12b",
+        label: "Gemma 4 12B (highest quality, needs more RAM)",
+        // Google's quantization-aware-trained 4-bit release, same rationale as
+        // the GGUF QAT build in llm_models.rs. Larger on disk than that GGUF
+        // (11.0 GB vs. 7.15 GB) for the same parameter count, so it gets a
+        // higher RAM floor here.
+        repo: "mlx-community/gemma-4-12B-it-qat-4bit",
+        revision: "main",
+        dir_name: "gemma-4-12B-it-qat-4bit",
+        approx_bytes: 11_020_138_609,
+        min_ram_gb: 32,
+    },
+    CatalogEntry {
         id: "mlx-qwen3vl-4b",
         label: "Qwen3-VL 4B (balanced alternative to Gemma)",
         repo: "lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit",


### PR DESCRIPTION
## Summary
- Adds `mlx-gemma4-12b` (mlx-community/gemma-4-12B-it-qat-4bit) to the MLX model catalog alongside the existing E2B/E4B entries
- `approx_bytes` measured from the real Hugging Face file listing (excluding `.md`/`.git*`, matching `is_skippable_repo_file`)
- `min_ram_gb: 32`, one tier above the existing GGUF `gemma4-12b` QAT entry (24 GB) since this MLX build is ~54% larger on disk for the same model

## Test plan
- [x] `cargo fmt -p lrg-api`
- [x] `cargo clippy -p lrg-api --all-targets` (clean)
- [x] `cargo test -p lrg-api mlx_models` — catalog uniqueness, no id collision with the GGUF catalog, and discovery-directory placement all pass

https://claude.ai/code/session_01B9mRCjMFC9ZodT6RE4xUzS