### PR TITLE
docs: mark Vertex AI as removed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ Cargo workspace, one binary (`geniusai-server`) across these crates:
 - `lrg-imaging` — image conversion, EXIF/IPTC/XMP, pHash, culling metrics.
 - `lrg-ml` — ONNX Runtime (`ort` crate) session management, SigLIP2 pre/post-processing + `tokenizers`-crate Gemma tokenizer, SCRFD face detection + ArcFace embedding. Model file locations resolved in `model_paths.rs` (env vars, see [server-rs/README.md](server-rs/README.md)).
 - `lrg-analysis` — clustering, person matching, group/cull grading, style engine, keyword clustering.
-- `lrg-providers` — LLM provider trait + REST clients (OpenAI, Gemini, Ollama, LM Studio, Vertex AI via `gcp_auth`), edit-recipe schemas. `local_provider.rs` serves *both* local backends off one `LocalEngine` trait; it has no llama.cpp or MLX dependency of its own.
+- `lrg-providers` — LLM provider trait + REST clients (OpenAI, Gemini, Ollama, LM Studio, and Vertex AI via `gcp_auth` — Vertex AI was removed from the plugin UI in August 2026, so the client is dormant but still compiled and functional), edit-recipe schemas. `local_provider.rs` serves *both* local backends off one `LocalEngine` trait; it has no llama.cpp or MLX dependency of its own.
 - `lrg-mlx` — supervises the `lrgenius-mlx` Swift sidecar (`native/mlx-sidecar/`) and speaks its JSON-lines stdio protocol. No native build step, no cargo feature; Apple silicon only at runtime.
 - `lrg-api` — axum routers (one module per API domain under `routes/`), `db_path` auto-bind middleware, jobs registry.
 - `lrg-server` — the binary: CLI (`clap`), lifecycle, self-updater (`routes::update`), `migrate` subcommand.
@@ -143,7 +143,7 @@ Cargo workspace, one binary (`geniusai-server`) across these crates:
 ### Data & Identity
 
 - Primary photo identity: file-based `photo_id` (replaces legacy Lightroom UUIDs).
-- Vector search: LanceDB tables `IMAGE_TABLE`/`VERTEX_TABLE`/`FACE_TABLE` in `lrg_store` (SigLIP2, Vertex AI, and face embeddings respectively).
+- Vector search: LanceDB tables `IMAGE_TABLE`/`VERTEX_TABLE`/`FACE_TABLE` in `lrg_store` (SigLIP2, Vertex AI, and face embeddings respectively). `VERTEX_TABLE` is legacy: the plugin stopped writing and querying it when Vertex AI was removed (August 2026), existing rows are kept.
 - Multi-catalog support: photos track `catalog_ids`; reads are catalog-scoped when a `catalog_id` is provided. The server never physically deletes photo data.
 
 ---

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,7 +22,7 @@ You have full control over where your data is processed. This is how we handle i
 When using local models like **Ollama** or **LM Studio**, all analysis, tagging, and semantic indexing happen entirely on your machine. No image data or metadata is transmitted to external servers.
 
 ### 🌐 Cloud Processing (Optional)
-If you choose to enable cloud providers (OpenAI, Google Gemini, Vertex AI), only the necessary data is sent to these services:
+If you choose to enable cloud providers (OpenAI, Google Gemini; Vertex AI was removed in August 2026 and is no longer contacted), only the necessary data is sent to these services:
 - **Image Content**: Temporary transmission of image pixels or descriptive prompts for analysis.
 - **Contextual Hints**: Any manual photo context you provide.
 - **API Keys**: Stored locally and sent only to the respective provider.
@@ -53,7 +53,7 @@ If you choose to enable cloud providers (OpenAI, Google Gemini, Vertex AI), only
 We use **InsightFace** for local face clustering. These biometric templates are stored in your local backend database and are **never** shared with us or any third party.
 
 ### 🔑 API Keys
-Your API keys for services like OpenAI or Vertex AI are stored in the Lightroom plugin configuration (on your disk). They are transmitted only to the service provider via encrypted HTTPS requests.
+Your API keys for services like OpenAI or Google Gemini are stored in the Lightroom plugin configuration (on your disk). They are transmitted only to the service provider via encrypted HTTPS requests.
 
 ---
 
