### PR TITLE
Bound the indexing read-ahead, and split raw from non-raw in style training

### DIFF
--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -82,7 +82,13 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 `images` array instead, since both are properties of the individual photo.
 
 ### `POST /index_by_reference`
-Indexes photos using server-side file paths instead of uploading image data (for local-backend setups where the server has filesystem access).
+Indexes photos using server-side file paths instead of uploading image data (for local-backend
+setups where the server has filesystem access).
+
+Files are read one at a time, immediately before each is normalised, so a group of raw
+originals is never all resident at once — the normalised JPEG is a few hundred KB and the raw
+bytes are released the moment it exists. A file that cannot be read is reported as a failure
+against its own `photo_id` in `results`, not as an anonymous error for the batch.
 
 ### `POST /get`
 Returns stored metadata and embedding status for one or more `photo_id` values.
@@ -215,6 +221,20 @@ scene and time of day, and interpolates their develop settings. Needs at least
 five stored examples. The result passes through the same guardrail budget as
 `/edit` and carries the same `guardrail_reasons`.
 
+`temperature` is blended only from examples whose `is_raw` matches the photo
+being edited, because Lightroom's temperature is Kelvin for raw and a relative
+-100..100 for everything else — averaging the two produces a number that is
+meaningless on either scale. When no matched example qualifies the field is
+omitted entirely, and either way the reason is in `warning`. Examples saved
+before `is_raw` was recorded count as compatible with anything. Every other
+develop setting means the same on both kinds of file and is blended normally;
+`tint` differs only in range, which the clamp handles.
+
+The `/edit` few-shot path applies the same rule: an example whose raw status
+conflicts with the target has its white balance stripped before it reaches the
+prompt, so the model is never anchored on a number the schema it must answer in
+cannot express.
+
 ---
 
 ## Face Detection & Persons
@@ -282,6 +302,10 @@ Applies a list of approved keyword merge pairs to the backend's metadata records
 ## Style Training
 
 ### `POST /training/add`
+Stores one photo's develop settings as a training example. `is_raw` is recorded
+with it and decides, later, whether the example may contribute a temperature —
+see `POST /style_edit`.
+
 Saves a photo's Lightroom develop settings as a labeled training example.
 
 ### `GET /training/list`

--- a/docs/wiki/Help-Train-From-Edits.md
+++ b/docs/wiki/Help-Train-From-Edits.md
@@ -61,6 +61,24 @@ embedding to compare your saved edits against. AI Edit then falls back to the
 plain style preset and says so in the result, rather than silently producing a
 generic edit.
 
