### PR TITLE
Add Ministral 3 8B to the llama.cpp and MLX model catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
      - **Windows:** Click *More info* -> *Run anyway*.
      - **macOS:** Right-click the `.pkg` -> *Open* -> *Open anyway*.
    - Optional troubleshooting: if you want to start it manually, run `lrgenius-server/lrgenius-server.cmd` on Windows or `lrgenius-server/lrgenius-server` on macOS.
-4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** sections offer a curated list of vision models (Gemma 4, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. On Apple silicon use the **MLX** section, elsewhere the llama.cpp one. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
+4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** sections offer a curated list of vision models (Gemma 4, Ministral 3, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. On Apple silicon use the **MLX** section, elsewhere the llama.cpp one. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
 5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
    - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
    - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits

--- a/docs/wiki/Dev-Project-README.md
+++ b/docs/wiki/Dev-Project-README.md
@@ -56,7 +56,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
      - **Windows:** Click *More info* -> *Run anyway*.
      - **macOS:** Right-click the `.pkg` -> *Open* -> *Open anyway*.
    - Optional troubleshooting: if you want to start it manually, run `lrgenius-server/lrgenius-server.cmd` on Windows or `lrgenius-server/lrgenius-server` on macOS.
-4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** sections offer a curated list of vision models (Gemma 4, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. On Apple silicon use the **MLX** section, elsewhere the llama.cpp one. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
+4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** sections offer a curated list of vision models (Gemma 4, Ministral 3, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. On Apple silicon use the **MLX** section, elsewhere the llama.cpp one. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
 5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
    - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
    - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits

--- a/docs/wiki/Help-Choosing-AI-Model.md
+++ b/docs/wiki/Help-Choosing-AI-Model.md
@@ -75,11 +75,12 @@ it then appears in the model dropdown as `llamacpp: <model>` or `mlx: <model>`.
 - **`llamacpp`** — llama.cpp compiled into the backend, using GGUF models.
   Available on macOS (Metal), Windows (Vulkan, any GPU vendor), and Linux
   (CPU). Recommended entries: **Gemma 4 E4B** as the default, **Gemma 4 12B
-  (QAT)** if you have 24 GB of RAM, **Qwen3.5 9B** as an alternative,
-  **Qwen2.5-VL 3B** on modest hardware.
+  (QAT)** if you have 24 GB of RAM, **Ministral 3 8B** or **Qwen3.5 9B** as
+  alternatives, **Qwen2.5-VL 3B** on modest hardware.
 - **`mlx`** — Apple's MLX stack via a small Metal helper process, **Apple
   silicon only**. Recommended entries: **Gemma 4 E4B** as the default,
-  **Gemma 4 E2B** for speed, **Qwen3-VL 4B** as an alternative.
+  **Gemma 4 E2B** for speed, **Ministral 3 8B** or **Qwen3-VL 4B** as
+  alternatives.
 
 On an Apple silicon Mac both are available and worth a side-by-side run on the
 same 10–20 photos: MLX is Apple's native inference stack, while llama.cpp reuses

--- a/docs/wiki/Help-Local-AI-Models.md
+++ b/docs/wiki/Help-Local-AI-Models.md
@@ -44,6 +44,7 @@ would look selectable and then fail on the first photo.
 |---|---|---|
 | Gemma 4 E4B *(recommended)* | ~6.3 GB | 16 GB |
 | Gemma 4 12B (QAT, highest quality) | ~7.2 GB | 24 GB |
+| Ministral 3 8B (balanced alternative) | ~6.1 GB | 16 GB |
 | Qwen3.5 9B (balanced alternative) | ~6.5 GB | 16 GB |
 | Qwen2.5-VL 3B / 7B | ~3.4 / 6.5 GB | 8 / 16 GB |
 | SmolVLM 500M (testing only) | ~0.7 GB | 4 GB |
@@ -58,6 +59,8 @@ both.
 |---|---|---|
 | Gemma 4 E4B *(recommended)* | ~5.2 GB | 16 GB |
 | Gemma 4 E2B (faster, lower quality) | ~3.6 GB | 8 GB |
+| Gemma 4 12B (QAT, highest quality) | ~11.0 GB | 32 GB |
+| Ministral 3 8B (balanced alternative) | ~5.6 GB | 16 GB |
 | Qwen3-VL 4B (balanced alternative) | ~3.1 GB | 8 GB |
 
 An MLX model is a **directory** (config, safetensors shards, tokenizer), not a

--- a/server-rs/crates/lrg-api/src/llm_models.rs
+++ b/server-rs/crates/lrg-api/src/llm_models.rs
@@ -100,6 +100,21 @@ pub const CATALOG: &[CatalogEntry] = &[
         min_ram_gb: 24,
     },
     CatalogEntry {
+        id: "ministral3-8b",
+        label: "Ministral 3 8B (balanced alternative to Gemma)",
+        // `mistral3` architecture with a Pixtral projector, both of which the
+        // vendored llama.cpp handles. Its Jinja chat template names
+        // `[SYSTEM_PROMPT]` verbatim, so llama.cpp's legacy detector maps it to
+        // the built-in `mistral-v7` renderer rather than refusing it the way it
+        // refuses Gemma 4's — see `resolve_chat_template` in lrg-llama.
+        repo: "lmstudio-community/Ministral-3-8B-Instruct-2512-GGUF",
+        revision: "main",
+        model_file: "Ministral-3-8B-Instruct-2512-Q4_K_M.gguf",
+        mmproj_file: "mmproj-Ministral-3-8B-Instruct-2512-F16.gguf",
+        approx_bytes: 6_055_465_568,
+        min_ram_gb: 16,
+    },
+    CatalogEntry {
         id: "qwen3.5-9b",
         label: "Qwen3.5 9B (balanced alternative to Gemma)",
         repo: "lmstudio-community/Qwen3.5-9B-GGUF",
@@ -143,12 +158,47 @@ fn is_mmproj(file_name: &str) -> bool {
     file_name.to_ascii_lowercase().contains("mmproj")
 }
 
+/// `true` for a name segment that names a quantization rather than the model.
+///
+/// Covers the two shapes publishers use: a K-quant or legacy quant (`q4_k_m`,
+/// `q8_0`, `iq3_xs`) and a float format (`bf16`, `f16`).
+fn is_quant_tag(segment: &str) -> bool {
+    matches!(segment, "f16" | "f32" | "bf16" | "fp16" | "fp8" | "mxfp4")
+        || segment
+            .trim_start_matches('i')
+            .strip_prefix('q')
+            .is_some_and(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
+}
+
+/// The part of a file name that identifies *which model* it belongs to, with
+/// the `mmproj` marker and the quantization tag dropped:
+/// `mmproj-gemma-4-E4B-it-BF16.gguf` → `gemma-4-e4b-it`.
+///
+/// A pair is almost never quantized the same way — a Q4_K_M model ships with a
+/// BF16 or F16 projector — so the two file names match only once both tags are
+/// gone.
+fn pairing_key(file_name: &str) -> String {
+    let stem = file_name
+        .rsplit_once('.')
+        .map_or(file_name, |(stem, _)| stem)
+        .to_ascii_lowercase();
+    let mut parts: Vec<&str> = stem.split('-').filter(|part| *part != "mmproj").collect();
+    while parts.last().is_some_and(|part| is_quant_tag(part)) {
+        parts.pop();
+    }
+    parts.join("-")
+}
+
 /// Pair each text model with a projector from the same directory.
 ///
-/// Publishers name the pair consistently (`X.gguf` ↔ `mmproj-X.gguf`), so
-/// prefer a projector whose name shares the model's stem; otherwise fall back
-/// to the only projector present. Guessing across directories would be worse
-/// than offering the model as text-only.
+/// Publishers name the pair after the same model (`X-Q4_K_M.gguf` ↔
+/// `mmproj-X-BF16.gguf`), so prefer a projector with the model's
+/// [`pairing_key`], then one whose name contains the model's stem outright, and
+/// only then fall back to the single projector present. The fallback alone is
+/// not enough: models are downloaded into one flat directory, so as soon as a
+/// user has two of them every projector becomes ambiguous and both models would
+/// be offered as text-only. Guessing across directories would be worse than
+/// offering the model as text-only.
 fn pair_models(files: &[PathBuf], source: &'static str) -> Vec<LocalModel> {
     let (projectors, models): (Vec<&PathBuf>, Vec<&PathBuf>) = files
         .iter()
@@ -162,12 +212,20 @@ fn pair_models(files: &[PathBuf], source: &'static str) -> Vec<LocalModel> {
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_ascii_lowercase();
+            let key = pairing_key(&model_path.file_name().unwrap_or_default().to_string_lossy());
+            let name_of = |p: &PathBuf| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned()
+            };
             let matching = projectors
                 .iter()
-                .find(|p| {
-                    let name = p.file_name().unwrap_or_default().to_string_lossy();
-                    let name = name.to_ascii_lowercase();
-                    name.contains(stem.as_str())
+                .find(|p| pairing_key(&name_of(p)) == key)
+                .or_else(|| {
+                    projectors
+                        .iter()
+                        .find(|p| name_of(p).to_ascii_lowercase().contains(stem.as_str()))
                 })
                 .or(if projectors.len() == 1 {
                     projectors.first()
@@ -322,6 +380,54 @@ mod tests {
             paired[1].mmproj_path,
             Some(PathBuf::from("/m/mmproj-beta-Q4.gguf"))
         );
+    }
+
+    /// The real catalog case: every pair is published with the model quantized
+    /// and the projector in a float format, and downloads share one flat
+    /// directory. Matching file names outright pairs none of these, and the
+    /// single-projector fallback cannot fire, so both would be text-only.
+    #[test]
+    fn pairs_across_differing_quantization_tags() {
+        let files = vec![
+            PathBuf::from("/m/Ministral-3-8B-Instruct-2512-Q4_K_M.gguf"),
+            PathBuf::from("/m/gemma-4-E4B-it-Q4_K_M.gguf"),
+            PathBuf::from("/m/mmproj-Ministral-3-8B-Instruct-2512-F16.gguf"),
+            PathBuf::from("/m/mmproj-gemma-4-E4B-it-BF16.gguf"),
+        ];
+        let mut paired = pair_models(&files, "downloaded");
+        paired.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(paired.len(), 2);
+        assert_eq!(
+            paired[0].mmproj_path,
+            Some(PathBuf::from(
+                "/m/mmproj-Ministral-3-8B-Instruct-2512-F16.gguf"
+            ))
+        );
+        assert_eq!(
+            paired[1].mmproj_path,
+            Some(PathBuf::from("/m/mmproj-gemma-4-E4B-it-BF16.gguf"))
+        );
+    }
+
+    /// Every catalog pair must survive discovery, or the model downloads and
+    /// then silently cannot see photos.
+    #[test]
+    fn every_catalog_pair_survives_discovery() {
+        let files: Vec<PathBuf> = CATALOG
+            .iter()
+            .flat_map(|e| [PathBuf::from(e.model_file), PathBuf::from(e.mmproj_file)])
+            .collect();
+        let paired = pair_models(&files, "downloaded");
+        assert_eq!(paired.len(), CATALOG.len());
+        for entry in CATALOG {
+            let model = paired.iter().find(|m| m.name == entry.model_file).unwrap();
+            assert_eq!(
+                model.mmproj_path,
+                Some(PathBuf::from(entry.mmproj_file)),
+                "{} paired with the wrong projector",
+                entry.id
+            );
+        }
     }
 
     #[test]

--- a/server-rs/crates/lrg-api/src/mlx_models.rs
+++ b/server-rs/crates/lrg-api/src/mlx_models.rs
@@ -81,6 +81,18 @@ pub const CATALOG: &[CatalogEntry] = &[
         min_ram_gb: 32,
     },
     CatalogEntry {
+        id: "mlx-ministral3-8b",
+        label: "Ministral 3 8B (balanced alternative to Gemma)",
+        // `model_type: mistral3` with a Pixtral vision tower, which
+        // mlx-swift-lm's VLM factory registers, so the sidecar loads it as a
+        // vision model rather than falling back to the text-only factory.
+        repo: "mlx-community/Ministral-3-8B-Instruct-2512-4bit",
+        revision: "main",
+        dir_name: "Ministral-3-8B-Instruct-2512-4bit",
+        approx_bytes: 5_630_652_158,
+        min_ram_gb: 16,
+    },
+    CatalogEntry {
         id: "mlx-qwen3vl-4b",
         label: "Qwen3-VL 4B (balanced alternative to Gemma)",
         repo: "lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit",

--- a/server-rs/crates/lrg-api/src/routes/llm.rs
+++ b/server-rs/crates/lrg-api/src/routes/llm.rs
@@ -14,7 +14,7 @@
 //! is TLS-authenticated, and a length check catches the failure mode that
 //! actually occurs (an interrupted stream).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use axum::extract::State;
@@ -437,7 +437,7 @@ async fn repo_files(
         .await
         .map_err(|e| format!("could not read the file list for {repo}: {e}"))?;
 
-    let mut files: Vec<(String, u64)> = entries
+    let files: Vec<(String, u64)> = entries
         .iter()
         .filter(|entry| entry.get("type").and_then(Value::as_str) == Some("file"))
         .filter_map(|entry| {
@@ -447,31 +447,84 @@ async fn repo_files(
         })
         .collect();
 
-    // Some repos carry a stale `model.safetensors.index.json` left over from
-    // before the weights were consolidated into a single `model.safetensors`
-    // (observed on lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit — the
-    // index's weight_map still points at `model-0000N-of-0000N.safetensors`
-    // shards that no longer exist in the repo). mlx-swift-lm trusts the index
-    // over the consolidated file when both are present, so downloading it
-    // produces a directory that fails to load with a confusing "not
-    // supported" error. A monolithic `model.safetensors` needs no index, so
-    // drop the index whenever both live in the same directory.
-    let monolithic_dirs: std::collections::HashSet<String> = files
-        .iter()
-        .filter_map(|(path, _)| {
-            let (dir, name) = path.rsplit_once('/').unwrap_or(("", path.as_str()));
-            (name == "model.safetensors").then(|| dir.to_string())
-        })
-        .collect();
-    files.retain(|(path, _)| {
-        let (dir, name) = path.rsplit_once('/').unwrap_or(("", path.as_str()));
-        name != "model.safetensors.index.json" || !monolithic_dirs.contains(dir)
-    });
-
     if files.is_empty() {
         return Err(format!("{repo} contains no downloadable model files"));
     }
     Ok(files)
+}
+
+/// The weight files a `model.safetensors.index.json` names that are not in
+/// `present`, plus a description of an index that cannot be used at all.
+///
+/// An unreadable index counts as unusable rather than fine: mlx-swift-lm
+/// decodes the same JSON and would fail on it too.
+fn missing_from_shard_index(
+    index_json: &str,
+    present: &std::collections::HashSet<&str>,
+) -> Vec<String> {
+    let Ok(index) = serde_json::from_str::<Value>(index_json) else {
+        return vec!["the index is not readable JSON".to_string()];
+    };
+    let Some(map) = index.get("weight_map").and_then(Value::as_object) else {
+        return vec!["the index has no weight_map".to_string()];
+    };
+    let mut missing: Vec<String> = map
+        .values()
+        .filter_map(Value::as_str)
+        .filter(|file| !present.contains(file))
+        .map(str::to_string)
+        .collect();
+    missing.sort();
+    missing.dedup();
+    missing
+}
+
+/// Delete a `model.safetensors.index.json` that does not describe the weights
+/// sitting next to it.
+///
+/// Repos ship indexes left over from an earlier revision. Two have been seen:
+/// lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit, whose index still names
+/// the shards from before the weights were consolidated into one
+/// `model.safetensors`, and mlx-community/Ministral-3-8B-Instruct-2512-4bit,
+/// whose index describes a three-shard layout over a repo that has two.
+///
+/// mlx-swift-lm loads exactly the files the `weight_map` names and fails on the
+/// first one missing — the error surfaces as "this MLX model is not supported",
+/// which sends the reader looking in entirely the wrong place. With no index it
+/// loads every `.safetensors` in the directory instead, which is correct both
+/// for a monolithic file and for a complete shard set. So an index naming a
+/// file that is not there is strictly worse than no index.
+///
+/// Only ever called on a freshly staged snapshot, where every file the repo
+/// listed has been downloaded and verified for length: a name the index gets
+/// wrong here is the repo disagreeing with itself, not a partial download.
+async fn prune_stale_shard_index(dir: &Path) {
+    let index_path = dir.join("model.safetensors.index.json");
+    let Ok(index_json) = tokio::fs::read_to_string(&index_path).await else {
+        return;
+    };
+    let Ok(mut entries) = tokio::fs::read_dir(dir).await else {
+        return;
+    };
+    let mut present: Vec<String> = Vec::new();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        present.push(entry.file_name().to_string_lossy().into_owned());
+    }
+    let present: std::collections::HashSet<&str> = present.iter().map(String::as_str).collect();
+
+    let missing = missing_from_shard_index(&index_json, &present);
+    if missing.is_empty() {
+        return;
+    }
+    log::warn!(
+        "{} does not match the downloaded weights ({}); removing it so every \
+         safetensors file in the directory is loaded instead",
+        index_path.display(),
+        missing.join(", ")
+    );
+    if let Err(e) = tokio::fs::remove_file(&index_path).await {
+        log::warn!("could not remove {}: {e}", index_path.display());
+    }
 }
 
 /// Download a whole MLX model snapshot.
@@ -601,6 +654,8 @@ async fn run_mlx_download(downloads: Downloads, entry: &'static mlx_models::Cata
         }
     }
 
+    prune_stale_shard_index(&staging).await;
+
     if let Err(e) = tokio::fs::rename(&staging, &destination).await {
         let _ = tokio::fs::remove_dir_all(&staging).await;
         return set_error(
@@ -634,6 +689,79 @@ pub fn destination_for(entry: &CatalogEntry) -> (PathBuf, PathBuf) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn present<'a>(names: impl IntoIterator<Item = &'a str>) -> std::collections::HashSet<&'a str> {
+        names.into_iter().collect()
+    }
+
+    #[test]
+    fn an_index_matching_the_downloaded_shards_is_kept() {
+        let index = r#"{"weight_map":{"a":"model-00001-of-00002.safetensors",
+                                      "b":"model-00002-of-00002.safetensors"}}"#;
+        let files = present([
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+            "config.json",
+        ]);
+        assert!(missing_from_shard_index(index, &files).is_empty());
+    }
+
+    /// mlx-community/Ministral-3-8B-Instruct-2512-4bit: a three-shard index
+    /// over a repo that ships two.
+    #[test]
+    fn an_index_describing_a_different_shard_layout_is_stale() {
+        let index = r#"{"weight_map":{"a":"model-00001-of-00003.safetensors",
+                                      "b":"model-00003-of-00003.safetensors"}}"#;
+        let files = present([
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
+        assert_eq!(
+            missing_from_shard_index(index, &files),
+            vec![
+                "model-00001-of-00003.safetensors",
+                "model-00003-of-00003.safetensors"
+            ]
+        );
+    }
+
+    /// lmstudio-community/Qwen3-VL-4B-Instruct-MLX-4bit: an index left over
+    /// from before the weights were consolidated into one file.
+    #[test]
+    fn an_index_naming_shards_beside_a_consolidated_file_is_stale() {
+        let index = r#"{"weight_map":{"a":"model-00001-of-00002.safetensors"}}"#;
+        let files = present(["model.safetensors", "config.json"]);
+        assert_eq!(
+            missing_from_shard_index(index, &files),
+            vec!["model-00001-of-00002.safetensors"]
+        );
+    }
+
+    #[test]
+    fn an_index_that_cannot_be_parsed_counts_as_unusable() {
+        let files = present(["model.safetensors"]);
+        assert!(!missing_from_shard_index("not json", &files).is_empty());
+        assert!(!missing_from_shard_index("{}", &files).is_empty());
+    }
+
+    #[tokio::test]
+    async fn pruning_removes_only_a_stale_index() {
+        for (index, stays) in [
+            (r#"{"weight_map":{"a":"model.safetensors"}}"#, true),
+            (
+                r#"{"weight_map":{"a":"model-00001-of-00003.safetensors"}}"#,
+                false,
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let index_path = dir.path().join("model.safetensors.index.json");
+            std::fs::write(dir.path().join("model.safetensors"), b"w").unwrap();
+            std::fs::write(&index_path, index).unwrap();
+
+            prune_stale_shard_index(dir.path()).await;
+            assert_eq!(index_path.is_file(), stays);
+        }
+    }
 
     #[test]
     fn engine_overrides_read_the_advanced_fields() {


### PR DESCRIPTION
Adds Ministral 3 8B Instruct to both local-backend catalogs. It is a vision
model (`mistral3` text architecture + Pixtral encoder) in both formats, and both
engines run it as shipped — no engine changes here.

| | Repo | Download | RAM floor |
|---|---|---|---|
| llama.cpp | `lmstudio-community/Ministral-3-8B-Instruct-2512-GGUF` (Q4_K_M + F16 mmproj) | 6.06 GB | 16 GB |
| MLX | `mlx-community/Ministral-3-8B-Instruct-2512-4bit` | 5.63 GB | 16 GB |

Both are ungated. `approx_bytes` is the measured total of the files the download
code actually fetches, so the progress bar's denominator is exact.

## Support was checked, not assumed

* **llama.cpp** — the vendored llama.cpp (llama-cpp-2 0.1.154) has
  `src/models/mistral3.cpp` and `PROJECTOR_TYPE_PIXTRAL` in mtmd. The model's
  Jinja chat template names `[SYSTEM_PROMPT]` verbatim, so llama.cpp's legacy
  detector maps it to the built-in `mistral-v7` renderer instead of refusing it
  the way it refuses Gemma 4's — `resolve_chat_template` needs no new branch.
* **MLX** — `config.json` is `model_type: mistral3` with a Pixtral tower, and
  mlx-swift-lm registers `"mistral3"` in `VLMModelFactory`, so the sidecar loads
  it as a vision model rather than falling back to the text-only factory.

## Two bugs found while verifying, both fixed here

**Projector pairing was effectively broken for every catalog entry but one.**
`pair_models` only matched a projector whose file name contained the model's
full stem. That is true for SmolVLM alone; every other pair ships the model
quantized and the projector in a float format (`gemma-4-E4B-it-Q4_K_M.gguf` ↔
`mmproj-gemma-4-E4B-it-BF16.gguf`), so pairing worked only via the "exactly one
projector present" fallback. Downloads land in one flat directory, so a user
with two models had every projector go ambiguous and **both models silently
became text-only** — the model still loads, it just cannot see photos. Names are
now compared with the quantization tag and `mmproj` marker stripped. A test
asserts every catalog pair survives discovery, so a future entry whose naming
breaks this fails CI instead of shipping.

**The MLX repo ships a stale shard index.** Its
`model.safetensors.index.json` weight_map names a three-shard layout
(`total_size` 10.4 GB) while the repo contains two shards totalling 5.6 GB.
mlx-swift-lm loads exactly the files the index names, so the model downloaded
cleanly and then failed with `This MLX model is not supported by the bundled
mlx-swift-lm` — an error that points at entirely the wrong cause. 8fe3751
handled this class of bug but only when a monolithic `model.safetensors` sat
beside the index, which cannot catch a shard-count mismatch. That rule is
replaced by a check on the staged snapshot before it is renamed into place: an
index naming a file that was not downloaded is deleted, with a log line saying
which files were missing. The loader then reads every `.safetensors` in the
directory, which is correct for both a monolithic file and a complete shard set.

## Verification

* All four `lrg-mlx` sidecar smoke tests pass against the downloaded MLX model:
  `vision=true`, schema-constrained JSON valid, batch and unconstrained paths,
  ~48–49 tok/s decode on an M-series Mac. They fail on the unpruned directory
  and pass once the stale index is gone, which is what the fix automates.
* `/llm/catalog` on a running binary lists both new entries with the right
  sizes, RAM floors and `installed` flags.
* Asset URLs and byte counts confirmed by HEAD against Hugging Face.
* `cargo clippy --workspace --all-targets` clean with and without
  `--features llamacpp`; `cargo test --workspace` green.

Not yet exercised end-to-end: the llama.cpp side is still downloading, and the
staged-download prune has unit coverage (using the real file names of both
affected repos) rather than a second full 5.6 GB re-download. I'll comment with
the llama.cpp result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqcu34jmSwbpAfD7YEHFBZ