@@ -62,7 +62,7 @@ Your API keys for services like OpenAI or Vertex AI are stored in the Lightroom 
 If you utilize cloud features, please refer to the privacy policies of the supported providers:
 
 *   [OpenAI Privacy Policy](https://openai.com/policies/privacy-policy)
-*   [Google Cloud (Vertex AI) Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)
+*   ~~[Google Cloud (Vertex AI) Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice)~~ - *Vertex AI removed, no longer used*
 *   [Ollama (Local)](https://ollama.com/) - *Fully Private*
 *   [LM Studio (Local)](https://lmstudio.ai/) - *Fully Private*
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 - **👥 People & Faces:** Detect and cluster faces, assign names to persons, browse person collections, and find similar faces across your catalog.
 - **🔎 Find Similar Images:** Find near-duplicate or visually similar photos for any selected image using perceptual hash or semantic CLIP comparison.
 - **🏠 Built-In Local AI (no external app):** The backend runs vision models itself — **llama.cpp** in-process (GGUF, all platforms; Metal on macOS, Vulkan on Windows) and **MLX** on Apple silicon via a small Metal helper process. Pick a model in the Plug-in Manager, click *Download*, and analysis runs entirely on your machine. Models you already have in LM Studio (or the Hugging Face cache) are picked up without a second copy.
-- **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI**, **Google Gemini**, and **Vertex AI**.
+- **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI** and **Google Gemini**. (~~**Vertex AI**~~ — *removed*, see below.)
 - **🎨 Customizable Prompts & Temperature Control:** System prompts for the AI can be added, edited, and deleted directly within the Lightroom Plug-In Manager. Use the temperature slider to control whether the AI should be highly creative or strictly consistent.
 - **📝 Photo Context (Contextual Info):** Provide manual hints to the AI before analysis (e.g., names of people or specific background details) that aren't immediately obvious from the image itself. This can be done via a popup dialog or directly in Lightroom's metadata panel.
 - **🗂️ Keyword Management:** Interactive synonym deduplication and automatic de-clutter during indexing to keep your keyword catalog clean.
@@ -64,7 +64,12 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 
 ---
 
-For detailed instructions on how to use Google Vertex AI, please see our [Google Vertex AI Login Wiki Page](https://github.com/LrGenius/LrGeniusAI/wiki/Google-Vertex-AI-Login).
+> **⚠️ Google Vertex AI has been removed (August 2026).**
+> The Vertex AI controls are gone from the Lightroom plugin: no project ID / location
+> settings, no Vertex embeddings during *Analyze & Index*, and no *Semantic (Vertex AI)*
+> search option. Existing Vertex embeddings in your database stay untouched but are no
+> longer created or queried. The old setup instructions are kept for reference on the
+> [Google Vertex AI Login Wiki Page](https://github.com/LrGenius/LrGeniusAI/wiki/Google-Vertex-AI-Login).
 
 ## ⚖️ License
 
@@ -81,7 +86,7 @@ This project is built on the belief that AI tooling for creatives should remain 
 - **Identity & Faces:** InsightFace (ONNX)
 - **Local Inference:** llama.cpp compiled into the backend (Metal / Vulkan / CPU), plus an MLX Swift helper (`lrgenius-mlx`) for Apple silicon
 - **Database:** LanceDB
-- **Supported Interfaces:** built-in llama.cpp, built-in MLX (Apple silicon), Google Gemini, Vertex AI, ChatGPT/OpenAI, Ollama, LM-Studio
+- **Supported Interfaces:** built-in llama.cpp, built-in MLX (Apple silicon), Google Gemini, ChatGPT/OpenAI, Ollama, LM-Studio (~~Vertex AI~~ — *removed*)
 
 
 ---

--- a/docs/wiki/Credits.md
+++ b/docs/wiki/Credits.md
@@ -18,7 +18,7 @@ LrGeniusAI is made possible by these amazing open-source projects and AI framewo
 
 ## AI Model Providers & Interfaces
 - **Google Gemini**: Large language models for multimodal analysis.
-- **Google Vertex AI**: Enterprise AI platform for training and deploying models.
+- ~~**Google Vertex AI**: Enterprise AI platform for training and deploying models.~~ *(removed from the plugin in August 2026; the backend client code remains but is unused.)*
 - **OpenAI / ChatGPT**: Advanced conversational AI and embeddings.
 - **Ollama**: Run open-source large language models locally. [Website](https://ollama.ai/)
 - **LM Studio**: Discover, download, and run local LLMs. [Website](https://lmstudio.ai/)

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -296,7 +296,9 @@ Progress of the current local-model download (same shape as the CLIP download st
 Returns aggregate database statistics:
 - total indexed photos
 - photos with SigLIP embeddings
-- photos with Vertex AI embeddings
+- photos with Vertex AI embeddings *(legacy — Vertex AI was removed from the plugin in
+  August 2026; the field is still returned but the plugin no longer displays it and the
+  count no longer grows)*
 - photos with title / caption / keywords
 - total detected faces
 - total persons

--- a/docs/wiki/Dev-Build-Environment-Setup.md
+++ b/docs/wiki/Dev-Build-Environment-Setup.md
@@ -8,7 +8,9 @@ build/test commands once the environment is ready, see the
 There are three layers, each opt-in on top of the last:
 
 1. **Baseline** — builds `geniusai-server` with cloud providers only (Gemini,
-   OpenAI, Ollama, LM Studio, Vertex AI). No local-model support.
+   OpenAI, Ollama, LM Studio, and the now-unused Vertex AI client — Vertex AI was
+   removed from the plugin UI in August 2026, so nothing requests it). No
+   local-model support.
 2. **`llamacpp` feature** — adds in-process local inference via llama.cpp.
    Compiles llama.cpp from source, so it needs `cmake` + `libclang` (for
    `bindgen`), and on Windows a GPU backend (Vulkan, not CUDA — see

--- a/docs/wiki/Dev-Plugin-README.md
+++ b/docs/wiki/Dev-Plugin-README.md
@@ -71,7 +71,7 @@ The plugin is designed to work with local and cloud providers, while keeping Lig
 - Optional API keys depending on provider:
   - Gemini
   - OpenAI / ChatGPT
-  - Vertex AI (project + location)
+  - ~~Vertex AI (project + location)~~ — **removed**, the plugin no longer offers Vertex AI
 
 ---
 
@@ -100,7 +100,9 @@ Notes:
 
 - Migration is incremental and skips photos that are not indexed in backend.
 - Existing migrated entries are skipped automatically.
-- Main embeddings, vertex embeddings, and face references are migrated.
+- Main embeddings, vertex embeddings, and face references are migrated. (Vertex embeddings
+  are legacy — they are still migrated if present, but no new ones are created since Vertex AI
+  was removed.)
 
 ---
 
@@ -145,7 +147,7 @@ In the plugin settings dialog you can configure:
 
 - Backend server URL
 - Ollama and LM Studio base URLs
-- API keys and Vertex settings
+- API keys (the Vertex AI project/location fields were removed)
 - **Local AI Model (no external app)** — browse, download and select GGUF vision
   models run in-process by the backend's llama.cpp engine, plus the advanced
   knobs (context size, photos in parallel, layers on the GPU)
@@ -158,7 +160,12 @@ In the plugin settings dialog you can configure:
 
 ---
 
-## Google Vertex AI Login (gcloud)
+## Google Vertex AI Login (gcloud) — REMOVED
+
+> **⚠️ Vertex AI was removed from the plugin in August 2026.** The project ID / location
+> fields, the *Create Vertex AI embeddings* option in Analyze & Index, and the
+> *Semantic (Vertex AI)* search option are gone from the Lightroom UI. The section below is
+> kept for reference only and no longer describes a working setup path.
 
 If you want to use Vertex AI from LrGeniusAI, run the login on the machine where the backend server runs.
 
@@ -223,7 +230,7 @@ If you migrated from legacy UUID-based IDs to `photo_id`:
 
 - The plugin can trigger backend migration from the Plugin Manager UI.
 - Migration uses a progress scope and batch requests.
-- Existing collections (main embeddings, vertex embeddings, faces) are migrated through backend migration endpoints.
+- Existing collections (main embeddings, legacy vertex embeddings, faces) are migrated through backend migration endpoints.
 
 ---
 

--- a/docs/wiki/Dev-Project-README.md
+++ b/docs/wiki/Dev-Project-README.md
@@ -14,9 +14,6 @@
   [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/W7X2240HF4)
 </div>
 
----
-
-> **Note:** The lead developer is currently [taking a break from open-source development](https://blog.fokuspunk.de/posts/taking-a-break-from-open-source/). The project remains available, but active maintenance is paused.
 
 ---
 
@@ -37,7 +34,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 - **👥 People & Faces:** Detect and cluster faces, assign names to persons, browse person collections, and find similar faces across your catalog.
 - **🔎 Find Similar Images:** Find near-duplicate or visually similar photos for any selected image using perceptual hash or semantic CLIP comparison.
 - **🏠 Built-In Local AI (no external app):** The backend runs vision models itself — **llama.cpp** in-process (GGUF, all platforms; Metal on macOS, Vulkan on Windows) and **MLX** on Apple silicon via a small Metal helper process. Pick a model in the Plug-in Manager, click *Download*, and analysis runs entirely on your machine. Models you already have in LM Studio (or the Hugging Face cache) are picked up without a second copy.
-- **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI**, **Google Gemini**, and **Vertex AI**.
+- **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI** and **Google Gemini**. (~~**Vertex AI**~~ — *removed*, see below.)
 - **🎨 Customizable Prompts & Temperature Control:** System prompts for the AI can be added, edited, and deleted directly within the Lightroom Plug-In Manager. Use the temperature slider to control whether the AI should be highly creative or strictly consistent.
 - **📝 Photo Context (Contextual Info):** Provide manual hints to the AI before analysis (e.g., names of people or specific background details) that aren't immediately obvious from the image itself. This can be done via a popup dialog or directly in Lightroom's metadata panel.
 - **🗂️ Keyword Management:** Interactive synonym deduplication and automatic de-clutter during indexing to keep your keyword catalog clean.
@@ -71,7 +68,12 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 
 ---
 
-For detailed instructions on how to use Google Vertex AI, please see our [Google Vertex AI Login Wiki Page](https://github.com/LrGenius/LrGeniusAI/wiki/Google-Vertex-AI-Login).
+> **⚠️ Google Vertex AI has been removed (August 2026).**
+> The Vertex AI controls are gone from the Lightroom plugin: no project ID / location
+> settings, no Vertex embeddings during *Analyze & Index*, and no *Semantic (Vertex AI)*
+> search option. Existing Vertex embeddings in your database stay untouched but are no
+> longer created or queried. The old setup instructions are kept for reference on the
+> [Google Vertex AI Login Wiki Page](https://github.com/LrGenius/LrGeniusAI/wiki/Google-Vertex-AI-Login).
 
 ## ⚖️ License
 
@@ -88,7 +90,7 @@ This project is built on the belief that AI tooling for creatives should remain 
 - **Identity & Faces:** InsightFace (ONNX)
 - **Local Inference:** llama.cpp compiled into the backend (Metal / Vulkan / CPU), plus an MLX Swift helper (`lrgenius-mlx`) for Apple silicon
 - **Database:** LanceDB
-- **Supported Interfaces:** built-in llama.cpp, built-in MLX (Apple silicon), Google Gemini, Vertex AI, ChatGPT/OpenAI, Ollama, LM-Studio
+- **Supported Interfaces:** built-in llama.cpp, built-in MLX (Apple silicon), Google Gemini, ChatGPT/OpenAI, Ollama, LM-Studio (~~Vertex AI~~ — *removed*)
 
 
 ---

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -8,7 +8,7 @@ LrGeniusAI is an AI extension for Adobe Lightroom Classic. It adds AI-powered me
 
 ### Does it send my photos to the cloud?
 
-Only if you choose a cloud provider (ChatGPT/OpenAI, Google Gemini, Vertex AI). With a local provider — the built-in llama.cpp and MLX engines, or an external Ollama / LM Studio server — your photos never leave your machine. For cloud providers, images are sent to the respective API for analysis. Embeddings and all generated metadata are always stored locally.
+Only if you choose a cloud provider (ChatGPT/OpenAI, Google Gemini; Vertex AI was removed in August 2026). With a local provider — the built-in llama.cpp and MLX engines, or an external Ollama / LM Studio server — your photos never leave your machine. For cloud providers, images are sent to the respective API for analysis. Embeddings and all generated metadata are always stored locally.
 
 ### Which Lightroom version is supported?
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -30,7 +30,7 @@ When you try to open the `.pkg` installer or the backend binary:
 Once installed, open the **Lightroom Plug-in Manager** (`File -> Plug-in Manager`) and locate LrGeniusAI. Here you need to:
 - **Set the Backend Server URL:** This defaults to `http://127.0.0.1:19819` but if you're running the backend on a different machine (e.g. via Docker), update the address here.
 - **Configure Provider/API Keys:** If you plan to use cloud providers like OpenAI or Google Gemini, enter your API keys. For external local servers like Ollama or LM Studio, ensure their respective base URLs are correctly configured.
-- **Set Vertex AI Details:** If using Google Cloud's Vertex AI, provide your project ID and preferred location.
+- ~~**Set Vertex AI Details:** If using Google Cloud's Vertex AI, provide your project ID and preferred location.~~ **Removed** — the Vertex AI fields no longer exist in the Plug-in Manager (see [section 7](#7-vertex-ai-login--removed)).
 
 *Having trouble? Refer to the [Troubleshooting](Troubleshooting) guide for connectivity and API issues.*
 
@@ -83,7 +83,11 @@ We highly recommend creating regular backups of your backend data, especially be
 2. Navigate to `Backend Server` and click **Download DB backup**.
 3. Save the resulting `.zip` file somewhere safe. The backup contains the full persistent backend directory including your embeddings and metadata databases.
 
-## 7. Vertex AI Login
+## 7. Vertex AI Login — REMOVED
+
+> **⚠️ Vertex AI was removed from LrGeniusAI in August 2026.** The plugin no longer exposes
+> Vertex AI project/location settings, Vertex embeddings, or *Semantic (Vertex AI)* search,
+> so this step is no longer needed. It is kept here for reference only.
 
 For users of Google's Vertex AI, you need to use Google Cloud ADC (Application Default Credentials) on the host running the server.
 

--- a/docs/wiki/Google-Vertex-AI-Login.md
+++ b/docs/wiki/Google-Vertex-AI-Login.md
@@ -1,4 +1,16 @@
-# ☁️ Google Vertex AI Login (gcloud)
+# ☁️ Google Vertex AI Login (gcloud) — REMOVED
+
+> **⚠️ Vertex AI support was removed from LrGeniusAI in August 2026.**
+>
+> The plugin no longer offers any Vertex AI option: the *Vertex AI Project ID* / *Vertex AI
+> Location* fields are gone from the Plug-in Manager, *Analyze & Index* no longer creates
+> Vertex embeddings, and *Advanced Search* no longer offers the *Semantic (Vertex AI)*
+> option. Vertex embeddings already stored in your database are kept, but they are neither
+> updated nor searched anymore.
+>
+> This page is kept as historical reference for the previous setup. Nothing below applies to
+> the current version — use [Choosing an AI Model](Help-Choosing-AI-Model) to pick a
+> supported provider instead.
 
 If you want to use Vertex AI with LrGeniusAI, run the login on the machine where `geniusai-server` is running.
 

--- a/docs/wiki/Help-Choosing-AI-Model.md
+++ b/docs/wiki/Help-Choosing-AI-Model.md
@@ -48,7 +48,13 @@ Note: GPT-5 and GPT-5.4 models ignore the `temperature` slider and use a
 fixed reasoning effort — small differences in plugin temperature settings
 will not affect output for these models.
 
-### Vertex AI (embeddings only)
+### ~~Vertex AI (embeddings only)~~ — REMOVED
+
+> **⚠️ Removed in August 2026.** The plugin no longer offers Vertex AI anywhere: no
+> project/location settings, no Vertex embeddings during *Analyze & Index*, no
+> *Semantic (Vertex AI)* search option. Semantic search now runs on the built-in SigLIP2
+> embeddings only. Existing Vertex embeddings stay in the database but are not updated or
+> queried. Description below kept for reference.
 
 Vertex AI is used for the `multimodalembedding@001` model that powers the
 `image_embeddings_vertex` semantic-search collection. It is **not** an

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -31,7 +31,7 @@ Welcome to the project wiki.
 - [Help: Local AI Models](Help-Local-AI-Models) — built-in llama.cpp & MLX engines, no external app
 - [Help: Ollama Setup](Help-Ollama-Setup)
 - [Help: LM Studio Setup](Help-LM-Studio-Setup)
-- [Google Vertex AI Login](Google-Vertex-AI-Login)
+- [Google Vertex AI Login](Google-Vertex-AI-Login) — *removed, kept for reference*
 
 ### Other
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -67,7 +67,7 @@ The plugin is designed to work with local and cloud providers, while keeping Lig
 - Optional API keys depending on provider:
   - Gemini
   - OpenAI / ChatGPT
-  - Vertex AI (project + location)
+  - ~~Vertex AI (project + location)~~ — **removed**, the plugin no longer offers Vertex AI
 
 ---
 
@@ -96,7 +96,9 @@ Notes:
 
 - Migration is incremental and skips photos that are not indexed in backend.
 - Existing migrated entries are skipped automatically.
-- Main embeddings, vertex embeddings, and face references are migrated.
+- Main embeddings, vertex embeddings, and face references are migrated. (Vertex embeddings
+  are legacy — they are still migrated if present, but no new ones are created since Vertex AI
+  was removed.)
 
 ---
 
@@ -141,7 +143,7 @@ In the plugin settings dialog you can configure:
 
 - Backend server URL
 - Ollama and LM Studio base URLs
-- API keys and Vertex settings
+- API keys (the Vertex AI project/location fields were removed)
 - **Local AI Model (no external app)** — browse, download and select GGUF vision
   models run in-process by the backend's llama.cpp engine, plus the advanced
   knobs (context size, photos in parallel, layers on the GPU)
@@ -154,7 +156,12 @@ In the plugin settings dialog you can configure:
 
 ---
 
-## Google Vertex AI Login (gcloud)
+## Google Vertex AI Login (gcloud) — REMOVED
+
+> **⚠️ Vertex AI was removed from the plugin in August 2026.** The project ID / location
+> fields, the *Create Vertex AI embeddings* option in Analyze & Index, and the
+> *Semantic (Vertex AI)* search option are gone from the Lightroom UI. The section below is
+> kept for reference only and no longer describes a working setup path.
 
 If you want to use Vertex AI from LrGeniusAI, run the login on the machine where the backend server runs.
 
@@ -219,7 +226,7 @@ If you migrated from legacy UUID-based IDs to `photo_id`:
 
 - The plugin can trigger backend migration from the Plugin Manager UI.
 - Migration uses a progress scope and batch requests.
-- Existing collections (main embeddings, vertex embeddings, faces) are migrated through backend migration endpoints.
+- Existing collections (main embeddings, legacy vertex embeddings, faces) are migrated through backend migration endpoints.
 
 ---
 


### PR DESCRIPTION
Follow-up to #253, which commented out every Vertex AI control in the Lightroom UI. The docs still advertised Vertex AI as a supported provider — they now mark it as removed. Nothing is deleted: the old setup instructions stay in place as historical reference.

## User-facing docs

- **README.md** / **plugin/README.md** — provider lists struck through; the Vertex link section is now a callout stating exactly what disappeared (project ID / location fields, Vertex embeddings in Analyze & Index, *Semantic (Vertex AI)* search) and that existing embeddings are kept but no longer created or queried.
- **Google-Vertex-AI-Login**, **Getting-Started** (section 7 + the settings bullet), **Help-Choosing-AI-Model** — REMOVED banners above the untouched instructions.
- **Home**, **FAQ**, **Credits**, **PRIVACY.md** — annotated as removed; the API-key example in PRIVACY.md now names Gemini instead of Vertex.

## Dev docs

- **Dev-Backend-API** — the `/db/stats` Vertex count is legacy: still returned, no longer displayed, no longer grows.
- **Dev-Build-Environment-Setup**, **CLAUDE.md** — the backend still compiles and supports Vertex AI; only the plugin stopped requesting it. `VERTEX_TABLE` marked legacy.

The two `Dev-*-README` wiki pages were regenerated with `scripts/build-wiki-pages.sh`. That also drops the "taking a break from open-source" note which had been hand-added to the auto-generated `Dev-Project-README.md` — removed intentionally.

Removal is dated "August 2026" rather than tied to a version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwbBTGeRM5qfJQmmDrRQaM
