### PR TITLE
Hide Vertex AI from the plugin GUI

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -1310,7 +1310,8 @@ function SearchIndexAPI.formatStats(stats)
 		"Photos with title: " .. tostring(photos.with_title or 0),
 		"Photos with caption: " .. tostring(photos.with_caption or 0),
 		"Photos with keywords: " .. tostring(photos.with_keywords or 0),
-		"Photos with Vertex AI: " .. tostring(photos.with_vertexai or 0),
+		-- Vertex AI is disabled in the GUI; the backend code is untouched.
+		-- "Photos with Vertex AI: " .. tostring(photos.with_vertexai or 0),
 		"Faces total: " .. tostring(faces.total or 0),
 		"Persons total: " .. tostring(persons.total or 0),
 	}, "\n")

--- a/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
@@ -17,8 +17,9 @@ function PluginInfoDialogSections.startDialog(propertyTable)
 	propertyTable.logging = prefs.logging
 	propertyTable.geminiApiKey = prefs.geminiApiKey
 	propertyTable.chatgptApiKey = prefs.chatgptApiKey
-	propertyTable.vertexProjectId = prefs.vertexProjectId
-	propertyTable.vertexLocation = prefs.vertexLocation or "us-central1"
+	-- Vertex AI is disabled in the GUI; the backend code is untouched.
+	-- propertyTable.vertexProjectId = prefs.vertexProjectId
+	-- propertyTable.vertexLocation = prefs.vertexLocation or "us-central1"
 
 	propertyTable.exportSize = prefs.exportSize
 	propertyTable.exportQuality = prefs.exportQuality
@@ -549,30 +550,31 @@ function PluginInfoDialogSections.sectionsForTopOfDialog(f, propertyTable)
 						width = share("apiKeyButtonWidth"),
 					}),
 				}),
-				f:row({
-					fill_horizontal = 1,
-					f:static_text({
-						title = LOC("$$$/LrGeniusAI/PluginInfo/VertexProjectId=Vertex AI Project ID"),
-						alignment = "right",
-						width = share("apiKeyLabelWidth"),
-					}),
-					f:edit_field({
-						value = bind("vertexProjectId"),
-						fill_horizontal = 1,
-					}),
-				}),
-				f:row({
-					fill_horizontal = 1,
-					f:static_text({
-						title = LOC("$$$/LrGeniusAI/PluginInfo/VertexLocation=Vertex AI Location"),
-						alignment = "right",
-						width = share("apiKeyLabelWidth"),
-					}),
-					f:edit_field({
-						value = bind("vertexLocation"),
-						width_in_chars = 20,
-					}),
-				}),
+				-- Vertex AI is disabled in the GUI; the backend code is untouched.
+				-- f:row({
+				-- 	fill_horizontal = 1,
+				-- 	f:static_text({
+				-- 		title = LOC("$$$/LrGeniusAI/PluginInfo/VertexProjectId=Vertex AI Project ID"),
+				-- 		alignment = "right",
+				-- 		width = share("apiKeyLabelWidth"),
+				-- 	}),
+				-- 	f:edit_field({
+				-- 		value = bind("vertexProjectId"),
+				-- 		fill_horizontal = 1,
+				-- 	}),
+				-- }),
+				-- f:row({
+				-- 	fill_horizontal = 1,
+				-- 	f:static_text({
+				-- 		title = LOC("$$$/LrGeniusAI/PluginInfo/VertexLocation=Vertex AI Location"),
+				-- 		alignment = "right",
+				-- 		width = share("apiKeyLabelWidth"),
+				-- 	}),
+				-- 	f:edit_field({
+				-- 		value = bind("vertexLocation"),
+				-- 		width_in_chars = 20,
+				-- 	}),
+				-- }),
 			}),
 			f:group_box({
 				width = groupBoxWidth,
@@ -1449,10 +1451,11 @@ end
 function PluginInfoDialogSections.endDialog(propertyTable)
 	prefs.geminiApiKey = propertyTable.geminiApiKey
 	prefs.chatgptApiKey = propertyTable.chatgptApiKey
-	prefs.vertexProjectId = (propertyTable.vertexProjectId and propertyTable.vertexProjectId:gsub("^%s*(.-)%s*$", "%1"))
-		or ""
-	prefs.vertexLocation = (propertyTable.vertexLocation and propertyTable.vertexLocation:gsub("^%s*(.-)%s*$", "%1"))
-		or "us-central1"
+	-- Vertex AI is disabled in the GUI; the backend code is untouched.
+	-- prefs.vertexProjectId = (propertyTable.vertexProjectId and propertyTable.vertexProjectId:gsub("^%s*(.-)%s*$", "%1"))
+	-- 	or ""
+	-- prefs.vertexLocation = (propertyTable.vertexLocation and propertyTable.vertexLocation:gsub("^%s*(.-)%s*$", "%1"))
+	-- 	or "us-central1"
 	prefs.exportSize = propertyTable.exportSize
 	prefs.exportQuality = propertyTable.exportQuality
 	prefs.indexSubmitOriginals = (propertyTable.indexSubmitOriginals == true)

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -24,7 +24,9 @@ local function showAnalyzeAndIndexDialog(ctx)
 	props.enableEmbeddings = (prefs.enableEmbeddings ~= false) and props.clipReady -- default true
 	props.enableMetadata = prefs.enableMetadata ~= false -- default true
 	props.enableFaces = prefs.enableFaces or false
-	props.enableVertexAI = prefs.enableVertexAI or false
+	-- Vertex AI is disabled in the GUI; the backend code is untouched.
+	props.enableVertexAI = false
+	-- props.enableVertexAI = prefs.enableVertexAI or false
 	props.enableImportBeforeIndex = prefs.enableImportBeforeIndex or false
 	props.regenerateMetadata = prefs.regenerateMetadata or false
 
@@ -261,14 +263,15 @@ local function showAnalyzeAndIndexDialog(ctx)
 							),
 						}),
 					}),