+## Raw and non-raw examples are kept apart
+
+Only for white balance, and only because Lightroom forces the issue: its
+temperature slider is Kelvin on a raw file and a relative −100..+100 on a JPEG.
+Averaging an example edited from a raw with one edited from a JPEG would produce
+a number that means nothing on either scale — and it would land on a real photo.
+
+So when the backend blends a white balance, it uses only the examples whose file
+type matches the photo you are editing. If none of the matched examples qualify,
+it leaves white balance alone and tells you why. Everything else — exposure,
+contrast, presence, colour, curves — means the same on both, and is blended from
+all matched examples as usual.
+
+Practically: if you shoot raw and JPEG both, keep saving examples from both.
+Nothing is wasted; the pool simply narrows for that one field. Examples you saved
+before this existed count as compatible with anything, so nothing you already
+have stops working.
+
 ---
 
 ## Tips

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -4179,6 +4179,13 @@ function SearchIndexAPI.addTrainingExample(photoId, filepath, developSettings, o
 	if options.shutter_speed and options.shutter_speed ~= "" then
 		table.insert(mimeChunks, { name = "shutter_speed", value = tostring(options.shutter_speed) })
 	end
+	-- Recorded with the example so the style engine can keep raw and rendered
+	-- sources apart when it blends a white balance: Lightroom's Temp is Kelvin
+	-- for one and a relative -100..100 for the other, and averaging the two
+	-- produces a number that means nothing on either scale.
+	if type(options.is_raw) == "boolean" then
+		table.insert(mimeChunks, { name = "is_raw", value = tostring(options.is_raw) })
+	end
 
 	if filepath and LrFileUtils.exists(filepath) then
 		local filename = LrPathUtils.leafName(filepath)

--- a/plugin/LrGeniusAI.lrdevplugin/TaskTrainFromEdits.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskTrainFromEdits.lua
@@ -191,6 +191,10 @@ LrTasks.startAsyncTask(function()
 				local exifOptions = Util.getPhotoExif(photo)
 				exifOptions.label = options.label
 				exifOptions.summary = options.summary
+				-- Which Temp scale this example's develop settings are on. Left
+				-- absent when the format is unreadable; the style engine treats
+				-- that as compatible with anything.
+				exifOptions.is_raw = Util.isRawPhoto(photo)
 
 				-- Export a JPEG thumbnail for CLIP embedding + exposure analysis.
 				local exportedPath = SearchIndexAPI.exportPhotoForIndexing(photo)

--- a/server-rs/crates/lrg-analysis/src/style_engine.rs
+++ b/server-rs/crates/lrg-analysis/src/style_engine.rs
@@ -123,6 +123,11 @@ pub struct TrainingCandidate {
     pub scene_tags: Vec<String>,
     pub exposure: ExposureFeatures,
     pub time_of_day_bucket: String,
+    /// Whether the photo this example was saved from is a raw file.
+    ///
+    /// `None` for examples saved before the flag was recorded. See
+    /// [`restrict_temperature_to_matching_raw_status`] for why it matters.
+    pub is_raw: Option<bool>,
 }
 
 /// The new photo's own query-side features.
@@ -131,6 +136,8 @@ pub struct StyleQuery {
     pub exposure: ExposureFeatures,
     pub scene_tags: Vec<String>,
     pub time_of_day_bucket: String,
+    /// Whether the photo being edited is a raw file. `None` means unknown.
+    pub is_raw: Option<bool>,
 }
 
 /// Port of `calculate_composite_score`.
@@ -168,6 +175,78 @@ pub fn interpolate_recipes(winners: &[(TrainingCandidate, f64)]) -> Map<String, 
         .into_iter()
         .map(|(k, v)| (k, json!(round_to(v, 1))))
         .collect()
+}
+
+/// Recompute `temperature` from only the winners whose raw status matches the
+/// photo being edited, or drop it.
+///
+/// Every other canonical field means the same thing on a raw file and on a
+/// JPEG. `temperature` does not: Lightroom exposes it as Kelvin for raw and as
+/// a relative -100..100 for everything else. Averaging 5600 and +12 produces a
+/// number that is meaningless on either scale, and the result is applied to a
+/// real photo — so the blend is restricted rather than corrected afterwards.
+///
+/// `tint` is deliberately left alone. Its *range* differs (-150..150 raw,
+/// -100..100 otherwise) but its meaning does not, so a mixed blend is a scale
+/// distortion the clamp already handles, not a category error.
+///
+/// Examples with an unknown raw status (saved before the flag was recorded)
+/// count as matching, since excluding them would quietly shrink every
+/// long-standing user's pool to nothing.
+///
+/// Returns a warning when the field had to be dropped entirely.
+pub fn restrict_temperature_to_matching_raw_status(
+    blended: &mut Map<String, Value>,
+    winners: &[(TrainingCandidate, f64)],
+    query_is_raw: Option<bool>,
+) -> Option<String> {
+    if !blended.contains_key("temperature") {
+        return None;
+    }
+    let compatible = |candidate: &TrainingCandidate| match (query_is_raw, candidate.is_raw) {
+        (Some(q), Some(c)) => q == c,
+        _ => true,
+    };
+    if winners.iter().all(|(c, _)| compatible(c)) {
+        return None;
+    }
+
+    let matching: Vec<&(TrainingCandidate, f64)> =
+        winners.iter().filter(|(c, _)| compatible(c)).collect();
+    let total_weight: f64 = matching.iter().map(|(_, s)| s).sum();
+    let recomputed: Option<f64> = if total_weight > 0.0 {
+        let sum: f64 = matching
+            .iter()
+            .filter_map(|(c, s)| {
+                c.canonical_settings
+                    .get("temperature")
+                    .and_then(Value::as_f64)
+                    .map(|v| v * (s / total_weight))
+            })
+            .sum();
+        Some(round_to(sum, 1))
+    } else {
+        None
+    };
+
+    match recomputed {
+        Some(v) => {
+            blended.insert("temperature".into(), json!(v));
+            Some(format!(
+                "White balance was blended from {} of {} matched examples — the others were saved from {} files, where Lightroom's temperature is on a different scale.",
+                matching.len(),
+                winners.len(),
+                if query_is_raw == Some(true) { "non-raw" } else { "raw" }
+            ))
+        }
+        None => {
+            blended.remove("temperature");
+            Some(
+                "White balance was left unchanged: every matched training example was saved from a file whose temperature is on a different scale than this photo's."
+                    .to_string(),
+            )
+        }
+    }
 }
 
 /// Port of `adaptive_compensation`.
@@ -350,6 +429,8 @@ pub fn generate_style_edit(
         .collect();
 
     let mut blended = interpolate_recipes(&winners);
+    let temperature_warning =
+        restrict_temperature_to_matching_raw_status(&mut blended, &winners, query.is_raw);
     adaptive_compensation(&mut blended, &query.exposure, &winners);
 
     // Python builds this from a `set(...)`, whose iteration order is not
@@ -399,6 +480,12 @@ pub fn generate_style_edit(
         ))
     } else {
         None
+    };
+    // Both can be true at once, and the user needs both: one is about how well
+    // the style matched, the other about a field that was left out of it.
+    let warning = match (warning, temperature_warning) {
+        (Some(a), Some(b)) => Some(format!("{a}\n{b}")),
+        (a, b) => a.or(b),
     };
 
     StyleEngineResult {
@@ -501,6 +588,7 @@ mod tests {
             },
             scene_tags: vec!["scene_portrait".to_string()],
             time_of_day_bucket: "afternoon".to_string(),
+            is_raw: None,
         };
         let mut c = candidate(&[("exposure", 1.0), ("contrast", 10.0)], 0.1);
         c.exposure = ExposureFeatures {
@@ -518,5 +606,91 @@ mod tests {
         assert!(result.confidence > 0.9); // near-identical query/candidate
         assert_eq!(result.recipe["global"]["exposure"], json!(1.0));
         assert_eq!(result.matched_filenames, vec!["photo1.jpg".to_string()]);
+    }
+
+    fn raw_candidate(temperature: f64, is_raw: Option<bool>) -> TrainingCandidate {
+        let mut c = candidate(&[("temperature", temperature), ("contrast", 10.0)], 0.0);
+        c.is_raw = is_raw;
+        c
+    }
+
+    #[test]
+    fn a_uniform_pool_blends_temperature_as_before() {
+        let mut blended = interpolate_recipes(&[
+            (raw_candidate(5600.0, Some(true)), 1.0),
+            (raw_candidate(5000.0, Some(true)), 1.0),
+        ]);
+        let winners = vec![
+            (raw_candidate(5600.0, Some(true)), 1.0),
+            (raw_candidate(5000.0, Some(true)), 1.0),
+        ];
+        let warning =
+            restrict_temperature_to_matching_raw_status(&mut blended, &winners, Some(true));
+
+        assert!(warning.is_none(), "nothing to report when nothing changed");
+        assert_eq!(blended["temperature"], json!(5300.0));
+    }
+
+    #[test]
+    fn a_mixed_pool_blends_only_the_matching_examples() {
+        // Averaging 5600 K with a relative +10 produces a number that is
+        // meaningless on either scale, and it lands on a real photo.
+        let winners = vec![
+            (raw_candidate(5600.0, Some(true)), 1.0),
+            (raw_candidate(10.0, Some(false)), 1.0),
+        ];
+        let mut blended = interpolate_recipes(&winners);
+        assert_eq!(blended["temperature"], json!(2805.0), "the bad average");
+
+        let warning =
+            restrict_temperature_to_matching_raw_status(&mut blended, &winners, Some(true));
+        assert_eq!(blended["temperature"], json!(5600.0));
+        let warning = warning.expect("the user has to be told the pool was narrowed");
+        assert!(warning.contains("1 of 2"), "got {warning:?}");
+    }
+
+    #[test]
+    fn temperature_is_dropped_when_no_example_matches() {
+        let winners = vec![(raw_candidate(5600.0, Some(true)), 1.0)];
+        let mut blended = interpolate_recipes(&winners);
+        let warning =
+            restrict_temperature_to_matching_raw_status(&mut blended, &winners, Some(false));
+
+        assert!(
+            blended.get("temperature").is_none(),
+            "no white balance beats a wrong-scale one"
+        );
+        assert_eq!(blended["contrast"], json!(10.0), "other fields survive");
+        assert!(warning.unwrap().contains("left unchanged"));
+    }
+
+    #[test]
+    fn examples_saved_before_the_flag_existed_still_count() {
+        // Excluding them would shrink every long-standing user's pool to
+        // nothing on the first edit after upgrading.
+        let winners = vec![
+            (raw_candidate(5600.0, None), 1.0),
+            (raw_candidate(5000.0, Some(true)), 1.0),
+        ];
+        let mut blended = interpolate_recipes(&winners);
+        let warning =
+            restrict_temperature_to_matching_raw_status(&mut blended, &winners, Some(true));
+
+        assert!(warning.is_none());
+        assert_eq!(blended["temperature"], json!(5300.0));
+    }
+
+    #[test]
+    fn an_unknown_target_accepts_every_example() {
+        let winners = vec![
+            (raw_candidate(5600.0, Some(true)), 1.0),
+            (raw_candidate(5000.0, Some(false)), 1.0),
+        ];
+        let mut blended = interpolate_recipes(&winners);
+        let warning = restrict_temperature_to_matching_raw_status(&mut blended, &winners, None);
+        assert!(
+            warning.is_none(),
+            "nothing is known, so nothing is excluded"
+        );
     }
 }

