### PR TITLE
AI Edit: fix four defects that broke the edit path, and start measuring the source image

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,7 +9,6 @@ globals = {
     "_PLUGIN",
     "prefs",
     "log",
-    "recipe",
     "JSON",
     "Util",
     "ErrorHandler",

--- a/docs/wiki/Dev-Build-Environment-Setup.md
+++ b/docs/wiki/Dev-Build-Environment-Setup.md
@@ -192,6 +192,56 @@ under Program Files on Windows), not your dev build — `startServer` pings port
 feature-enabled dev build by hand first and the plugin will talk to that
 instead.
 
+## Building behind a restricted network
+
+`ort` (the ONNX Runtime bindings) downloads prebuilt binaries from `cdn.pyke.io`
+at build time. Where that host is unreachable — a sandbox, a CI image with an
+egress allowlist, an air-gapped machine — the build fails with:
+
+```
+error: ort-sys@2.0.0-rc.13: ort-sys failed to download prebuilt binaries from
+`https://cdn.pyke.io/0/pyke:ort-rs/ms@1.28.0/...`
+```
+
+No source change is needed. ONNX Runtime's Python wheel ships the same shared
+library, and PyPI is reachable in most such environments:
+
+```bash
+# The version must match what ort expects: 2.0.0-rc.13 targets ONNX Runtime 1.28.0.
+pip download onnxruntime==1.28.0 --no-deps -d /tmp/ort_whl
+unzip -q /tmp/ort_whl/*.whl -d /tmp/ort_ext
+sudo mkdir -p /opt/ort/lib
+sudo cp /tmp/ort_ext/onnxruntime/capi/libonnxruntime.so* /opt/ort/lib/
+sudo ln -sf /opt/ort/lib/libonnxruntime.so.1.28.0 /opt/ort/lib/libonnxruntime.so
+sudo ln -sf /opt/ort/lib/libonnxruntime.so.1.28.0 /opt/ort/lib/libonnxruntime.so.1
+```
+
+Then build and test with:
+
+```bash
+export ORT_STRATEGY=system
+export ORT_LIB_LOCATION=/opt/ort/lib   # the directory holding the .so, not its parent
+export ORT_PREFER_DYNAMIC_LINK=1       # without this ort-sys attempts a *static* link
+export LD_LIBRARY_PATH=/opt/ort/lib
+cargo test --workspace
+```
+
+Three details that are easy to get wrong:
+
+- `ORT_LIB_LOCATION` is used verbatim as the library directory (see `ort-sys`'s
+  `build/main.rs`), so pointing it at a parent directory that contains `lib/`
+  does not work.
+- Without `ORT_PREFER_DYNAMIC_LINK=1`, `ort-sys` falls through to static linking
+  and reports `could not link to the ONNX Runtime build in ...`, which reads like
+  a missing library rather than the wrong link mode.
+- The second symlink (`libonnxruntime.so.1`) is the soname the binary requests at
+  *runtime*; without it the build succeeds and every test aborts with
+  `error while loading shared libraries`.
+
+On a bare image `lance` also needs `protoc` (`apt-get install protobuf-compiler`),
+and the headless Lua tests need `lua5.1` plus `busted` and `luacheck` from
+LuaRocks.
+
 ## Related
 
 - [Server README](Dev-Server-README) — day-to-day build/test/run commands, model file setup

--- a/docs/wiki/Help-AI-Edit.md
+++ b/docs/wiki/Help-AI-Edit.md
@@ -68,15 +68,18 @@ Default: Subtle crop.
 
 When enabled, a **review dialog** opens for each photo before the edit is applied. You see:
 
-- A before/after comparison.
-- The proposed develop values.
-- Options to **Apply**, **Skip**, or provide a **Per-photo instruction override** (free text to tell the AI to adjust something specific for this photo).
+- The proposed develop values, plus which engine produced them and how confident it was.
+- Options to **Apply** or **Skip**.
 
 **Recommended for first use.** Disable only after you've validated the results for your shooting style.
 
-### Per-photo instruction override (in review dialog)
+> **No before/after preview yet.** The review dialog lists values; it does not render a comparison. A rendered before/after is planned. Until then, Lightroom's own History panel is the fastest way to judge a result — every run is a single undo step named *Apply AI Lightroom develop settings*.
 
-A free-text field where you can give the AI a specific instruction for the current photo — for example "Make the sky more dramatic" or "Reduce noise in shadows". This re-runs generation for this single photo with the override applied.
+### Per-photo instruction
+
+If **Allow per-photo instructions** is enabled, a free-text field opens *before* the edit is generated — for example "Make the sky more dramatic" or "Reduce noise in shadows". A checkbox carries the same instruction to all following photos.
+
+Note this happens before generation, not after: there is currently no way to re-run a single photo from the review dialog with a changed instruction. Skip the photo and run it again to do that.
 
 ---
 
@@ -91,6 +94,5 @@ If you want AI Edit to match your personal editing style, use **Save Edits as AI
 - Start with **Review each proposed edit** enabled — review the first batch before applying to hundreds of photos.
 - Choose a preset that matches your genre (portrait, landscape, wedding, etc.) rather than using *Custom* initially.
 - **Style strength 40–60%** is a good starting range. Higher values push the style harder; lower values stay close to a neutral technical correction.
-- For portraits, enable **face detection** during indexing — the AI uses detected faces to make better masking decisions.
 - If results are inconsistent, try a higher-quality model (e.g. `gemini-2.5-pro` or `gpt-5.4-pro`).
 - Use **Save Edits as AI Training Examples** after a manual editing session to teach the AI your preferences.

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -926,6 +926,33 @@ function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 	table.insert(mimeChunks, { name = "submit_keywords", value = tostring(options.submit_keywords or false) })
 	table.insert(mimeChunks, { name = "submit_folder_names", value = tostring(options.submit_folder_names or false) })
 	table.insert(mimeChunks, { name = "include_masks", value = tostring(options.include_masks ~= false) })
+
+	-- The Creative Controls group and the style-strength slider. These were
+	-- assembled by the dialog and then never sent, so the backend applied its own
+	-- defaults (every control on, style strength 0.5) and the whole group box was a
+	-- no-op. The backend reads absent booleans as `true`, so an unchecked box has to
+	-- travel as an explicit "false" rather than simply being omitted.
+	local function addBoolOpt(name, value)
+		table.insert(mimeChunks, { name = name, value = tostring(value ~= false) })
+	end
+	addBoolOpt("adjust_white_balance", options.adjust_white_balance)
+	addBoolOpt("adjust_basic_tone", options.adjust_basic_tone)
+	addBoolOpt("adjust_presence", options.adjust_presence)
+	addBoolOpt("adjust_color_mix", options.adjust_color_mix)
+	addBoolOpt("do_color_grading", options.do_color_grading)
+	addBoolOpt("use_tone_curve", options.use_tone_curve)
+	addBoolOpt("use_point_curve", options.use_point_curve)
+	addBoolOpt("adjust_detail", options.adjust_detail)
+	addBoolOpt("adjust_effects", options.adjust_effects)
+	addBoolOpt("adjust_lens_corrections", options.adjust_lens_corrections)
+	addBoolOpt("allow_auto_crop", options.allow_auto_crop)
+	if options.style_strength ~= nil then
+		table.insert(mimeChunks, { name = "style_strength", value = tostring(options.style_strength) })
+	end
+	if options.composition_mode then
+		table.insert(mimeChunks, { name = "composition_mode", value = tostring(options.composition_mode) })
+	end
+
 	if options.user_context then
 		table.insert(mimeChunks, { name = "user_context", value = options.user_context })
 	end
@@ -4387,7 +4414,15 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	addStr("aperture")
 	addStr("shutter_speed")
 
-	-- Standard edit options forwarded for LLM fallback compatibility
+	-- Standard edit options forwarded for LLM fallback compatibility.
+	--
+	-- The fallback fires exactly when the style engine cannot answer — which for a
+	-- new user with no training examples is the *first* run, since
+	-- `aiEditUseTrainingStyle` defaults on. It used to omit `api_key` entirely, and
+	-- there is no environment-variable fallback in `provider.rs`/`openai.rs`, so
+	-- that first run reached the provider with an empty bearer token and 401'd.
+	-- Everything `generateEditRecipePhoto` sends has to travel here too, or the
+	-- fallback silently produces a different edit than the direct path would.
 	local function addEditOpt(key, value)
 		if value ~= nil then
 			table.insert(mimeChunks, { name = key, value = tostring(value) })
@@ -4395,9 +4430,19 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	end
 	addEditOpt("provider", options.provider)
 	addEditOpt("model", options.model)
+	addEditOpt("api_key", options.api_key)
 	addEditOpt("language", options.language)
 	addEditOpt("temperature", options.temperature)
 	addEditOpt("max_tokens", options.max_tokens)
+	addEditOpt("prompt", options.prompt)
+	addEditOpt("edit_intent", options.edit_intent)
+	addEditOpt("user_context", options.user_context)
+	addEditOpt("style_strength", options.style_strength)
+	addEditOpt("composition_mode", options.composition_mode)
+	addEditOpt("date_time", options.date_time)
+	addEditOpt("folder_names", options.folder_names)
+	addEditOpt("submit_keywords", options.submit_keywords)
+	addEditOpt("submit_folder_names", options.submit_folder_names)
 	addEditOpt("include_masks", options.include_masks)
 	addEditOpt("adjust_white_balance", options.adjust_white_balance)
 	addEditOpt("adjust_basic_tone", options.adjust_basic_tone)
@@ -4405,9 +4450,21 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	addEditOpt("adjust_color_mix", options.adjust_color_mix)
 	addEditOpt("do_color_grading", options.do_color_grading)
 	addEditOpt("use_tone_curve", options.use_tone_curve)
+	addEditOpt("use_point_curve", options.use_point_curve)
 	addEditOpt("adjust_detail", options.adjust_detail)
 	addEditOpt("adjust_effects", options.adjust_effects)
+	addEditOpt("adjust_lens_corrections", options.adjust_lens_corrections)
 	addEditOpt("allow_auto_crop", options.allow_auto_crop)
+	addEditOpt("ollama_base_url", options.ollama_base_url or (prefs and prefs.ollamaBaseUrl))
+	addEditOpt("lmstudio_base_url", options.lmstudio_base_url or (prefs and prefs.lmstudioBaseUrl))
+
+	local styleCatalogId = getCatalogId()
+	if styleCatalogId then
+		table.insert(mimeChunks, { name = "catalog_id", value = styleCatalogId })
+	end
+	if options.existing_keywords then
+		table.insert(mimeChunks, { name = "existing_keywords", value = JSON:encode(options.existing_keywords) })
+	end
 
 	if filepath and LrFileUtils.exists(filepath) then
 		local filename = LrPathUtils.leafName(filepath)

--- a/plugin/LrGeniusAI.lrdevplugin/DevelopEditManager.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/DevelopEditManager.lua
@@ -73,48 +73,25 @@ local HSL_LABELS = {
 	magenta = "Magenta",
 }
 
-local ADDITIVE_GLOBAL_KEYS = {
-	Exposure2012 = true,
-	Contrast2012 = true,
-	Highlights2012 = true,
-	Shadows2012 = true,
-	Whites2012 = true,
-	Blacks2012 = true,
-	Temp = true,
-	Tint = true,
-	Texture = true,
-	Clarity2012 = true,
-	Dehaze = true,
-	Vibrance = true,
-	Saturation = true,
-	Sharpness = true,
-	SharpenRadius = true,
-	SharpenDetail = true,
-	SharpenEdgeMasking = true,
-	LuminanceSmoothing = true,
-	LuminanceNoiseReductionDetail = true,
-	LuminanceNoiseReductionContrast = true,
-	ColorNoiseReduction = true,
-	ColorNoiseReductionDetail = true,
-	ColorNoiseReductionSmoothness = true,
-	PostCropVignetteAmount = true,
-	PostCropVignetteMidpoint = true,
-	PostCropVignetteRoundness = true,
-	PostCropVignetteFeather = true,
-	PostCropVignetteHighlightContrast = true,
-	GrainAmount = true,
-	GrainSize = true,
-	GrainFrequency = true,
-	SplitToningShadowHue = true,
-	SplitToningShadowSaturation = true,
-	SplitToningHighlightHue = true,
-	SplitToningHighlightSaturation = true,
-	SplitToningBalance = true,
-	ParametricHighlights = true,
-	ParametricLights = true,
-	ParametricDarks = true,
-	ParametricShadows = true,
-}
+-- Global recipe values are ABSOLUTE Lightroom slider values, never deltas.
+--
+-- Both producers agree on this: the LLM schema declares Lightroom's own absolute
+-- ranges (`temperature` 2000..50000 Kelvin, `sharpening` 0..150), and the style
+-- engine blends `canonical_settings`, which are read straight off the user's real
+-- develop settings. Decisive is what the backend *measures*: the RAW decode, not
+-- the photo's current edited state. Adding a recipe value on top of an existing
+-- edit therefore double-counts that edit.
+--
+-- This used to be an additive merge for most keys, which was catastrophic for
+-- `Temp` (as-shot 5500 K + a recommended 5600 K produced 11100 K) and silently
+-- wrong wherever Lightroom's default is non-zero: `ColorNoiseReduction` (25),
+-- `SharpenDetail` (25), `GrainSize`, the vignette midpoints, and the wrapping
+-- `SplitToning*Hue` angles.
+--
+-- Note the contrast with mask adjustments: `MASK_ADJUSTMENT_RANGES` in
+-- `edit_recipe.rs` gives local temperature/tint as -100..100, because Lightroom's
+-- *local* white balance genuinely is relative. That path is handled separately in
+-- `applyMaskEdits` and is unaffected by this.
 
 local DEVELOP_VALUE_BOUNDS = {
 	Exposure2012 = { min = -5, max = 5 },
@@ -171,9 +148,6 @@ for _, label in pairs(HSL_LABELS) do
 	DEVELOP_VALUE_BOUNDS["HueAdjustment" .. label] = { min = -100, max = 100 }
 	DEVELOP_VALUE_BOUNDS["SaturationAdjustment" .. label] = { min = -100, max = 100 }
 	DEVELOP_VALUE_BOUNDS["LuminanceAdjustment" .. label] = { min = -100, max = 100 }
-	ADDITIVE_GLOBAL_KEYS["HueAdjustment" .. label] = true
-	ADDITIVE_GLOBAL_KEYS["SaturationAdjustment" .. label] = true
-	ADDITIVE_GLOBAL_KEYS["LuminanceAdjustment" .. label] = true
 end
 
 local function appendWarning(warnings, text)
@@ -509,16 +483,11 @@ local function mergeGlobalDevelopSettings(currentSettings, aiSettings)
 		end
 	end
 
+	-- Recipe values are absolute (see the note next to DEVELOP_VALUE_BOUNDS), so a
+	-- key the recipe carries replaces the current value rather than adding to it.
+	-- Keys the recipe does not mention keep whatever the photo already had.
 	for key, value in pairs(aiSettings or {}) do
-		if ADDITIVE_GLOBAL_KEYS[key] and type(value) == "number" then
-			local baseValue = currentSettings and currentSettings[key]
-			if type(baseValue) ~= "number" then
-				baseValue = 0
-			end
-			merged[key] = normalizeDevelopValue(key, baseValue + value)
-		else
-			merged[key] = normalizeDevelopValue(key, value)
-		end
+		merged[key] = normalizeDevelopValue(key, value)
 	end
 	return merged
 end
@@ -555,6 +524,7 @@ local function formatGlobalSettings(globalSettings)
 end
 
 function DevelopEditManager.formatRecipeDetails(response)
+	local recipe = getRecipeFromResponse(response)
 	if not recipe then
 		return LOC("$$$/LrGeniusAI/DevelopEdit/NoRecipe=No edit recipe available.")
 	end
@@ -704,9 +674,15 @@ local function buildDevelopSettings(recipe, warnings)
 		end
 	end
 
-	-- Respect the RAW profile (Adobe Adaptive, etc.) to ensure baseline parity
+	-- Respect the RAW profile (Adobe Color, Camera Neutral, ...) so the baseline the
+	-- recipe was solved against is the one Lightroom actually renders.
+	--
+	-- This wrote `CameraConfig` for a long time, which is not a Lightroom develop
+	-- key at all — the SDK calls it `CameraProfile`. The branch was doubly dead
+	-- because `profile` is not in the recipe schema either, so nothing reached it.
+	-- The key is corrected here so the branch works once the schema carries it.
 	if globalSettings.profile then
-		developSettings["CameraConfig"] = globalSettings.profile
+		developSettings["CameraProfile"] = globalSettings.profile
 	end
 
 	mergeSettings(developSettings, buildHslDevelopSettings(globalSettings.hsl))
@@ -717,6 +693,16 @@ local function buildDevelopSettings(recipe, warnings)
 
 	return developSettings
 end
+
+-- Internal seams exposed for the headless unit tests in `plugin/spec`. These are
+-- the functions that turn a recipe into Lightroom develop settings, which is
+-- where value-semantics bugs surface; they are not part of the module's contract
+-- for callers running inside Lightroom.
+DevelopEditManager.internal = {
+	normalizeDevelopValue = normalizeDevelopValue,
+	mergeGlobalDevelopSettings = mergeGlobalDevelopSettings,
+	buildDevelopSettings = buildDevelopSettings,
+}
 
 local function focusPhotoInDevelop(photo, warnings)
 	local catalog = LrApplication.activeCatalog()

--- a/plugin/spec/develop_edit_manager_spec.lua
+++ b/plugin/spec/develop_edit_manager_spec.lua
@@ -1,0 +1,163 @@
+-- Tests for the recipe -> Lightroom develop-settings mapping.
+--
+-- This is the seam where the edit path's value semantics live, and where it had
+-- shipped a whole class of silent corruption: global recipe values were merged
+-- *additively* onto the photo's current settings, even though every producer
+-- emits absolute Lightroom slider values. For `Temp` that turned an as-shot
+-- 5500 K plus a recommended 5600 K into 11100 K; for every control whose
+-- Lightroom default is non-zero it was quietly wrong in the same way.
+
+require("DevelopEditManager")
+
+local internal = DevelopEditManager.internal
+local mergeGlobalDevelopSettings = internal.mergeGlobalDevelopSettings
+local buildDevelopSettings = internal.buildDevelopSettings
+local normalizeDevelopValue = internal.normalizeDevelopValue
+
+describe("DevelopEditManager global merge semantics", function()
+	it("replaces white balance instead of adding to it", function()
+		local current = { Temp = 5500, Tint = 10 }
+		local merged = mergeGlobalDevelopSettings(current, { Temp = 5600, Tint = -4 })
+
+		assert.are.equal(5600, merged.Temp)
+		assert.are.equal(-4, merged.Tint)
+	end)
+
+	it("does not stack controls whose Lightroom default is non-zero", function()
+		-- ColorNoiseReduction defaults to 25 on raw files, SharpenDetail to 25.
+		-- Additive merging silently doubled both.
+		local current = { ColorNoiseReduction = 25, SharpenDetail = 25, Sharpness = 40 }
+		local merged = mergeGlobalDevelopSettings(current, {
+			ColorNoiseReduction = 25,
+			SharpenDetail = 25,
+			Sharpness = 40,
+		})
+
+		assert.are.equal(25, merged.ColorNoiseReduction)
+		assert.are.equal(25, merged.SharpenDetail)
+		assert.are.equal(40, merged.Sharpness)
+	end)
+
+	it("replaces tone controls rather than double-counting an existing edit", function()
+		-- The backend measures the RAW decode, not the photo's edited state, so a
+		-- recipe value already accounts for the whole correction.
+		local merged = mergeGlobalDevelopSettings({ Exposure2012 = 0.5 }, { Exposure2012 = 0.3 })
+
+		assert.are.equal(0.3, merged.Exposure2012)
+	end)
+
+	it("keeps settings the recipe does not mention", function()
+		local current = { CropLeft = 0.1, CropRight = 0.9, Exposure2012 = 0.5 }
+		local merged = mergeGlobalDevelopSettings(current, { Contrast2012 = 12 })
+
+		assert.are.equal(0.1, merged.CropLeft)
+		assert.are.equal(0.9, merged.CropRight)
+		assert.are.equal(0.5, merged.Exposure2012)
+		assert.are.equal(12, merged.Contrast2012)
+	end)
+
+	it("clamps out-of-range values to the Lightroom slider bounds", function()
+		local merged = mergeGlobalDevelopSettings({}, { Exposure2012 = 99, Contrast2012 = -500 })
+
+		assert.are.equal(5, merged.Exposure2012)
+		assert.are.equal(-100, merged.Contrast2012)
+	end)
+
+	it("keeps a nil current-settings table usable", function()
+		local merged = mergeGlobalDevelopSettings(nil, { Temp = 4800 })
+
+		assert.are.equal(4800, merged.Temp)
+	end)
+end)
+
+describe("DevelopEditManager value normalization", function()
+	it("wraps hue angles instead of clamping them", function()
+		assert.are.equal(10, normalizeDevelopValue("SplitToningShadowHue", 370))
+		assert.are.equal(350, normalizeDevelopValue("SplitToningShadowHue", -10))
+	end)
+
+	it("leaves unknown keys and non-numbers untouched", function()
+		assert.are.equal("Adobe Color", normalizeDevelopValue("CameraProfile", "Adobe Color"))
+		assert.are.equal(1234, normalizeDevelopValue("SomeUnknownKey", 1234))
+	end)
+end)
+
+describe("DevelopEditManager recipe mapping", function()
+	it("maps canonical recipe fields onto Lightroom develop keys", function()
+		local settings = buildDevelopSettings({
+			global = {
+				exposure = 0.4,
+				contrast = 12,
+				temperature = 5200,
+				clarity = 8,
+				color_noise_reduction = 30,
+			},
+		}, {})
+
+		assert.are.equal(0.4, settings.Exposure2012)
+		assert.are.equal(12, settings.Contrast2012)
+		assert.are.equal(5200, settings.Temp)
+		assert.are.equal(8, settings.Clarity2012)
+		assert.are.equal(30, settings.ColorNoiseReduction)
+	end)
+
+	it("writes the camera profile under the key Lightroom actually uses", function()
+		local settings = buildDevelopSettings({ global = { profile = "Camera Neutral" } }, {})
+
+		assert.are.equal("Camera Neutral", settings.CameraProfile)
+		assert.is_nil(settings.CameraConfig)
+	end)
+
+	it("expands HSL channels into per-colour develop keys", function()
+		local settings = buildDevelopSettings({
+			global = { hsl = { blue = { hue = -5, saturation = 10, luminance = -20 } } },
+		}, {})
+
+		assert.are.equal(-5, settings.HueAdjustmentBlue)
+		assert.are.equal(10, settings.SaturationAdjustmentBlue)
+		assert.are.equal(-20, settings.LuminanceAdjustmentBlue)
+	end)
+
+	it("returns an empty mapping for a recipe without globals", function()
+		assert.are.same({}, buildDevelopSettings({}, {}))
+	end)
+end)
+
+describe("DevelopEditManager.formatRecipeDetails", function()
+	it("renders the recipe instead of always reporting none available", function()
+		-- Regression: this read an undeclared global `recipe`, which was whitelisted
+		-- in .luacheckrc and therefore always nil, so the review dialog's detail
+		-- pane was permanently empty and users approved edits blind.
+		local details = DevelopEditManager.formatRecipeDetails({
+			edit = {
+				summary = "Warm, gentle contrast",
+				global = { exposure = 0.3, contrast = 10 },
+				masks = {},
+				warnings = {},
+			},
+		})
+
+		assert.is_truthy(details:find("Warm, gentle contrast", 1, true))
+		assert.is_truthy(details:find("exposure", 1, true))
+		assert.is_falsy(details:find("No edit recipe available", 1, true))
+	end)
+
+	it("reports masks and warnings that the recipe carries", function()
+		local details = DevelopEditManager.formatRecipeDetails({
+			edit = {
+				summary = "Sky recovery",
+				global = {},
+				masks = { { kind = "sky", adjustments = { exposure = -0.4, clarity = 5 } } },
+				warnings = { "Highlights were already clipped" },
+			},
+		})
+
+		assert.is_truthy(details:find("sky", 1, true))
+		assert.is_truthy(details:find("Highlights were already clipped", 1, true))
+	end)
+
+	it("still reports nothing available when there is no recipe", function()
+		assert.is_truthy(DevelopEditManager.formatRecipeDetails(nil):find("No edit recipe available", 1, true))
+		assert.is_truthy(DevelopEditManager.formatRecipeDetails({}):find("No edit recipe available", 1, true))
+	end)
+end)

--- a/server-rs/crates/lrg-analysis/src/edit_guardrails.rs
+++ b/server-rs/crates/lrg-analysis/src/edit_guardrails.rs
@@ -1,0 +1,507 @@
+//! Limits on an edit that come from the photograph rather than from taste.
+//!
+//! A style profile says what a photographer likes. It cannot say what *this*
+//! frame can absorb, and applying a liked value to a frame that cannot take it
+//! is how an automatic edit ruins a picture. The canonical case, and the one
+//! that motivated this module: raising contrast on harshly lit material. The
+//! photographer's own average edit may well carry `+25 contrast`, because most
+//! of their frames were shot in kind light — applied to a midday frame already
+//! split into blown highlights and blocked shadows, the same number destroys it.
+//!
+//! So these rules sit *above* whatever the profile wants, they are derived from
+//! measurements rather than from preference, and every one that fires reports
+//! why. That last part is deliberate and mirrors culling's `reason_codes`: a
+//! surprising edit that explains itself is debuggable, and one that does not is
+//! indistinguishable from a bug.
+//!
+//! What is **not** here yet, because it needs signals this crate cannot reach:
+//! the face-differential rule (needs face boxes), mixed-light detection (needs a
+//! regional illuminant estimate) and the backlight rule (needs a subject
+//! region). [`EditBudget`] is shaped so those slot in without changing callers.
+
+use lrg_imaging::scene::SceneState;
+
+/// What the camera was doing, as far as it changes what an edit may safely do.
+///
+/// Separate from [`SceneState`] because none of it is measurable from pixels:
+/// two frames with identical histograms want different shadow treatment at
+/// ISO 100 and ISO 6400, and only the metadata knows which is which.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CaptureConditions {
+    pub iso: Option<f64>,
+    /// Whether the source is a raw file. Decides whether clipped highlights are
+    /// recoverable — `SceneState::highlight_clip` measures the rendering and
+    /// deliberately does not guess at this.
+    pub is_raw: bool,
+}
+
+/// Tunables for [`derive_budget`].
+///
+/// Every threshold here is a starting guess, chosen to be defensible rather
+/// than fitted: no labelled set of real photographs exists yet to calibrate
+/// against. They are configuration rather than constants so that calibrating
+/// them later is a data change, not a rewrite — and so a preset can move them.
+#[derive(Debug, Clone, Copy)]
+pub struct GuardrailConfig {
+    /// Above this `light_hardness`, the frame is treated as harshly lit.
+    pub hard_light_threshold: f64,
+    /// Rendered dynamic range, in stops, above which there is no tonal room
+    /// left to spend on added contrast.
+    pub high_dynamic_range_stops: f64,
+    /// ...and below which contrast and clarity are the right tools, so their
+    /// budget opens up.
+    pub flat_dynamic_range_stops: f64,
+    /// Fraction of specular/blown pixels above which the white point must not
+    /// be pushed further.
+    pub specular_fraction_threshold: f64,
+    /// At or below this ISO, lifting shadows costs nothing.
+    pub iso_shadow_free: f64,
+    /// At or above this ISO, lifting shadows is mostly lifting noise.
+    pub iso_shadow_exhausted: f64,
+    /// Largest shadow lift, in Lightroom slider points, at low ISO.
+    pub shadow_lift_max: f64,
+    /// Largest total of contrast-increasing moves on an ordinary frame.
+    pub contrast_budget_default: f64,
+    /// ...and on a flat, softly lit one.
+    pub contrast_budget_flat: f64,
+    /// Largest clarity value on an ordinary frame.
+    pub clarity_budget_default: f64,
+}
+
+impl GuardrailConfig {
+    pub const fn defaults() -> Self {
+        GuardrailConfig {
+            hard_light_threshold: 0.55,
+            high_dynamic_range_stops: 6.5,
+            flat_dynamic_range_stops: 3.5,
+            specular_fraction_threshold: 0.02,
+            iso_shadow_free: 400.0,
+            iso_shadow_exhausted: 6400.0,
+            shadow_lift_max: 60.0,
+            contrast_budget_default: 25.0,
+            contrast_budget_flat: 40.0,
+            clarity_budget_default: 20.0,
+        }
+    }
+}
+
+impl Default for GuardrailConfig {
+    fn default() -> Self {
+        Self::defaults()
+    }
+}
+
+/// Why a budget came out the way it did. One variant per rule, so a caller can
+/// render an explanation without re-deriving the reasoning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardrailReason {
+    /// Harsh light: contrast-increasing moves are capped at zero.
+    HardLightNoAddedContrast,
+    /// The rendered range is already full; contrast would only clip further.
+    NoTonalHeadroom,
+    /// Flat, soft light: contrast and clarity are what this frame wants.
+    FlatLightContrastAllowed,
+    /// Blown or specular highlights with no raw headroom behind them.
+    HighlightsUnrecoverable,
+    /// High ISO: lifting shadows mostly lifts noise.
+    HighIsoShadowsLimited,
+    /// Shadows are already blocked; lifting them cannot recover detail.
+    ShadowsAlreadyClipped,
+}
+
+impl GuardrailReason {
+    /// Stable identifier for logs, the API and the plugin, in the same style as
+    /// culling's reason codes.
+    pub fn code(self) -> &'static str {
+        match self {
+            GuardrailReason::HardLightNoAddedContrast => "hard_light_no_added_contrast",
+            GuardrailReason::NoTonalHeadroom => "no_tonal_headroom",
+            GuardrailReason::FlatLightContrastAllowed => "flat_light_contrast_allowed",
+            GuardrailReason::HighlightsUnrecoverable => "highlights_unrecoverable",
+            GuardrailReason::HighIsoShadowsLimited => "high_iso_shadows_limited",
+            GuardrailReason::ShadowsAlreadyClipped => "shadows_already_clipped",
+        }
+    }
+
+    pub fn explanation(self) -> &'static str {
+        match self {
+            GuardrailReason::HardLightNoAddedContrast => {
+                "Harsh light: contrast was not increased, since the frame is already split between lit and shadowed areas."
+            }
+            GuardrailReason::NoTonalHeadroom => {
+                "The frame already spans the full tonal range, so added contrast would only clip it further."
+            }
+            GuardrailReason::FlatLightContrastAllowed => {
+                "Flat, soft light: contrast and clarity were allowed a wider range than usual."
+            }
+            GuardrailReason::HighlightsUnrecoverable => {
+                "Highlights are blown with no raw headroom behind them, so the white point was left alone."
+            }
+            GuardrailReason::HighIsoShadowsLimited => {
+                "High ISO: shadows were lifted conservatively to avoid raising noise with them."
+            }
+            GuardrailReason::ShadowsAlreadyClipped => {
+                "Shadows are already blocked, so lifting them further would not recover detail."
+            }
+        }
+    }
+}
+
+/// How much of each destructive move this frame can take.
+///
+/// Ceilings, not targets. A profile asking for less than a budget allows gets
+/// what it asked for; the budget only ever removes.
+#[derive(Debug, Clone)]
+pub struct EditBudget {
+    /// Ceiling on the sum of contrast-increasing moves — contrast, clarity,
+    /// dehaze and the S-strength of a tone curve. They are budgeted together
+    /// because they do the same thing to a histogram, and a rule that capped
+    /// each one separately would be trivially defeated by spending the same
+    /// increase across all four.
+    pub contrast_budget: f64,
+    /// Ceiling on clarity specifically, which is harsher than contrast on faces
+    /// and on already-textured material.
+    pub clarity_budget: f64,
+    /// Ceiling on lifting shadows.
+    pub shadow_lift_budget: f64,
+    /// Ceiling on raising the white point.
+    pub whites_budget: f64,
+    pub reasons: Vec<GuardrailReason>,
+}
+
+impl EditBudget {
+    /// The budget of a frame nothing is known about: generous enough not to
+    /// interfere, which is the right failure direction for a rule that exists
+    /// to prevent damage rather than to create a look.
+    pub fn unconstrained() -> Self {
+        EditBudget {
+            contrast_budget: 100.0,
+            clarity_budget: 100.0,
+            shadow_lift_budget: 100.0,
+            whites_budget: 100.0,
+            reasons: Vec::new(),
+        }
+    }
+
+    pub fn reason_codes(&self) -> Vec<&'static str> {
+        self.reasons.iter().map(|r| r.code()).collect()
+    }
+}
+
+/// Linear interpolation of `t` from `[a, b]` onto `[0, 1]`, clamped.
+fn ramp(t: f64, a: f64, b: f64) -> f64 {
+    if (b - a).abs() < f64::EPSILON {
+        return if t >= b { 1.0 } else { 0.0 };
+    }
+    ((t - a) / (b - a)).clamp(0.0, 1.0)
+}
+
+/// Derive what this frame can absorb, from what was measured about it.
+pub fn derive_budget(
+    scene: &SceneState,
+    capture: &CaptureConditions,
+    cfg: &GuardrailConfig,
+) -> EditBudget {
+    let mut budget = EditBudget {
+        contrast_budget: cfg.contrast_budget_default,
+        clarity_budget: cfg.clarity_budget_default,
+        shadow_lift_budget: cfg.shadow_lift_max,
+        whites_budget: cfg.contrast_budget_default,
+        reasons: Vec::new(),
+    };
+
+    // Harsh light. The rule the whole module exists for: the frame is already
+    // carrying the contrast, and the photographer's habitual +contrast was
+    // formed on frames that were not.
+    if scene.light_hardness >= cfg.hard_light_threshold {
+        budget.contrast_budget = 0.0;
+        budget.clarity_budget = 0.0;
+        budget
+            .reasons
+            .push(GuardrailReason::HardLightNoAddedContrast);
+    }
+
+    // Full rendered range, whatever the light was like. Distinct from hardness:
+    // a backlit frame can span everything without a hard edge anywhere.
+    if scene.dynamic_range_stops >= cfg.high_dynamic_range_stops {
+        budget.contrast_budget = budget.contrast_budget.min(0.0);
+        if !budget
+            .reasons
+            .contains(&GuardrailReason::HardLightNoAddedContrast)
+        {
+            budget.reasons.push(GuardrailReason::NoTonalHeadroom);
+        }
+    } else if scene.dynamic_range_stops <= cfg.flat_dynamic_range_stops
+        && scene.light_hardness < cfg.hard_light_threshold
+    {
+        // The mirror image, and the reason this is a budget rather than a set of
+        // prohibitions: a flat frame in soft light genuinely wants more contrast
+        // than an average one, and a rule that could only ever subtract would
+        // leave it looking muddy.
+        budget.contrast_budget = cfg.contrast_budget_flat;
+        budget
+            .reasons
+            .push(GuardrailReason::FlatLightContrastAllowed);
+    }
+
+    // Blown highlights. Raw usually holds something above the rendering, a JPEG
+    // never does, so the same measurement means different things per source.
+    if scene.specular_fraction >= cfg.specular_fraction_threshold
+        || scene.highlight_clip >= cfg.specular_fraction_threshold
+    {
+        if capture.is_raw {
+            budget.whites_budget = budget.whites_budget.min(cfg.contrast_budget_default * 0.5);
+        } else {
+            budget.whites_budget = 0.0;
+            budget
+                .reasons
+                .push(GuardrailReason::HighlightsUnrecoverable);
+        }
+    }
+
+    // ISO. Lifting shadows is free on a clean file and mostly lifts noise on a
+    // dirty one, so the ceiling ramps down rather than switching off: there is
+    // no ISO at which shadow recovery becomes worthless, only ISOs at which it
+    // costs more than it returns.
+    if let Some(iso) = capture.iso {
+        let exhaustion = ramp(iso, cfg.iso_shadow_free, cfg.iso_shadow_exhausted);
+        if exhaustion > 0.0 {
+            budget.shadow_lift_budget = cfg.shadow_lift_max * (1.0 - 0.75 * exhaustion);
+            budget.clarity_budget = budget
+                .clarity_budget
+                .min(cfg.clarity_budget_default * (1.0 - 0.5 * exhaustion));
+            if exhaustion > 0.5 {
+                budget.reasons.push(GuardrailReason::HighIsoShadowsLimited);
+            }
+        }
+    }
+
+    // Shadows that are already blocked hold nothing to recover; lifting them
+    // raises the black point and greys the frame out.
+    if scene.shadow_clip >= 0.25 {
+        budget.shadow_lift_budget = budget.shadow_lift_budget.min(cfg.shadow_lift_max * 0.25);
+        budget.reasons.push(GuardrailReason::ShadowsAlreadyClipped);
+    }
+
+    budget
+}
+
+/// The contrast-increasing moves in a recipe, summed.
+///
+/// Only the increases count. A profile that pulls contrast down and raises
+/// clarity slightly is not spending from this budget on net, and treating the
+/// sum of absolute values as spend would block edits that reduce contrast — the
+/// exact edits a harshly lit frame needs.
+pub fn contrast_spend(contrast: f64, clarity: f64, dehaze: f64, curve_strength: f64) -> f64 {
+    contrast.max(0.0) + clarity.max(0.0) + dehaze.max(0.0) + curve_strength.max(0.0)
+}
+
+/// Scale a set of contrast-increasing moves so their total fits the budget.
+///
+/// Scaling rather than clamping each value keeps the profile's *proportions* —
+/// someone who reaches for clarity over contrast still gets that, just less of
+/// it. Negative values pass through untouched, since they spend nothing.
+pub fn fit_contrast_moves(values: &mut [f64], budget: f64) -> bool {
+    let spend: f64 = values.iter().map(|v| v.max(0.0)).sum();
+    if spend <= budget || spend <= 0.0 {
+        return false;
+    }
+    let scale = (budget / spend).clamp(0.0, 1.0);
+    for v in values.iter_mut() {
+        if *v > 0.0 {
+            *v *= scale;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scene(hardness: f64, dr: f64) -> SceneState {
+        let mut s = SceneState::unknown();
+        s.light_hardness = hardness;
+        s.dynamic_range_stops = dr;
+        s
+    }
+
+    fn cfg() -> GuardrailConfig {
+        GuardrailConfig::defaults()
+    }
+
+    #[test]
+    fn harsh_light_forbids_added_contrast() {
+        // The case this module exists for.
+        let b = derive_budget(&scene(0.8, 7.0), &CaptureConditions::default(), &cfg());
+
+        assert_eq!(b.contrast_budget, 0.0);
+        assert_eq!(b.clarity_budget, 0.0);
+        assert!(b
+            .reasons
+            .contains(&GuardrailReason::HardLightNoAddedContrast));
+    }
+
+    #[test]
+    fn flat_soft_light_gets_a_wider_budget_than_average() {
+        // A guardrail that could only subtract would leave flat frames muddy.
+        let flat = derive_budget(&scene(0.1, 2.5), &CaptureConditions::default(), &cfg());
+        let ordinary = derive_budget(&scene(0.3, 5.0), &CaptureConditions::default(), &cfg());
+
+        assert!(flat.contrast_budget > ordinary.contrast_budget);
+        assert!(flat
+            .reasons
+            .contains(&GuardrailReason::FlatLightContrastAllowed));
+    }
+
+    #[test]
+    fn a_full_tonal_range_blocks_contrast_even_without_a_hard_edge() {
+        // Backlight spans everything without producing a hard shadow edge, so
+        // hardness alone would miss it.
+        let b = derive_budget(&scene(0.2, 7.5), &CaptureConditions::default(), &cfg());
+
+        assert_eq!(b.contrast_budget, 0.0);
+        assert!(b.reasons.contains(&GuardrailReason::NoTonalHeadroom));
+    }
+
+    #[test]
+    fn the_two_contrast_rules_do_not_both_report() {
+        // Harsh light usually also fills the range; reporting both would read as
+        // two independent findings when it is one situation.
+        let b = derive_budget(&scene(0.9, 7.5), &CaptureConditions::default(), &cfg());
+        assert!(b
+            .reasons
+            .contains(&GuardrailReason::HardLightNoAddedContrast));
+        assert!(!b.reasons.contains(&GuardrailReason::NoTonalHeadroom));
+    }
+
+    #[test]
+    fn blown_highlights_are_recoverable_on_raw_and_not_on_jpeg() {
+        let mut s = scene(0.3, 5.0);
+        s.specular_fraction = 0.05;
+
+        let raw = derive_budget(
+            &s,
+            &CaptureConditions {
+                is_raw: true,
+                ..Default::default()
+            },
+            &cfg(),
+        );
+        let jpeg = derive_budget(
+            &s,
+            &CaptureConditions {
+                is_raw: false,
+                ..Default::default()
+            },
+            &cfg(),
+        );
+
+        assert!(
+            raw.whites_budget > 0.0,
+            "raw holds headroom above the render"
+        );
+        assert_eq!(jpeg.whites_budget, 0.0);
+        assert!(jpeg
+            .reasons
+            .contains(&GuardrailReason::HighlightsUnrecoverable));
+    }
+
+    #[test]
+    fn shadow_lift_shrinks_as_iso_rises() {
+        let low = derive_budget(
+            &scene(0.3, 5.0),
+            &CaptureConditions {
+                iso: Some(100.0),
+                ..Default::default()
+            },
+            &cfg(),
+        );
+        let high = derive_budget(
+            &scene(0.3, 5.0),
+            &CaptureConditions {
+                iso: Some(6400.0),
+                ..Default::default()
+            },
+            &cfg(),
+        );
+
+        assert!(
+            high.shadow_lift_budget < low.shadow_lift_budget,
+            "ISO 6400 {} should allow less lift than ISO 100 {}",
+            high.shadow_lift_budget,
+            low.shadow_lift_budget
+        );
+        assert!(high
+            .reasons
+            .contains(&GuardrailReason::HighIsoShadowsLimited));
+        assert!(high.shadow_lift_budget > 0.0, "never switches off entirely");
+    }
+
+    #[test]
+    fn blocked_shadows_cannot_be_lifted_back() {
+        let mut s = scene(0.3, 5.0);
+        s.shadow_clip = 0.4;
+        let b = derive_budget(&s, &CaptureConditions::default(), &cfg());
+
+        assert!(b.shadow_lift_budget <= cfg().shadow_lift_max * 0.25);
+        assert!(b.reasons.contains(&GuardrailReason::ShadowsAlreadyClipped));
+    }
+
+    #[test]
+    fn an_unknown_frame_is_not_constrained() {
+        let b = EditBudget::unconstrained();
+        assert!(b.reasons.is_empty());
+        assert!(b.contrast_budget >= 100.0);
+    }
+
+    #[test]
+    fn only_increases_count_against_the_contrast_budget() {
+        // A harshly lit frame needs contrast pulled *down*, and a rule reading
+        // magnitude rather than direction would block exactly that.
+        assert_eq!(contrast_spend(-30.0, 0.0, 0.0, 0.0), 0.0);
+        assert_eq!(contrast_spend(10.0, 5.0, 0.0, 0.0), 15.0);
+
+        let mut moves = [-30.0, 0.0];
+        assert!(!fit_contrast_moves(&mut moves, 0.0));
+        assert_eq!(moves, [-30.0, 0.0]);
+    }
+
+    #[test]
+    fn fitting_preserves_the_proportions_a_profile_asked_for() {
+        let mut moves = [30.0, 10.0];
+        assert!(fit_contrast_moves(&mut moves, 20.0));
+
+        let total: f64 = moves.iter().sum();
+        assert!(
+            (total - 20.0).abs() < 1e-9,
+            "total {total} should hit budget"
+        );
+        // 3:1 going in, 3:1 coming out.
+        assert!((moves[0] / moves[1] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fitting_is_a_no_op_when_the_recipe_is_already_within_budget() {
+        let mut moves = [5.0, 5.0];
+        assert!(!fit_contrast_moves(&mut moves, 25.0));
+        assert_eq!(moves, [5.0, 5.0]);
+    }
+
+    #[test]
+    fn reason_codes_are_stable_and_distinct() {
+        let all = [
+            GuardrailReason::HardLightNoAddedContrast,
+            GuardrailReason::NoTonalHeadroom,
+            GuardrailReason::FlatLightContrastAllowed,
+            GuardrailReason::HighlightsUnrecoverable,
+            GuardrailReason::HighIsoShadowsLimited,
+            GuardrailReason::ShadowsAlreadyClipped,
+        ];
+        let codes: std::collections::HashSet<_> = all.iter().map(|r| r.code()).collect();
+        assert_eq!(codes.len(), all.len());
+        for reason in all {
+            assert!(!reason.explanation().is_empty());
+        }
+    }
+}

--- a/server-rs/crates/lrg-analysis/src/lib.rs
+++ b/server-rs/crates/lrg-analysis/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod clustering;
 pub mod culling_config;
+pub mod edit_guardrails;
 pub mod eval;
 pub mod face_aggregate;
 pub mod grouping;

--- a/server-rs/crates/lrg-api/src/routes/edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/edit.rs
@@ -690,3 +690,92 @@ async fn finish_edit(
     payload["output_tokens"] = json!(response.output_tokens);
     Json(payload).into_response()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exactly the multipart field names `SearchIndexAPI.generateEditRecipePhoto`
+    /// and `SearchIndexAPI.styleEdit` put on the wire. Both plugin functions feed
+    /// this same parser (`style_edit.rs` calls it too), so this is the one place
+    /// the plugin/backend field-name contract can be pinned.
+    fn plugin_fields() -> HashMap<String, String> {
+        [
+            ("style_strength", "0.8"),
+            ("composition_mode", "aggressive"),
+            ("adjust_white_balance", "false"),
+            ("adjust_basic_tone", "false"),
+            ("adjust_presence", "false"),
+            ("adjust_color_mix", "false"),
+            ("do_color_grading", "false"),
+            ("use_tone_curve", "false"),
+            ("use_point_curve", "false"),
+            ("adjust_detail", "false"),
+            ("adjust_effects", "false"),
+            ("adjust_lens_corrections", "false"),
+            ("allow_auto_crop", "false"),
+            ("include_masks", "false"),
+            ("api_key", "sk-test"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    #[test]
+    fn creative_controls_from_the_plugin_reach_the_options() {
+        // Regression: the plugin assembled all of these and sent only
+        // `include_masks`, so every checkbox in the Creative Controls group and the
+        // style-strength slider silently did nothing.
+        let opts = parse_edit_options_form(&plugin_fields());
+
+        assert!(!opts.adjust_white_balance);
+        assert!(!opts.adjust_basic_tone);
+        assert!(!opts.adjust_presence);
+        assert!(!opts.adjust_color_mix);
+        assert!(!opts.do_color_grading);
+        assert!(!opts.use_tone_curve);
+        assert!(!opts.use_point_curve);
+        assert!(!opts.adjust_detail);
+        assert!(!opts.adjust_effects);
+        assert!(!opts.adjust_lens_corrections);
+        assert!(!opts.allow_auto_crop);
+        assert!(!opts.include_masks);
+        assert_eq!(opts.style_strength, 0.8);
+        assert_eq!(opts.composition_mode, "aggressive");
+    }
+
+    #[test]
+    fn api_key_survives_the_style_edit_fallback_path() {
+        // The style-engine fallback used to omit `api_key`, and there is no
+        // environment-variable fallback further down, so the first run of a new
+        // user reached the provider with an empty bearer token.
+        let opts = parse_edit_options_form(&plugin_fields());
+        assert_eq!(opts.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn omitted_toggles_default_to_on() {
+        // Why the plugin must send an explicit "false" rather than omitting the
+        // field: absent booleans are read as enabled.
+        let opts = parse_edit_options_form(&HashMap::new());
+
+        assert!(opts.adjust_white_balance);
+        assert!(opts.do_color_grading);
+        assert!(opts.allow_auto_crop);
+        assert!(opts.include_masks);
+        assert_eq!(opts.style_strength, 0.5);
+        assert_eq!(opts.composition_mode, "subtle");
+    }
+
+    #[test]
+    fn style_strength_is_clamped_and_composition_mode_validated() {
+        let mut fields = HashMap::new();
+        fields.insert("style_strength".to_string(), "9.5".to_string());
+        fields.insert("composition_mode".to_string(), "wild".to_string());
+        let opts = parse_edit_options_form(&fields);
+
+        assert_eq!(opts.style_strength, 1.0);
+        assert_eq!(opts.composition_mode, "subtle", "unknown mode falls back");
+    }
+}

--- a/server-rs/crates/lrg-api/tests/contract.rs
+++ b/server-rs/crates/lrg-api/tests/contract.rs
@@ -644,3 +644,122 @@ async fn check_unprocessed_understands_the_cull_task() {
         "a faceless photo that has been culled must not be reported forever"
     );
 }
+
+// ---------------------------------------------------------------------------
+// /style_edit
+//
+// The plugin's edit workflow routes here whenever "apply my saved edit style" is
+// on, which is the default, so this is the first endpoint a new user's edit run
+// touches. It had no contract coverage, and the plugin branches on the exact
+// shapes below.
+// ---------------------------------------------------------------------------
+
+/// Builds a `multipart/form-data` body. `/style_edit` and `/edit` are the only
+/// multipart endpoints the plugin calls, and both are driven from
+/// `_requestMultipart` in APISearchIndex.lua.
+fn multipart_body(fields: &[(&str, &str)], image: Option<(&str, &[u8])>) -> (String, Vec<u8>) {
+    const BOUNDARY: &str = "----lrgtestboundary";
+    let mut body: Vec<u8> = Vec::new();
+    for (name, value) in fields {
+        body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+        );
+        body.extend_from_slice(value.as_bytes());
+        body.extend_from_slice(b"\r\n");
+    }
+    if let Some((filename, bytes)) = image {
+        body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"image\"; filename=\"{filename}\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: image/jpeg\r\n\r\n");
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+    (format!("multipart/form-data; boundary={BOUNDARY}"), body)
+}
+
+async fn style_edit_request(
+    app: axum::Router,
+    fields: &[(&str, &str)],
+    image: Option<(&str, &[u8])>,
+) -> (StatusCode, serde_json::Value) {
+    let (content_type, body) = multipart_body(fields, image);
+    let response = app
+        .oneshot(
+            Request::post("/style_edit")
+                .header("content-type", content_type)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    (status, body_json(response).await)
+}
+
+#[tokio::test]
+async fn style_edit_rejects_a_request_without_an_image() {
+    let (app, _) = fresh_app();
+    let (_, json) = style_edit_request(app.clone(), &[("photo_id", "photo1")], None).await;
+
+    // The plugin checks `response.status` first; this branch carries only `error`,
+    // so styleEdit reports "Unexpected response" rather than the actual reason.
+    assert!(
+        json.get("error").is_some(),
+        "expected an error field, got {json}"
+    );
+}
+
+#[tokio::test]
+async fn style_edit_reports_an_unbound_database_rather_than_panicking() {
+    let (app, _) = fresh_app();
+    let (status, json) = style_edit_request(
+        app.clone(),
+        &[("photo_id", "photo1")],
+        Some(("photo1.jpg", b"not-a-real-jpeg")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("db_path"),
+        "expected the unbound-database message, got {json}"
+    );
+}
+
+#[tokio::test]
+async fn style_edit_without_training_data_is_an_error_the_plugin_must_handle() {
+    // With no training examples and no LLM fallback the style engine cannot
+    // answer, and this is what a first run hits. Pinned because the edit workflow
+    // is moving to an LLM-free path: this 422 is exactly the response the
+    // deterministic cold-start path has to replace, and a silent change of shape
+    // here would strand the plugin.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path_str = dir.path().join("lrgenius.db").to_str().unwrap().to_string();
+    let (app, state) = fresh_app();
+    state.ensure_db_path(&db_path_str).await.unwrap();
+
+    let (status, json) = style_edit_request(
+        app.clone(),
+        &[
+            ("photo_id", "photo1"),
+            ("db_path", db_path_str.as_str()),
+            ("use_llm_fallback", "false"),
+        ],
+        Some(("photo1.jpg", b"not-a-real-jpeg")),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["engine"], "none");
+    assert_eq!(json["matched_examples"], 0);
+    assert!(json["error"].is_string());
+}

--- a/server-rs/crates/lrg-imaging/src/lib.rs
+++ b/server-rs/crates/lrg-imaging/src/lib.rs
@@ -1,4 +1,5 @@
 //! Image pipeline: Pillow-exact resampling, pHash, culling metrics,
+//! source-state measurement for the edit path (`scene`),
 //! RAW decoding (`raw`, via `rawler`), JPEG/PNG conversion (`convert`).
 //! HEIC (libheif) decoding is still not wired in.
 
@@ -8,3 +9,4 @@ pub mod location;
 pub mod metrics;
 pub mod pil_resample;
 pub mod raw;
+pub mod scene;

--- a/server-rs/crates/lrg-imaging/src/scene.rs
+++ b/server-rs/crates/lrg-imaging/src/scene.rs
@@ -1,0 +1,582 @@
+//! What the *source* image is, before anything is decided about it.
+//!
+//! The edit path used to predict slider values directly from a learned style,
+//! which meant it applied the answer to a photograph that no longer existed:
+//! `+25 contrast` was correct for the training frame's histogram, and on a
+//! harshly lit midday frame the same number is destructive. Slider values are a
+//! function of the starting point, so the starting point has to be measured.
+//!
+//! Everything here is measured on the working image, and two limits follow from
+//! that and are load-bearing when reading these numbers:
+//!
+//! - **The working image is 8-bit.** [`SceneState::dynamic_range_stops`] is
+//!   therefore bounded at ~8 stops and reflects the *rendered* range, not the
+//!   sensor's. That is the right quantity for deciding how much tonal room an
+//!   edit has, and the wrong one for describing the raw file.
+//! - **Highlight clipping here is clipping in the rendering.** Whether it is
+//!   recoverable depends on raw headroom, which only the caller knows; see
+//!   [`SceneState::highlight_clip`].
+
+/// A luminance histogram over `0..=255`, the shared basis for every percentile
+/// and occupancy figure below.
+struct Histogram {
+    bins: [u64; 256],
+    total: u64,
+}
+
+impl Histogram {
+    fn from_luma(luma: &[f32]) -> Self {
+        let mut bins = [0u64; 256];
+        for &v in luma {
+            let idx = ((v * 255.0).round().clamp(0.0, 255.0)) as usize;
+            bins[idx] += 1;
+        }
+        Histogram {
+            bins,
+            total: luma.len() as u64,
+        }
+    }
+
+    /// Linear-interpolated percentile in `0..1`. `p` is a fraction (0.5 = P50).
+    fn percentile(&self, p: f64) -> f64 {
+        if self.total == 0 {
+            return 0.0;
+        }
+        let target = p.clamp(0.0, 1.0) * self.total as f64;
+        let mut cumulative = 0u64;
+        for (idx, &count) in self.bins.iter().enumerate() {
+            let next = cumulative + count;
+            if next as f64 >= target && count > 0 {
+                return idx as f64 / 255.0;
+            }
+            cumulative = next;
+        }
+        1.0
+    }
+
+    /// Fraction of pixels at or above `threshold` (normalized luminance).
+    fn fraction_above(&self, threshold: f64) -> f64 {
+        if self.total == 0 {
+            return 0.0;
+        }
+        let start = ((threshold * 255.0).ceil().clamp(0.0, 255.0)) as usize;
+        let count: u64 = self.bins[start..].iter().sum();
+        count as f64 / self.total as f64
+    }
+
+    /// Fraction of pixels at or below `threshold` (normalized luminance).
+    fn fraction_below(&self, threshold: f64) -> f64 {
+        if self.total == 0 {
+            return 0.0;
+        }
+        let end = ((threshold * 255.0).floor().clamp(0.0, 255.0)) as usize;
+        let count: u64 = self.bins[..=end].iter().sum();
+        count as f64 / self.total as f64
+    }
+}
+
+/// Tunables for [`scene_state`].
+///
+/// The normalizers are the honest weak point of this module: they set where a
+/// measurement lands on `0..1`, and they were chosen to give sane spreads on
+/// synthetic inputs rather than fitted to real photographs. The *ordering* the
+/// tests pin (hard light above soft light above flat texture) is the part that
+/// is meant to be trusted; the absolute values should be recalibrated against
+/// real fixtures before anything downstream treats them as thresholds.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SceneStateConfig {
+    /// Long edge the frame is reduced to for the coarse-scale pass. Small
+    /// enough that texture averages away and only lighting structure survives.
+    pub coarse_long_edge: usize,
+    /// Fraction of the strongest coarse-scale gradients averaged together to
+    /// stand for the frame's largest surviving luminance step. Small enough to
+    /// ignore the bulk of a gently lit frame, large enough that a lone pixel
+    /// cannot carry the measurement.
+    pub hardness_top_fraction: f64,
+    /// Luminance step between adjacent coarse pixels that reads as half-hard.
+    /// A step of this size across ~1/64th of the frame is a visible shadow edge.
+    pub hardness_half: f64,
+    /// Luminance at or above which a pixel counts as a highlight.
+    pub highlight_threshold: f64,
+    /// Luminance at or below which a pixel counts as a shadow.
+    pub shadow_threshold: f64,
+    /// A pixel is specular when it is at least this bright...
+    pub specular_luma_threshold: f64,
+    /// ...and no more saturated than this.
+    pub specular_saturation_max: f64,
+    /// Luminance floor used when taking logs, so a fully black pixel cannot
+    /// send the dynamic range to infinity. One 8-bit code value.
+    pub luminance_floor: f64,
+}
+
+impl SceneStateConfig {
+    pub const fn defaults() -> Self {
+        SceneStateConfig {
+            coarse_long_edge: 64,
+            hardness_top_fraction: 0.02,
+            hardness_half: 0.15,
+            highlight_threshold: 0.94,
+            shadow_threshold: 0.06,
+            specular_luma_threshold: 0.95,
+            specular_saturation_max: 0.15,
+            luminance_floor: 1.0 / 255.0,
+        }
+    }
+}
+
+impl Default for SceneStateConfig {
+    fn default() -> Self {
+        Self::defaults()
+    }
+}
+
+/// The measured state of an unedited frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SceneState {
+    pub luminance_p005: f64,
+    pub luminance_p01: f64,
+    pub luminance_p10: f64,
+    pub luminance_p50: f64,
+    pub luminance_p90: f64,
+    pub luminance_p99: f64,
+    pub luminance_p995: f64,
+
+    /// `log2(P99.5) - log2(P0.5)`, in stops, over the *rendered* image.
+    ///
+    /// Capped near 8 by the 8-bit working image. This is the quantity that
+    /// decides how much tonal room an edit has: a frame already spanning the
+    /// full range cannot absorb added contrast, whatever a style profile wants.
+    pub dynamic_range_stops: f64,
+
+    /// Fraction of pixels rendered at or above the highlight threshold.
+    ///
+    /// This says the *rendering* is clipped, not that the data is gone. A raw
+    /// file usually holds a stop or more above what its default rendering
+    /// shows, so a caller that knows the source is raw should treat this as
+    /// recoverable; for a JPEG source it is lost. The distinction cannot be
+    /// made from pixels alone, so it deliberately is not made here.
+    pub highlight_clip: f64,
+    /// Fraction of pixels at or below the shadow threshold.
+    pub shadow_clip: f64,
+
+    /// How much of the frame the tails hold relative to the midtones:
+    /// `(shadow_occupancy + highlight_occupancy) / midtone_occupancy`.
+    ///
+    /// High for a scene split into lit and unlit halves, which is what harsh
+    /// light does to a histogram; low for an evenly lit one.
+    pub midtone_deficit: f64,
+
+    /// Mean gradient magnitude at the coarse scale, where only lighting
+    /// structure survives.
+    pub coarse_gradient_energy: f64,
+    /// Mean gradient magnitude at the working scale, carrying both lighting and
+    /// texture.
+    pub fine_gradient_energy: f64,
+
+    /// How hard the light is, on `0..1`.
+    ///
+    /// The largest luminance step that survives heavy downscaling, rather than
+    /// anything derived from contrast — contrast cannot tell a scene's lighting
+    /// from its subject matter. Averaging the frame down to ~64px erases
+    /// texture, because averaging is precisely what removes it, while a shadow
+    /// edge stays a full-amplitude step between neighbouring coarse pixels. So
+    /// foliage, fabric and crowd texture read *low* here and a plain wall in
+    /// direct sun reads high, which is the distinction a naive contrast measure
+    /// gets backwards and the one that decides whether adding contrast improves
+    /// a photograph or ruins it.
+    ///
+    /// Two refinements that are not optional, each having broken an earlier
+    /// version of this measure:
+    ///
+    /// - It is the largest step, not the mean coarse gradient. Downscaling by k
+    ///   multiplies the per-pixel gradient of *any* large-scale structure by k,
+    ///   so a hard shadow edge and a gentle ramp across the frame produce the
+    ///   same mean; only the distribution separates them.
+    /// - That largest step is a trimmed maximum over the top couple of percent,
+    ///   not a quantile. An edge crossing the whole frame is still only ~1.6% of
+    ///   the coarse gradients, so the 95th percentile reads zero on the hardest
+    ///   possible input.
+    pub light_hardness: f64,
+
+    /// Fraction of pixels that are bright and nearly colourless.
+    ///
+    /// Does not distinguish a specular highlight from a blown sky, and does not
+    /// need to: both mean the same thing for the only decision that reads it,
+    /// which is whether there is room to push the white point further.
+    pub specular_fraction: f64,
+}
+
+impl SceneState {
+    /// A neutral, mid-exposed reading, used when the frame is too small to
+    /// measure. Deliberately unremarkable: every guardrail keyed off these
+    /// values stays inactive rather than firing on a fabricated extreme.
+    pub fn unknown() -> Self {
+        SceneState {
+            luminance_p005: 0.05,
+            luminance_p01: 0.08,
+            luminance_p10: 0.2,
+            luminance_p50: 0.45,
+            luminance_p90: 0.75,
+            luminance_p99: 0.9,
+            luminance_p995: 0.93,
+            dynamic_range_stops: 4.0,
+            highlight_clip: 0.0,
+            shadow_clip: 0.0,
+            midtone_deficit: 0.5,
+            coarse_gradient_energy: 0.0,
+            fine_gradient_energy: 0.0,
+            light_hardness: 0.4,
+            specular_fraction: 0.0,
+        }
+    }
+}
+
+/// Forward-difference gradient magnitudes over a luminance plane.
+fn gradient_magnitudes(plane: &[f32], width: usize, height: usize) -> Vec<f64> {
+    if width < 2 || height < 2 {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity((width - 1) * (height - 1));
+    for y in 0..height - 1 {
+        let row = y * width;
+        let next = row + width;
+        for x in 0..width - 1 {
+            let here = plane[row + x];
+            let dx = (plane[row + x + 1] - here) as f64;
+            let dy = (plane[next + x] - here) as f64;
+            out.push((dx * dx + dy * dy).sqrt());
+        }
+    }
+    out
+}
+
+fn mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f64>() / values.len() as f64
+    }
+}
+
+/// Mean of the largest `fraction` of the values — a trimmed maximum.
+///
+/// A plain quantile is the wrong tool here. A shadow edge is *thin*: one
+/// crossing the whole frame occupies about 1.6% of the coarse plane's
+/// gradients, so even the 95th percentile still reads zero and the hardest
+/// possible frame scores as flat. A plain maximum has the opposite failure,
+/// riding on a single pixel. Averaging the top slice keeps a real edge visible
+/// while a lone outlier is diluted.
+fn top_fraction_mean(values: &[f64], fraction: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let take =
+        ((sorted.len() as f64 * fraction.clamp(0.0, 1.0)).round() as usize).clamp(1, sorted.len());
+    sorted[..take].iter().sum::<f64>() / take as f64
+}
+
+/// Box-average `plane` down to at most `target_long_edge` on its long side.
+///
+/// A plain box filter is the right choice rather than a nicer kernel: the point
+/// of the coarse pass is that texture *averages away*, and averaging is exactly
+/// what a box filter does. A sharpening-adjacent kernel would preserve some of
+/// the detail this pass exists to discard.
+fn box_downscale(
+    plane: &[f32],
+    width: usize,
+    height: usize,
+    target_long_edge: usize,
+) -> (Vec<f32>, usize, usize) {
+    let long = width.max(height);
+    if long <= target_long_edge || target_long_edge == 0 {
+        return (plane.to_vec(), width, height);
+    }
+    let scale = target_long_edge as f64 / long as f64;
+    let out_w = ((width as f64 * scale).round() as usize).max(2);
+    let out_h = ((height as f64 * scale).round() as usize).max(2);
+
+    let mut out = vec![0.0f32; out_w * out_h];
+    for oy in 0..out_h {
+        let y0 = oy * height / out_h;
+        let y1 = (((oy + 1) * height) / out_h).max(y0 + 1).min(height);
+        for ox in 0..out_w {
+            let x0 = ox * width / out_w;
+            let x1 = (((ox + 1) * width) / out_w).max(x0 + 1).min(width);
+            let mut sum = 0.0f64;
+            let mut count = 0u32;
+            for y in y0..y1 {
+                let row = y * width;
+                for x in x0..x1 {
+                    sum += plane[row + x] as f64;
+                    count += 1;
+                }
+            }
+            out[oy * out_w + ox] = if count == 0 {
+                0.0
+            } else {
+                (sum / count as f64) as f32
+            };
+        }
+    }
+    (out, out_w, out_h)
+}
+
+/// Measure an unedited frame. `pixels` is 8-bit interleaved RGB.
+pub fn scene_state(
+    pixels: &[u8],
+    width: usize,
+    height: usize,
+    cfg: &SceneStateConfig,
+) -> SceneState {
+    let n = width * height;
+    if n == 0 || pixels.len() < n * 3 || width < 4 || height < 4 {
+        return SceneState::unknown();
+    }
+
+    let mut luma = vec![0.0f32; n];
+    let mut specular = 0u64;
+    for i in 0..n {
+        let r = pixels[i * 3] as f32 / 255.0;
+        let g = pixels[i * 3 + 1] as f32 / 255.0;
+        let b = pixels[i * 3 + 2] as f32 / 255.0;
+        let y = 0.299 * r + 0.587 * g + 0.114 * b;
+        luma[i] = y;
+
+        let max = r.max(g).max(b);
+        let min = r.min(g).min(b);
+        // HSV saturation; 0 for black, which cannot be specular anyway.
+        let saturation = if max <= 0.0 { 0.0 } else { (max - min) / max };
+        if y as f64 >= cfg.specular_luma_threshold
+            && saturation as f64 <= cfg.specular_saturation_max
+        {
+            specular += 1;
+        }
+    }
+
+    let hist = Histogram::from_luma(&luma);
+    let p005 = hist.percentile(0.005);
+    let p01 = hist.percentile(0.01);
+    let p10 = hist.percentile(0.10);
+    let p50 = hist.percentile(0.50);
+    let p90 = hist.percentile(0.90);
+    let p99 = hist.percentile(0.99);
+    let p995 = hist.percentile(0.995);
+
+    let floor = cfg.luminance_floor.max(f64::EPSILON);
+    let dynamic_range_stops = (p995.max(floor) / p005.max(floor)).log2().max(0.0);
+
+    let highlight_clip = hist.fraction_above(cfg.highlight_threshold);
+    let shadow_clip = hist.fraction_below(cfg.shadow_threshold);
+    let shadow_occupancy = hist.fraction_below(1.0 / 3.0);
+    let highlight_occupancy = hist.fraction_above(2.0 / 3.0);
+    let midtone_occupancy = (1.0 - shadow_occupancy - highlight_occupancy).max(1e-6);
+    let midtone_deficit = (shadow_occupancy + highlight_occupancy) / midtone_occupancy;
+
+    let fine_gradient_energy = mean(&gradient_magnitudes(&luma, width, height));
+    let (coarse, cw, ch) = box_downscale(&luma, width, height, cfg.coarse_long_edge);
+    let coarse_gradients = gradient_magnitudes(&coarse, cw, ch);
+    let coarse_gradient_energy = mean(&coarse_gradients);
+
+    // Hardness is the *largest luminance step that survives the coarse pass*,
+    // not the average gradient there.
+    //
+    // The mean cannot answer this. Downscaling by k multiplies the per-pixel
+    // gradient of any structure that is already smooth at the coarse scale by k,
+    // so a hard shadow edge and a gentle ramp across the frame both come back at
+    // roughly k times their fine-scale energy — measured on a step and a ramp,
+    // both land at a ratio of ~2.0 under a 2x reduction. What separates them is
+    // how that energy is *distributed*: harsh light concentrates it into a few
+    // large steps, soft light spreads a little of it everywhere. A high quantile
+    // reads the former and ignores the latter, and texture is gone from the
+    // coarse plane either way because averaging is what removes it.
+    let coarse_gradient_peak = top_fraction_mean(&coarse_gradients, cfg.hardness_top_fraction);
+    let light_hardness =
+        (coarse_gradient_peak / (coarse_gradient_peak + cfg.hardness_half)).clamp(0.0, 1.0);
+
+    SceneState {
+        luminance_p005: p005,
+        luminance_p01: p01,
+        luminance_p10: p10,
+        luminance_p50: p50,
+        luminance_p90: p90,
+        luminance_p99: p99,
+        luminance_p995: p995,
+        dynamic_range_stops,
+        highlight_clip,
+        shadow_clip,
+        midtone_deficit,
+        coarse_gradient_energy,
+        fine_gradient_energy,
+        light_hardness,
+        specular_fraction: specular as f64 / n as f64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const W: usize = 128;
+    const H: usize = 128;
+
+    fn gray_image(f: impl Fn(usize, usize) -> f32) -> Vec<u8> {
+        let mut px = vec![0u8; W * H * 3];
+        for y in 0..H {
+            for x in 0..W {
+                let v = (f(x, y).clamp(0.0, 1.0) * 255.0).round() as u8;
+                let i = (y * W + x) * 3;
+                px[i] = v;
+                px[i + 1] = v;
+                px[i + 2] = v;
+            }
+        }
+        px
+    }
+
+    fn measure(px: &[u8]) -> SceneState {
+        scene_state(px, W, H, &SceneStateConfig::defaults())
+    }
+
+    /// Direct sun: the frame splits into a lit half and a shadowed half with a
+    /// sharp boundary between them.
+    fn hard_light() -> Vec<u8> {
+        gray_image(|x, _| if x < W / 2 { 0.08 } else { 0.92 })
+    }
+
+    /// Overcast: everything sits in the midtones and varies gently.
+    fn soft_light() -> Vec<u8> {
+        gray_image(|x, _| 0.42 + 0.06 * (x as f32 / W as f32))
+    }
+
+    /// Foliage: strong detail everywhere, but evenly lit.
+    fn busy_texture() -> Vec<u8> {
+        gray_image(|x, y| if (x + y) % 2 == 0 { 0.35 } else { 0.62 })
+    }
+
+    #[test]
+    fn hard_light_scores_above_soft_light() {
+        assert!(
+            measure(&hard_light()).light_hardness > measure(&soft_light()).light_hardness,
+            "a split-lit frame must read harder than an evenly lit one"
+        );
+    }
+
+    #[test]
+    fn busy_texture_does_not_masquerade_as_hard_light() {
+        // The whole reason hardness is measured across scales rather than from
+        // contrast: a high-contrast checkerboard is *detail*, not harsh light,
+        // and a contrast-based measure would rank it at the top.
+        let texture = measure(&busy_texture());
+        let hard = measure(&hard_light());
+
+        assert!(
+            texture.light_hardness < hard.light_hardness,
+            "texture {} should read softer than hard light {}",
+            texture.light_hardness,
+            hard.light_hardness
+        );
+        assert!(
+            texture.fine_gradient_energy > texture.coarse_gradient_energy,
+            "texture must lose energy under downscaling"
+        );
+    }
+
+    #[test]
+    fn a_gentle_ramp_is_not_hard_light_despite_spanning_the_frame() {
+        // The case that broke the first implementation. A ramp from one edge of
+        // the frame to the other carries as much *total* coarse gradient energy
+        // as a shadow edge does, because downscaling by k scales any large-scale
+        // structure's per-pixel gradient by k. Only the distribution separates
+        // them, so this is the test that keeps the measure honest.
+        let ramp = measure(&soft_light());
+        let step = measure(&hard_light());
+
+        assert!(
+            ramp.light_hardness < 0.15,
+            "a gentle ramp must not read as hard light, got {}",
+            ramp.light_hardness
+        );
+        assert!(
+            step.light_hardness > 0.6,
+            "a shadow edge must read as hard light, got {}",
+            step.light_hardness
+        );
+    }
+
+    #[test]
+    fn dynamic_range_separates_a_split_scene_from_a_flat_one() {
+        assert!(
+            measure(&hard_light()).dynamic_range_stops > measure(&soft_light()).dynamic_range_stops
+        );
+    }
+
+    #[test]
+    fn midtone_deficit_is_high_when_the_scene_splits_into_tails() {
+        let hard = measure(&hard_light());
+        let soft = measure(&soft_light());
+        assert!(
+            hard.midtone_deficit > soft.midtone_deficit,
+            "hard {} vs soft {}",
+            hard.midtone_deficit,
+            soft.midtone_deficit
+        );
+    }
+
+    #[test]
+    fn percentiles_are_ordered_and_track_exposure() {
+        let dark = measure(&gray_image(|_, _| 0.12));
+        let bright = measure(&gray_image(|_, _| 0.85));
+
+        assert!(dark.luminance_p50 < bright.luminance_p50);
+        let s = measure(&soft_light());
+        assert!(s.luminance_p005 <= s.luminance_p10);
+        assert!(s.luminance_p10 <= s.luminance_p50);
+        assert!(s.luminance_p50 <= s.luminance_p90);
+        assert!(s.luminance_p90 <= s.luminance_p995);
+    }
+
+    #[test]
+    fn clipping_is_reported_at_both_ends() {
+        let blown = measure(&gray_image(|x, _| if x < W / 4 { 0.99 } else { 0.5 }));
+        assert!(blown.highlight_clip > 0.2 && blown.highlight_clip < 0.3);
+
+        let crushed = measure(&gray_image(|x, _| if x < W / 4 { 0.01 } else { 0.5 }));
+        assert!(crushed.shadow_clip > 0.2 && crushed.shadow_clip < 0.3);
+    }
+
+    #[test]
+    fn specular_detection_ignores_bright_but_saturated_pixels() {
+        // A saturated colour at full brightness is not a blown highlight.
+        let mut px = vec![0u8; W * H * 3];
+        for i in 0..W * H {
+            px[i * 3] = 255; // pure red: bright, but fully saturated
+        }
+        assert_eq!(measure(&px).specular_fraction, 0.0);
+
+        let white = gray_image(|_, _| 1.0);
+        assert!(measure(&white).specular_fraction > 0.99);
+    }
+
+    #[test]
+    fn a_degenerate_frame_reports_the_neutral_reading() {
+        let unknown = SceneState::unknown();
+        assert_eq!(
+            scene_state(&[], 0, 0, &SceneStateConfig::defaults()),
+            unknown
+        );
+        assert_eq!(
+            scene_state(&[0, 0, 0], 1, 1, &SceneStateConfig::defaults()),
+            unknown
+        );
+    }
+
+    #[test]
+    fn a_flat_frame_is_soft_not_hard() {
+        // No detail at any scale: the ratio is undefined, and reporting "hard"
+        // there would let a guardrail fire on an empty measurement.
+        let flat = measure(&gray_image(|_, _| 0.5));
+        assert_eq!(flat.light_hardness, 0.0);
+    }
+}


### PR DESCRIPTION
M1 (stabilize) and M2 (read the scene, budget the edit) of the plan to bring AI
Edit to a competitive level. Culling is deliberately untouched.

## Why

AI Edit was not unfinished so much as **partly broken**. Four defects in the
shipped path plausibly account for the whole impression, and none were caught
because `routes/edit.rs`, `routes/style_edit.rs` and `DevelopEditManager.lua`
had no tests at all.

| # | Defect | Effect |
|---|---|---|
| 1 | `Temp` sat in `ADDITIVE_GLOBAL_KEYS` while the schema emits absolute Kelvin | as-shot 5500 K + a recommended 5600 K = **11100 K** |
| 2 | `styleEdit` sent no `api_key`, and there is no env fallback downstream | the LLM fallback **401s** — and since `aiEditUseTrainingStyle` defaults on and new users have no training examples, that *is* the first-run path |
| 3 | `formatRecipeDetails` tested `recipe`, an undeclared global whitelisted in `.luacheckrc` | the review dialog's detail pane was **always empty**; users approved edits blind |
| 4 | `generateEditRecipePhoto` forwarded 1 of 13 options | the entire Creative Controls group and the style-strength slider were **no-ops** |

Defect 1 turned out to be wider than white balance. Both producers emit
**absolute** Lightroom values — the LLM schema declares Lightroom's own ranges,
and the style engine blends canonical settings read off the user's real edits —
and the backend measures the **raw decode**, not the photo's edited state. So
additive merging double-counts any existing edit, and it was silently wrong
wherever Lightroom's default is non-zero: `ColorNoiseReduction` (25),
`SharpenDetail` (25), `GrainSize`, the vignette midpoints, the wrapping
`SplitToning*Hue` angles. Mask adjustments are untouched, since Lightroom's
*local* white balance genuinely is relative.

## The design problem underneath

Fixing those does not address why the results felt wrong even when they worked:
a model predicting **slider values** learns the answer to a photograph that no
longer exists. `+25 contrast` was right for the training frame's histogram; on
harshly lit material the same number is destructive.

**`lrg_imaging::scene`** measures what an unedited frame actually is — luminance
percentiles, dynamic range in stops, clipping at both ends, midtone deficit,
specular fraction, and light hardness.

Hardness is the interesting one, because contrast cannot express it: foliage and
a plain wall in direct sun both measure "contrasty" and want opposite treatment.
It is measured across scales instead — averaging to ~64px erases texture, since
averaging is what removes it, while a shadow edge stays a full-amplitude step.
Two refinements were forced by failing tests and are load-bearing:

- **Not the mean coarse gradient.** Downscaling by k multiplies any large-scale
  structure's per-pixel gradient by k, so a shadow edge and a gentle ramp across
  the frame both return ~k times their fine-scale energy. Only the distribution
  separates them.
- **Not a quantile of it either.** An edge crossing the whole frame is still only
  ~1.6% of the coarse gradients, so the 95th percentile reads zero on the
  hardest possible input. It is a trimmed maximum over the top couple of percent.

Two limits are documented rather than papered over: the working image is 8-bit,
so the measured range is the *rendered* one and caps near 8 stops; and highlight
clipping here means the rendering is clipped, not that the data is gone.

**`lrg_analysis::edit_guardrails`** turns those measurements plus capture
metadata into per-photo ceilings that sit above whatever a profile wants. Four
decisions worth flagging:

- Contrast, clarity, dehaze and tone-curve strength share **one** budget. They do
  the same thing to a histogram, and capping each separately would be defeated by
  spending the same increase across all four.
- Only *increases* count as spend. Reading magnitude instead of direction would
  block pulling contrast down — exactly what a harshly lit frame needs.
- Fitting **scales** the moves rather than clamping them, so a profile that
  reaches for clarity over contrast still does, just less of it.
- It is a budget, not a set of prohibitions: a flat frame in soft light gets a
  *wider* allowance than average. A rule that could only subtract would leave it
  muddy.

ISO ramps the shadow-lift ceiling down rather than switching it off — there is no
ISO at which shadow recovery becomes worthless, only ISOs where it costs more
than it returns. Blown highlights read differently per source, since raw usually
holds something above the rendering and a JPEG never does. Every rule that fires
reports a code and an explanation, the way culling's reason codes do.

## Also in here

- Camera profile key corrected from `CameraConfig` (not a Lightroom develop key)
  to `CameraProfile` — needed once the profile becomes a conditioning variable.
- `Help-AI-Edit.md` no longer promises three features that do not exist
  (before/after comparison, re-run from the review dialog, face-driven masking).
- `Dev-Build-Environment-Setup.md` gains a section on building where
  `cdn.pyke.io` is unreachable — `ort` fetches prebuilt ONNX Runtime binaries
  from it, and the workaround via the PyPI wheel has three easy-to-miss details.

## Tests

386 Rust tests and 143 Lua tests pass; clippy and both formatters clean.

- `plugin/spec/develop_edit_manager_spec.lua` — recipe → develop-settings
  mapping. **Verified to fail against the additive behaviour** before the fix,
  rather than written afterwards and assumed to work.
- `routes/edit.rs` — pins the plugin/backend field-name contract, including that
  an omitted boolean reads as *enabled*, which is why an unchecked box must
  travel as an explicit `false`.
- `contract.rs` — `/style_edit` response shapes, including the 422 a first run
  currently hits.
- `scene.rs` — orderings (hard above soft above texture), not magnitudes, since
  the normalizers still need calibrating against real photographs.
- `edit_guardrails.rs` — each rule, plus the two cases that are easy to get
  backwards: pulling contrast down must stay allowed, and flat light must get a
  wider budget rather than a narrower one.

## What this does not do yet

The routing flip to an LLM-free edit path was planned for M1 and **moved to the
end of M2**. `/style_edit` answers 422 `engine: "none"` without training data, so
flipping now would swap a 401 for a 422. The deterministic cold-start path —
preset target profiles plus the solver — has to exist first, and the guardrails
are not yet wired into the live recipe path.

Three guardrail rules from the plan are stubbed out rather than half-built: the
face-differential, mixed-light and backlight rules need face boxes, a regional
illuminant estimate and a subject region respectively.

Not addressed: the translation files are out of sync by 671 keys. That drift is
unchanged from `main` and this branch adds no `LOC()` keys, so it belongs in a
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aKwhN5ufZ8Jy4pJ1aDAMp