-					f:row({
-						f:checkbox({
-							value = bind("enableVertexAI"),
-							title = LOC(
-								"$$$/LrGeniusAI/AnalyzeAndIndex/EnableVertexAI=Create Vertex AI embeddings (Cloud-based search)"
-							),
-						}),
-					}),
+					-- Vertex AI is disabled in the GUI; the backend code is untouched.
+					-- f:row({
+					-- 	f:checkbox({
+					-- 		value = bind("enableVertexAI"),
+					-- 		title = LOC(
+					-- 			"$$$/LrGeniusAI/AnalyzeAndIndex/EnableVertexAI=Create Vertex AI embeddings (Cloud-based search)"
+					-- 		),
+					-- 	}),
+					-- }),
 				}),
 			}), -- end General tab
 
@@ -570,7 +573,8 @@ local function showAnalyzeAndIndexDialog(ctx)
 		prefs.enableEmbeddings = props.enableEmbeddings
 		prefs.enableMetadata = props.enableMetadata
 		prefs.enableFaces = props.enableFaces
-		prefs.enableVertexAI = props.enableVertexAI
+		-- Vertex AI is disabled in the GUI; the backend code is untouched.
+		-- prefs.enableVertexAI = props.enableVertexAI
 		prefs.enableImportBeforeIndex = props.enableImportBeforeIndex
 		prefs.regenerateMetadata = props.regenerateMetadata
 		prefs.appendMetadata = props.appendMetadata

--- a/plugin/LrGeniusAI.lrdevplugin/TaskSemanticSearch.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskSemanticSearch.lua
@@ -11,7 +11,9 @@ local function showAdvancedSearchDialog(ctx)
 	-- Scope and search-in options from prefs (persisted)
 	props.searchScope = prefs.searchScope or "all"
 	props.searchInSemanticSiglip = prefs.searchInSemanticSiglip ~= false
-	props.searchInSemanticVertex = prefs.searchInSemanticVertex ~= false
+	-- Vertex AI is disabled in the GUI; the backend code is untouched.
+	props.searchInSemanticVertex = false
+	-- props.searchInSemanticVertex = prefs.searchInSemanticVertex ~= false
 	props.searchInMetadata = prefs.searchInMetadata ~= false
 	props.searchInMetadataKeywords = prefs.searchInMetadataKeywords ~= false
 	props.searchInMetadataCaption = prefs.searchInMetadataCaption ~= false