--- a/server-rs/crates/lrg-api/src/routes/edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/edit.rs
@@ -347,10 +347,48 @@ impl NoTrainingExamples {
     }
 }
 
+/// Lightroom's own key for white balance in a saved develop-settings blob, and
+/// the recipe schema's spelling of the same thing, since examples can come from
+/// either shape.
+const TEMPERATURE_KEYS: [&str; 2] = ["Temp", "temperature"];
+
+/// Strip the white balance from an example saved from a file whose temperature
+/// scale differs from the photo being edited.
+///
+/// The few-shot block exists to give the model the user's own numbers to anchor
+/// on. A Kelvin `Temp` offered as a reference for a JPEG — or the reverse —
+/// anchors it on a number that is meaningless for the target, while the schema
+/// it must answer in declares the other range entirely. Every other develop
+/// setting means the same thing on both kinds of file, so only this one goes.
+///
+/// An unknown raw status on either side means no conflict can be established,
+/// so nothing is removed.
+fn drop_incompatible_temperature(
+    settings: &mut Value,
+    example_is_raw: Option<bool>,
+    target_is_raw: Option<bool>,
+) -> bool {
+    let (Some(example), Some(target)) = (example_is_raw, target_is_raw) else {
+        return false;
+    };
+    if example == target {
+        return false;
+    }
+    let Some(map) = settings.as_object_mut() else {
+        return false;
+    };
+    let mut removed = false;
+    for key in TEMPERATURE_KEYS {
+        removed |= map.remove(key).is_some();
+    }
+    removed
+}
+
 pub(crate) async fn fetch_training_examples(
     store: &Store,
     photo_id: &str,
     n_results: usize,
+    target_is_raw: Option<bool>,
 ) -> Result<Vec<Value>, NoTrainingExamples> {
     let Ok(mut existing) = store.get(IMAGE_TABLE, &[photo_id.to_string()]).await else {
         return Err(NoTrainingExamples::PhotoNotIndexed);
@@ -375,15 +413,20 @@ pub(crate) async fn fetch_training_examples(
         return Err(NoTrainingExamples::NoneStored);
     }
 
-    Ok(scored
+    let mut dropped_temperature = 0usize;
+    let examples: Vec<Value> = scored
         .into_iter()
         .map(|(_, r)| {
-            let develop_settings = r
+            let mut develop_settings = r
                 .metadata
                 .get("develop_settings")
                 .and_then(Value::as_str)
                 .and_then(|s| serde_json::from_str::<Value>(s).ok())
                 .unwrap_or_else(|| json!({}));
+            let example_is_raw = r.metadata.get("is_raw").and_then(Value::as_bool);
+            if drop_incompatible_temperature(&mut develop_settings, example_is_raw, target_is_raw) {
+                dropped_temperature += 1;
+            }
             json!({
                 "label": r.metadata.get("label").cloned().unwrap_or(json!("")),
                 "filename": r.metadata.get("filename").cloned().unwrap_or(json!("")),
@@ -391,7 +434,13 @@ pub(crate) async fn fetch_training_examples(
                 "develop_settings": develop_settings,
             })
         })
-        .collect())
+        .collect();
+    if dropped_temperature > 0 {
+        log::debug!(
+            "Photo {photo_id}: dropped the white balance from {dropped_temperature} few-shot example(s) saved from files on the other temperature scale."
+        );
+    }
+    Ok(examples)
 }
 
 pub(crate) async fn generate_edit_recipe_for_photo(
@@ -453,7 +502,7 @@ pub(crate) async fn generate_edit_recipe_for_photo(
     let mut training_warning: Option<&'static str> = None;
     if options.use_training_style {
         if let Some(store) = store {
-            match fetch_training_examples(store, photo_id, 3).await {
+            match fetch_training_examples(store, photo_id, 3, options.is_raw).await {
                 Ok(examples) => request.training_examples = examples,
                 Err(reason) => training_warning = Some(reason.message()),
             }
@@ -940,5 +989,49 @@ mod tests {
 
         assert_eq!(opts.style_strength, 1.0);
         assert_eq!(opts.composition_mode, "subtle", "unknown mode falls back");
+    }
+
+    #[test]
+    fn a_wrong_scale_white_balance_is_kept_out_of_the_few_shot_block() {
+        // A Kelvin number offered to the model as a reference for a JPEG
+        // anchors it on a value the target's schema cannot even express.
+        let mut settings = json!({"Temp": 5600, "Exposure2012": 0.3});
+        assert!(drop_incompatible_temperature(
+            &mut settings,
+            Some(true),
+            Some(false)
+        ));
+        assert!(settings.get("Temp").is_none());
+        assert_eq!(
+            settings["Exposure2012"],
+            json!(0.3),
+            "everything else means the same on both kinds of file"
+        );
+    }
+
+    #[test]
+    fn a_matching_example_keeps_its_white_balance() {
+        let mut settings = json!({"Temp": 5600});
+        assert!(!drop_incompatible_temperature(
+            &mut settings,
+            Some(true),
+            Some(true)
+        ));
+        assert_eq!(settings["Temp"], json!(5600));
+    }
+
+    #[test]
+    fn an_unknown_raw_status_removes_nothing() {
+        // Examples saved before the flag existed would otherwise lose their
+        // white balance on every edit after upgrading.
+        for (example, target) in [(None, Some(true)), (Some(true), None), (None, None)] {
+            let mut settings = json!({"Temp": 5600});
+            assert!(!drop_incompatible_temperature(
+                &mut settings,
+                example,
+                target
+            ));
+            assert_eq!(settings["Temp"], json!(5600), "{example:?} vs {target:?}");
+        }
     }
 }

--- a/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
@@ -11,7 +11,7 @@ use axum::extract::State;
 use axum::response::{IntoResponse, Json, Response};
 use serde_json::{json, Map, Value};
 
-use crate::routes::index_upload::{process_batch, PhotoOverrides, UploadedImage};
+use crate::routes::index_upload::{process_batch, ImageSource, PhotoOverrides};
 use crate::state::AppState;
 
 /// Pulls the per-photo context out of one `images[]` entry.
@@ -125,81 +125,38 @@ async fn index_by_reference(
             .into_response();
     }
 
-    // Raw bytes only — `process_batch` runs the same `normalize_image_bytes`
-    // step on these that `/index` runs on its multipart uploads; doing it
-    // again here would double-convert.
-    let mut images: Vec<UploadedImage> = Vec::new();
+    // Paths, not bytes: `process_batch` reads each file only when it is about
+    // to normalise it, so a group of raw originals is never all resident at
+    // once. It also runs the same `normalize_image_bytes` step on these that
+    // `/index` runs on its multipart uploads — converting here too would
+    // double-convert.
+    //
+    // Files that cannot be read are reported by `process_batch` against their
+    // photo_id, which is what the plugin needs in order to retry that one photo
+    // through its export fallback. This loop used to read them here and lose
+    // the association.
+    let mut file_paths: Vec<String> = Vec::new();
     let mut photo_ids: Vec<String> = Vec::new();
-    let mut read_errors: Vec<String> = Vec::new();
-
     let mut overrides: Vec<PhotoOverrides> = Vec::new();
-    // Every file in the group is held at once, because `process_batch` takes
-    // the whole batch. That is bounded by the plugin's grouped batch size,
-    // which is 1 for every provider except llama.cpp and configurable there —
-    // so a user who raises it is trading memory for throughput knowingly. What
-    // was missing was any way to see it: this repository's indexing blow-ups
-    // have consistently been diagnosed after the fact with no number to point
-    // at. Turning this into a bounded stream means restructuring
-    // `process_batch` around a lazy source, which is a redesign, not a fix.
-    let mut bytes_read: usize = 0;
     for ((path, photo_id), photo_overrides) in paths
         .into_iter()
         .flatten()
         .zip(ids.into_iter().flatten())
         .zip(per_image)
     {
-        let raw = match tokio::fs::read(&path).await {
-            Ok(bytes) => bytes,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                log::warn!("File not found at path: {path}. Skipping.");
-                read_errors.push(format!("File not found: {path}"));
-                continue;
-            }
-            Err(e) => {
-                log::error!("Error reading file at path {path}: {e}");
-                read_errors.push(format!("Error reading {path}: {e}"));
-                continue;
-            }
-        };
-        let filename = std::path::Path::new(&path)
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| path.clone());
-        bytes_read += raw.len();
-        images.push(UploadedImage {
-            bytes: raw,
-            filename,
-        });
+        file_paths.push(path);
         photo_ids.push(photo_id);
-        // Pushed here rather than above the `continue`s so a skipped file
-        // cannot shift every later photo's context by one.
         overrides.push(photo_overrides);
-    }
-
-    const LARGE_GROUP_BYTES: usize = 512 * 1024 * 1024;
-    if bytes_read >= LARGE_GROUP_BYTES {
-        log::warn!(
-            "index_by_reference: read {} files totalling {:.1} GiB into memory before processing. \
-             Lower the grouped batch size if the process runs out of memory.",
-            images.len(),
-            bytes_read as f64 / (1024.0 * 1024.0 * 1024.0)
-        );
-    } else {
-        log::debug!(
-            "index_by_reference: read {} files totalling {:.1} MiB",
-            images.len(),
-            bytes_read as f64 / (1024.0 * 1024.0)
-        );
     }
 
     let fields = json_fields_to_string_map(obj);
     process_batch(
         state,
         fields,
-        images,
+        ImageSource::Paths(file_paths),
         photo_ids,
         overrides,
-        read_errors,
+        Vec::new(),
         false,
     )
     .await

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -346,6 +346,64 @@ pub(crate) struct UploadedImage {
     pub(crate) filename: String,
 }
 
+/// Where [`process_batch`] gets each photo's bytes.
+///
+/// The distinction is about peak memory, not convenience. `/index_by_reference`
+/// points at the user's originals — 25–50 MB raw files — and reading the whole
+/// group before normalising any of it kept every one of them resident at once.
+/// The normalised JPEG is a few hundred KB and the raw bytes are dead the
+/// moment it exists, so reading one file at a time bounds the raw side of the
+/// batch to a single photo. The normalised results still all live until the
+/// batch finishes, because the LLM call needs them together.
+pub(crate) enum ImageSource {
+    /// Already in memory: the multipart path, where axum buffered the request
+    /// body before the handler ran. Nothing to gain by being lazy here.
+    Loaded(Vec<UploadedImage>),
+    /// Paths on disk, read on demand.
+    Paths(Vec<String>),
+}
+
+impl ImageSource {
+    fn len(&self) -> usize {
+        match self {
+            ImageSource::Loaded(v) => v.len(),
+            ImageSource::Paths(v) => v.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Takes photo `index` out of the source, reading it from disk if needed.
+    ///
+    /// Consuming: the in-memory variant leaves an empty `Vec` behind so the
+    /// bytes are freed as the loop advances rather than at the end of it.
+    async fn take(&mut self, index: usize) -> Result<UploadedImage, String> {
+        match self {
+            ImageSource::Loaded(images) => Ok(UploadedImage {
+                bytes: std::mem::take(&mut images[index].bytes),
+                filename: std::mem::take(&mut images[index].filename),
+            }),
+            ImageSource::Paths(paths) => {
+                let path = std::mem::take(&mut paths[index]);
+                let bytes = tokio::fs::read(&path).await.map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        format!("File not found: {path}")
+                    } else {
+                        format!("Error reading {path}: {e}")
+                    }
+                })?;
+                let filename = std::path::Path::new(&path)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or(path);
+                Ok(UploadedImage { bytes, filename })
+            }
+        }
+    }
+}
+
 async fn index_batch(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
     log::info!("Index request received");
 
@@ -406,7 +464,7 @@ async fn index_batch(State(state): State<Arc<AppState>>, mut multipart: Multipar
     process_batch(
         state,
         fields,
-        images,
+        ImageSource::Loaded(images),
         photo_ids,
         Vec::new(),
         Vec::new(),
@@ -434,7 +492,7 @@ async fn index_batch(State(state): State<Arc<AppState>>, mut multipart: Multipar
 pub(crate) async fn process_batch(
     state: Arc<AppState>,
     fields: HashMap<String, String>,
-    images: Vec<UploadedImage>,
+    mut images: ImageSource,
     photo_ids: Vec<String>,
     overrides: Vec<PhotoOverrides>,
     pre_failures: Vec<String>,
@@ -507,9 +565,26 @@ pub(crate) async fn process_batch(
     // a full copy, so a 200-photo batch held the batch three times over.
     let mut triplets: Vec<(Arc<[u8]>, String, String, PhotoOverrides)> = Vec::new();
     let mut conversion_errors: Vec<String> = pre_failures;
-    for ((img, photo_id), photo_overrides) in images.into_iter().zip(photo_ids).zip(overrides) {
+    // One photo in flight at a time: read, normalise, drop the original. With
+    // `ImageSource::Paths` that is what keeps a group of raw files from all
+    // being resident at once. A read failure is recorded against its photo_id
+    // rather than as an anonymous string, which is what the caller needs in
+    // order to retry that photo alone.
+    for (index, (photo_id, photo_overrides)) in photo_ids.into_iter().zip(overrides).enumerate() {
+        let img = match images.take(index).await {
+            Ok(img) => img,
+            Err(msg) => {
+                log::warn!("Skipping {photo_id}: {msg}");
+                results.push(json!({
+                    "photo_id": photo_id, "success": false, "error": msg.clone(),
+                }));
+                conversion_errors.push(msg);
+                continue;
+            }
+        };
         let t0 = Instant::now();
         let result = normalize_image_bytes(&img.bytes, Some(&img.filename), max_edge, quality);
+        drop(img.bytes);
         log::debug!(
             "Photo {photo_id} ({}): decode+resize+encode took {:?}",
             img.filename,
@@ -1938,5 +2013,66 @@ mod sharp_s_tests {
         let mut m = meta(&[("title", "Bridge at night")]);
         replace_sharp_s(&mut m);
         assert_eq!(m["title"], json!("Bridge at night"));
+    }
+}
+
+#[cfg(test)]
+mod image_source_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn loaded_images_are_freed_as_the_batch_advances() {
+        // The point of taking rather than borrowing: a 200-photo multipart
+        // batch should not hold all 200 buffers until the loop ends.
+        let mut source = ImageSource::Loaded(vec![
+            UploadedImage {
+                bytes: vec![1, 2, 3],
+                filename: "a.jpg".into(),
+            },
+            UploadedImage {
+                bytes: vec![4, 5],
+                filename: "b.jpg".into(),
+            },
+        ]);
+        assert_eq!(source.len(), 2);
+
+        let first = source.take(0).await.expect("in-memory take cannot fail");
+        assert_eq!(first.bytes, vec![1, 2, 3]);
+        assert_eq!(first.filename, "a.jpg");
+
+        let ImageSource::Loaded(remaining) = &source else {
+            unreachable!()
+        };
+        assert!(
+            remaining[0].bytes.is_empty(),
+            "the taken photo's buffer must be released, not cloned"
+        );
+        assert_eq!(remaining[1].bytes, vec![4, 5], "later photos untouched");
+    }
+
+    #[tokio::test]
+    async fn paths_are_read_one_at_a_time() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("Straße.jpg");
+        std::fs::write(&path, b"jpegbytes").expect("write");
+
+        let mut source = ImageSource::Paths(vec![path.to_string_lossy().to_string()]);
+        let img = source.take(0).await.expect("existing file reads");
+        assert_eq!(img.bytes, b"jpegbytes");
+        assert_eq!(img.filename, "Straße.jpg", "filename, not the whole path");
+    }
+
+    #[tokio::test]
+    async fn a_missing_file_is_an_error_for_that_photo_only() {
+        // It used to be an anonymous string in `pre_failures` with no photo_id,
+        // so the plugin could not tell which photo to retry.
+        let mut source = ImageSource::Paths(vec!["/nonexistent/nope.cr3".to_string()]);
+        let Err(err) = source.take(0).await else {
+            panic!("a missing file must not read successfully")
+        };
+        assert!(
+            err.contains("File not found") && err.contains("nope.cr3"),
+            "the message has to name the file, got {err:?}"
+        );
     }
 }

--- a/server-rs/crates/lrg-api/src/routes/style_edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/style_edit.rs
@@ -75,6 +75,9 @@ fn record_to_candidate(id: &str, meta: &Map<String, Value>, distance: f64) -> Tr
             .and_then(Value::as_str)
             .unwrap_or("unknown")
             .to_string(),
+        // Absent on examples saved before the flag was recorded, which the
+        // style engine treats as compatible with anything.
+        is_raw: meta.get("is_raw").and_then(Value::as_bool),
     }
 }
 
@@ -230,6 +233,11 @@ async fn style_edit(State(state): State<Arc<AppState>>, mut multipart: Multipart
     )
     .await;
 
+    // Parsed before the style engine runs, not after: the engine needs to know
+    // whether this photo is raw in order to decide which examples may
+    // contribute a temperature.
+    let options = parse_edit_options_form(&fields);
+
     let query = StyleQuery {
         exposure: ExposureFeatures {
             luminance_mean: Some(query_exposure.exp_luminance_mean),
@@ -238,10 +246,12 @@ async fn style_edit(State(state): State<Arc<AppState>>, mut multipart: Multipart
         },
         scene_tags: query_scene_tags,
         time_of_day_bucket: query_tod,
+        // Decides which examples may contribute a temperature: Lightroom's is
+        // Kelvin for raw and relative for everything else, and the two cannot
+        // be averaged together.
+        is_raw: options.is_raw,
     };
     let result: StyleEngineResult = generate_style_edit(training_count, &candidates, &query);
-
-    let options = parse_edit_options_form(&fields);
 
     if (result.engine == "none" || result.confidence < CONFIDENCE_LOW) && use_llm_fallback {
         log::info!(

--- a/server-rs/crates/lrg-api/src/routes/training.rs
+++ b/server-rs/crates/lrg-api/src/routes/training.rs
@@ -123,6 +123,13 @@ async fn add_training_example(
     let shutter_speed = opt_str(&fields, "shutter_speed");
     let iso = opt_f64(&fields, "iso");
     let aperture = opt_f64(&fields, "aperture");
+    // Recorded so the style engine can keep raw and rendered examples apart
+    // when it blends a temperature. Absent means unknown, which it treats as
+    // compatible with anything — the only workable answer for examples saved
+    // before this field existed.
+    let is_raw = fields
+        .get("is_raw")
+        .map(|s| s.trim().eq_ignore_ascii_case("true"));
 
     let mut warning: Option<&'static str> = None;
     let mut embedding: Option<Vec<f32>> = None;
@@ -173,6 +180,9 @@ async fn add_training_example(
     }
     if let Some(s) = &summary {
         metadata.insert("summary".into(), json!(s));
+    }
+    if let Some(raw) = is_raw {
+        metadata.insert("is_raw".into(), json!(raw));
     }
     metadata.insert(
         "focal_length_bucket".into(),


### PR DESCRIPTION
> **Based on #272.** Review that one first; this branch contains its commit.

The two items #271 deliberately left open, both of which needed real work rather
than a patch.

---

## 1. `/index_by_reference` no longer reads the whole group up front

`process_batch` took `Vec<UploadedImage>` — every photo's bytes, materialised
before it was called. For the multipart path that is inherent (axum buffered the
request body already), but `/index_by_reference` points at the user's
**originals**: 25–50 MB raw files, read in full for a group, against a few
hundred KB for the normalised JPEG the rest of the pipeline actually uses. Every
one of them stayed resident until the loop finished.

It now takes an `ImageSource`:

```rust
pub(crate) enum ImageSource {
    /// Already in memory: the multipart path. Nothing to gain by being lazy.
    Loaded(Vec<UploadedImage>),
    /// Paths on disk, read on demand.
    Paths(Vec<String>),
}
```

Each photo is read → normalised → original dropped before the next one starts,
so the raw side of a batch is bounded to **one file** rather than to the group.
The `Loaded` variant takes rather than borrows, so multipart buffers are freed as
the loop advances too.

**It also fixes the error reporting on that path.** A file that could not be read
used to become an anonymous string in `pre_failures` — a group with one missing
photo told the plugin *something* failed but not *which*, so it could not run its
per-photo export fallback for just that one. Read failures now land in `results`
against their own `photo_id`, like every other per-photo failure.

## 2. Style training keeps raw and non-raw examples apart — for white balance only

Lightroom's temperature is **Kelvin** on a raw file and a relative **−100..+100**
on a JPEG. The style engine blends the develop settings of the top-3 matched
training examples and applies the result to a real photo. Averaging `5600` with
`+10` gives `2805`: not a compromise, a number that means nothing on either
scale.

So:

- `is_raw` is recorded with each training example (`POST /training/add`, from the
  plugin's `Util.isRawPhoto`).
- `temperature` is interpolated **only** from the winners whose flag matches the
  photo being edited.
- If none qualify, the field is dropped entirely — no white-balance change beats
  a wrong-scale one — and either way the reason lands in `warning`.

The `/edit` few-shot path gets the same rule from the other side: an example
whose raw status conflicts with the target has its white balance stripped before
it reaches the prompt, so the model is not anchored on a number the schema it
must answer in cannot even express.

### Deliberately narrow

- **`tint` is left alone.** Its range differs (−150..150 vs −100..100) but its
  meaning does not, so a mixed blend is a scale distortion the clamp already
  handles, not a category error.
- **Every other canonical field is blended from all matched examples**, exactly
  as before. Exposure, contrast, presence, colour and curves mean the same thing
  on both kinds of file.
- **Examples saved before `is_raw` existed count as compatible with anything.**
  Excluding them would shrink every long-standing user's pool to nothing on the
  first edit after upgrading.

This is a partition of one field, not of the training set. A user who shoots raw
and JPEG both keeps every example; the pool simply narrows for white balance.

---

## Verification

`cargo fmt --check` · `cargo clippy --workspace --all-targets` (zero warnings) ·
30 test blocks green · `stylua --check` · `luacheck` (0/0 across 35 files) ·
164 busted tests · `check-docs.py` clean.

New tests cover the parts that are easy to get subtly wrong: that `ImageSource`
actually releases each buffer as it advances, that a missing file names itself in
the error, that a uniform example pool blends temperature exactly as before, that
a mixed pool uses only the matching half, that an all-wrong-scale pool drops the
field while leaving other settings intact, and that unknown raw status excludes
nothing on either side.

Not exercised against a running binary. Worth doing by hand: index a group of
large RAWs by reference and watch RSS, and run an AI Edit on a JPEG with a
raw-only training set to see the white-balance warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd1XeSrt8rFfsZ1VSwuikF