@@ -118,10 +120,11 @@ local function showAdvancedSearchDialog(ctx)
 							"$$$/LrGeniusAI/AdvancedSearchTask/SearchInSemanticSiglip=Semantic (SigLIP / local AI)"
 						),
 					}),
-					f:checkbox({
-						value = bind("searchInSemanticVertex"),
-						title = LOC("$$$/LrGeniusAI/AdvancedSearchTask/SearchInSemanticVertex=Semantic (Vertex AI)"),
-					}),
+					-- Vertex AI is disabled in the GUI; the backend code is untouched.
+					-- f:checkbox({
+					-- 	value = bind("searchInSemanticVertex"),
+					-- 	title = LOC("$$$/LrGeniusAI/AdvancedSearchTask/SearchInSemanticVertex=Semantic (Vertex AI)"),
+					-- }),
 					f:checkbox({
 						value = bind("searchInMetadata"),
 						title = LOC("$$$/LrGeniusAI/AdvancedSearchTask/SearchInMetadata=Metadata"),
@@ -180,7 +183,8 @@ local function showAdvancedSearchDialog(ctx)
 		-- Persist dialog options to prefs for next time
 		prefs.searchScope = props.searchScope
 		prefs.searchInSemanticSiglip = props.searchInSemanticSiglip
-		prefs.searchInSemanticVertex = props.searchInSemanticVertex
+		-- Vertex AI is disabled in the GUI; the backend code is untouched.
+		-- prefs.searchInSemanticVertex = props.searchInSemanticVertex
 		prefs.searchInMetadata = props.searchInMetadata
 		prefs.searchInMetadataKeywords = props.searchInMetadataKeywords
 		prefs.searchInMetadataCaption = props.searchInMetadataCaption


### PR DESCRIPTION
Removes every Vertex AI control from the Lightroom UI by commenting it out. The code stays in place so it can be switched back on later, and the **backend is untouched** — the server still supports Vertex AI, the plugin just never offers or requests it.

## What is commented out

| Where | What |
|---|---|
| Plugin Manager → API keys | "Vertex AI Project ID" and "Vertex AI Location" fields, plus the `startDialog`/`endDialog` prefs plumbing behind them |
| Analyze & Index → General | "Create Vertex AI embeddings (Cloud-based search)" checkbox |
| Semantic Search → Search in | "Semantic (Vertex AI)" checkbox |
| Plugin Manager stats | "Photos with Vertex AI" line |

## Behaviour

Two props are hardcoded to `false` rather than read from prefs, so an existing pref value from a previous install cannot silently re-enable Vertex AI now that there is no checkbox to see it in:

- `TaskAnalyzeAndIndex`: `props.enableVertexAI = false` → `"vertexai"` is never added to the tasks array, and the pref is no longer written back.
- `TaskSemanticSearch`: `props.searchInSemanticVertex = false` → the search request always sends `semantic_vertex = false`. `searchIndex` has exactly one caller and it always passes `searchOptions`, so there is no path left that falls through to the backend default.

The `vertexProjectId` / `vertexLocation` / `searchInSemanticVertex` defaults in `Init.lua` are left alone (harmless, and needed if this is reverted), as is the "Vertex AI SDK (Google Cloud)" entry in the acknowledgements list in `Defaults.lua` — that documents a dependency the backend still compiles in.

## Checks

- `luacheck` — 0 warnings / 0 errors
- `stylua --check plugin/LrGeniusAI.lrdevplugin/` — clean
- `busted` — 128 successes / 0 failures
- `scripts/check_translations.py` — in sync across en/de/fr (709 keys). Orphan warnings go 35 → 36: `AnalyzeAndIndex/EnableVertexAI` is now unreferenced. Translation keys are deliberately kept so a revert needs no translation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMqFZBhGAMNN9o9HVVqbPs