### PR TITLE
Switch AI Edit to style engine only, remove LLM path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** section offers a curated list of vision models (Gemma 4, Ministral 3, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. The section shows the engine your platform ships: **MLX** on macOS, **llama.cpp** on Windows. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
 5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
    - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
-   - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits
+   - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits learned from your own edits
    - **Advanced Search...** — semantic free-text search
    - **Cull Similar Photos...** *(beta)* — burst grouping and auto-ranking
    - **People...** — face clusters and named person collections
    - **Find Similar Images...** — find near-duplicates or visually similar photos
    - **Deduplicate Keyword Synonyms...** — clean up synonym sprawl in your catalog
-6. For AI Edit, start with defaults, keep **Review each proposed edit before applying it** enabled, and tune style via **Overall look** + **Style strength**.
+6. For AI Edit, first teach it your style: edit a few photos by hand and run **Save Edits as AI Training Examples...**. AI Edit builds every recipe from those examples and needs at least five of them — it calls no LLM. Keep **Review each proposed edit before applying it** enabled while you validate the results.
 
 *For comprehensive details, model setup guides, and tips, please visit [lrgenius.com/help](http://lrgenius.com/help/).*
 

--- a/docs/doc-sources.toml
+++ b/docs/doc-sources.toml
@@ -66,11 +66,13 @@ sources = [
 # --- User-facing help pages, keyed to the task that implements the feature ---
 
 [page."Help-AI-Edit.md"]
+# `routes/edit.rs` is deliberately absent: the plugin no longer reaches the
+# LLM edit path, so the page documents the style engine only.
 sources = [
   "plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua",
   "plugin/LrGeniusAI.lrdevplugin/DevelopEditManager.lua",
-  "server-rs/crates/lrg-api/src/routes/edit.rs",
   "server-rs/crates/lrg-api/src/routes/style_edit.rs",
+  "server-rs/crates/lrg-analysis/src/style_engine.rs",
   "server-rs/crates/lrg-api/src/edit_budget.rs",
 ]
 

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -163,7 +163,14 @@ Runs the full culling pipeline on a set of photos: grouping, scoring, and classi
 ## AI Develop Edits
 
 ### `POST /edit`
-Generates a Lightroom develop recipe for a photo sent as a file upload.
+Generates a Lightroom develop recipe for a photo sent as a file upload, using an
+LLM.
+
+> No plugin workflow calls this any more. *AI Edit Photos* runs on
+> `POST /style_edit` alone and never asks for the LLM fallback, so this endpoint
+> and `/edit_base64` are currently reachable only by direct HTTP callers. Both
+> are fully supported; `SearchIndexAPI.generateEditRecipePhoto` in the plugin
+> still speaks to `/edit` and is simply not called.
 
 **Key request fields:**
 

--- a/docs/wiki/Dev-Plugin-README.md
+++ b/docs/wiki/Dev-Plugin-README.md
@@ -47,9 +47,10 @@ The plugin is designed to work with local and cloud providers, while keeping Lig
 
 ### AI Develop Edits
 
-- Generate a Develop recipe per photo and apply it non-destructively
-- Choose an overall look, or let the backend match the photo against edits you
-  saved yourself
+- Generate a Develop recipe per photo and apply it non-destructively, either to
+  the photo itself or to a virtual copy
+- No LLM involved: the backend matches the photo against the edits you saved
+  yourself and interpolates theirs
 - Recipes are constrained to what the frame can take: the backend measures the
   image and caps contrast, clarity, shadow lift and whites accordingly, and
   reports why
@@ -57,7 +58,7 @@ The plugin is designed to work with local and cloud providers, while keeping Lig
 ### Style Training
 
 - Save your own Develop settings as labeled training examples
-- Used both as few-shot context for the LLM and by the LLM-free Style Engine
+- The sole input to AI Develop Edits, which needs at least five of them
 
 ### Keyword Dedup & Declutter
 

--- a/docs/wiki/Dev-Project-README.md
+++ b/docs/wiki/Dev-Project-README.md
@@ -56,13 +56,13 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** section offers a curated list of vision models (Gemma 4, Ministral 3, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. The section shows the engine your platform ships: **MLX** on macOS, **llama.cpp** on Windows. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
 5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
    - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
-   - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits
+   - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits learned from your own edits
    - **Advanced Search...** — semantic free-text search
    - **Cull Similar Photos...** *(beta)* — burst grouping and auto-ranking
    - **People...** — face clusters and named person collections
    - **Find Similar Images...** — find near-duplicates or visually similar photos
    - **Deduplicate Keyword Synonyms...** — clean up synonym sprawl in your catalog
-6. For AI Edit, start with defaults, keep **Review each proposed edit before applying it** enabled, and tune style via **Overall look** + **Style strength**.
+6. For AI Edit, first teach it your style: edit a few photos by hand and run **Save Edits as AI Training Examples...**. AI Edit builds every recipe from those examples and needs at least five of them — it calls no LLM. Keep **Review each proposed edit before applying it** enabled while you validate the results.
 
 *For comprehensive details, model setup guides, and tips, please visit [lrgenius.com/help](http://lrgenius.com/help/).*
 

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -130,23 +130,23 @@ Results are ranked by combining visual semantic embeddings with a text search ov
 
 ### What does AI Edit generate?
 
-A structured Lightroom develop recipe: global adjustments (exposure, white balance, tone curve, HSL, etc.) and optional local masks (subject, sky, background). The recipe is applied via the Lightroom SDK — no raw pixel editing happens outside Lightroom.
+A structured Lightroom develop recipe of global adjustments (exposure, white balance, tone curve, contrast, presence, sharpening, and so on), built by matching the photo against your own saved edits. The recipe is applied via the Lightroom SDK — no raw pixel editing happens outside Lightroom.
+
+### Which model does AI Edit use?
+
+None. AI Edit does not call a language model at all — it interpolates the develop settings of the training examples closest to the photo. Model choice only affects *Analyze & Index*.
+
+### AI Edit says my style profile is not ready
+
+It needs at least five saved training examples before it can produce anything. Edit some photos the way you like them and run **Save Edits as AI Training Examples** (*Library → Plug-in Extras*). See [Help: Train from Edits](Help-Train-From-Edits).
 
 ### I want to review edits before they are applied
 
-Enable **Review each proposed edit before applying it** in the AI Edit dialog. You will see a before/after preview for each photo and can approve, skip, or adjust the edit.
+Enable **Review each proposed edit before applying it** in the AI Edit dialog. You will see the proposed develop values, the confidence of the style match, and any guardrail explanations, and can apply or skip each photo. (There is no rendered before/after preview yet — use Lightroom's History panel to judge the result.)
 
-### What are "Overall look" presets?
+### Can I keep my original untouched?
 
-Presets define the editing style — for example *Natural Professional*, *Moody Dramatic*, *Portrait - Skin Safe*, *Wedding - Soft Airy*. They inject a style description into the AI prompt. Choose *Custom* to write your own style instruction.
-
-### What does "Style strength" do?
-
-Controls how aggressively the AI applies the style. At 0% the AI makes only technical corrections; at 100% it applies the full stylized look. Default is 50%.
-
-### Can I train the AI on my own editing style?
-
-Yes — use **Save Edits as AI Training Examples** (*Library → Plug-in Extras*). See [Help: Train from Edits](Help-Train-From-Edits) for details.
+Enable **Apply the edit to a new virtual copy** in the AI Edit dialog. Each edited photo gets a virtual copy named *AI Edit* and the recipe lands there.
 
 ---
 

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -58,7 +58,7 @@ Before semantic search or AI-assisted culling can work, the backend needs to pro
 2. Navigate to `Library -> Plug-in Extras -> Analyze & Index Photos`.
 3. The plugin will pass the photos to the backend, generate descriptions, tags, and AI embeddings, and store them.
 
-Once indexing finishes, try out **Advanced Search**, the **People** workflows, use **Retrieve Metadata** to inject the generated tags straight back into your catalog, or run **AI Edit Photos** *(beta)* to get AI-suggested develop settings for each photo.
+Once indexing finishes, try out **Advanced Search**, the **People** workflows, or use **Retrieve Metadata** to inject the generated tags straight back into your catalog. For **AI Edit Photos** *(beta)*, first save a handful of your own edits with **Save Edits as AI Training Examples** — that is what AI Edit builds develop settings from.
 
 ## 4. Upgrading From a UUID-Era Database
 

--- a/docs/wiki/Help-AI-Edit.md
+++ b/docs/wiki/Help-AI-Edit.md
@@ -10,26 +10,58 @@ The **AI Edit Photos** workflow generates a structured Lightroom develop recipe 
 
 ---
 
+## It edits like you do — and only like you do
+
+AI Edit does not ask a language model what a good edit looks like. It builds
+every recipe from **your own saved edits**: the photo is matched against the
+training examples you stored with *Save Edits as AI Training Examples*, and the
+closest matches are blended into a recipe.
+
+The match is scored on four things:
+
+| Signal | Weight |
+|---|---|
+| Visual similarity (the photo's CLIP embedding) | 50% |
+| Exposure character — brightness, contrast, warmth | 25% |
+| Scene tags | 15% |
+| Time of day | 10% |
+
+The upshot: **AI Edit needs training examples to work at all.** With fewer than
+five saved examples the task stops before it uploads anything and points you at
+*Save Edits as AI Training Examples*. Five is the floor, not the target — the
+style profile is reported as *Building up* below ten examples and *Active* from
+fifty. See [Help: Train from Edits](Help-Train-From-Edits).
+
+Because the recipe comes from your own edits, there is no prompt, no model
+choice, no style preset and no API key involved. AI Edit works with every cloud
+provider switched off.
+
+---
+
 ## What it generates
 
-For each photo the AI produces a develop recipe that may include:
+A develop recipe of **global adjustments** — exposure, white balance,
+highlights, shadows, whites, blacks, contrast, texture, clarity, dehaze,
+vibrance, saturation, tone curve, sharpening, noise reduction, vignette, grain
+— averaged from the matching examples.
 
-- **Global adjustments** — exposure, white balance, highlights, shadows, whites, blacks, contrast, clarity, vibrance, saturation, HSL color shifts, tone curve, sharpening, noise reduction.
-- **Local masks** — subject, sky, or background masks with separate adjustments. Masks are only added when materially beneficial.
+Local masks are not part of a style-engine edit; every recipe carries an empty
+mask list.
 
-The recipe is applied via the Lightroom SDK. No raw pixel editing happens outside Lightroom; all results are reversible via Lightroom's Edit History.
+The recipe is applied via the Lightroom SDK. No raw pixel editing happens
+outside Lightroom; all results are reversible via Lightroom's Edit History.
 
 ---
 
 ## What the frame allows
 
-A model that cannot see how the light actually falls will happily add contrast
-to a scene that already has too much of it. So before a recipe reaches your
-photo, the backend measures the image itself — how hard the light is, how many
-stops of dynamic range there are, how much of the frame is specular highlight,
-how far the shadows are already clipped — and works out how much contrast,
-clarity, shadow lift and whites this particular frame can take. Values above
-that ceiling are pulled back down.
+Your habitual +25 contrast was learnt on the frames you shot, and this frame may
+have nothing in common with them. So before a recipe reaches your photo, the
+backend measures the image itself — how hard the light is, how many stops of
+dynamic range there are, how much of the frame is specular highlight, how far
+the shadows are already clipped — and works out how much contrast, clarity,
+shadow lift and whites this particular frame can take. Values above that ceiling
+are pulled back down.
 
 The review dialog shows why, in plain sentences: hard midday light means no
 extra contrast, flat overcast light means there is room for it, an already
@@ -39,9 +71,12 @@ never bit.
 
 The judgement changes with the file type: raw files still hold detail behind
 clipped highlights, JPEGs do not, so the same blown sky earns a stricter budget
-on a JPEG. The plugin tells the backend which it is, since the photo is
-exported to JPEG before upload and the original encoding is otherwise
-invisible from the server side.
+on a JPEG. The same distinction decides whether a training example's white
+balance can be carried over at all — Lightroom's temperature is Kelvin on a raw
+file and a relative −100…100 value on everything else, and the two cannot be
+averaged together. The plugin tells the backend which it is, since the photo is
+exported to JPEG before upload and the original encoding is otherwise invisible
+from the server side.
 
 ---
 
@@ -51,65 +86,19 @@ invisible from the server side.
 
 - **Selected photos only** — processes only the photos you have selected in the Library grid.
 - **Current view** — all photos in the currently visible folder or collection.
+- **All photos in catalog** — everything.
 
-### AI Model
+### Style profile
 
-Choose which LLM to use. The list is loaded from the backend at runtime and only shows providers that are configured and reachable. See [Help: Choosing AI Model](Help-Choosing-AI-Model).
-
-### Overall look
-
-Selects the editing style preset injected into the AI prompt:
-
-| Preset | Description |
-|---|---|
-| General - Natural Professional | Balanced contrast, realistic color, clean detail. Default. |
-| General - Moody Dramatic | Deeper shadows, restrained saturation, cinematic tonal separation. |
-| Landscape - Cinematic | Controlled dynamic range, subtle color contrast, tasteful depth. |
-| Landscape - Vibrant Natural | Clear tonal separation, protected highlights, controlled saturation. |
-| Portrait - Skin Safe | Gentle contrast, natural texture, flattering highlights. |
-| Portrait - Editorial | Clean skin tones, polished midtone contrast, soft highlight roll-off. |
-| Wedding - Soft Airy | Bright mids, warm-neutral white balance, gentle contrast. |
-| Wedding - Rich Filmic | Subtle warm skin tones, gentle black-point lift, cinematic color depth. |
-| Real Estate - Bright Neutral | Bright neutral interiors, straight tonal balance, minimal stylization. |
-| Commercial - Clean Product | Neutral white balance, crisp detail, true-to-product colors. |
-| Street - Punchy Documentary | Decisive contrast, neutral color fidelity, clear subject separation. |
-| Custom | Write your own style instruction in the text field. |
-
-### Style strength
-
-Controls how aggressively the preset style is applied, from subtle correction to full stylized look. Range: 0–100%. Default: 50%.
-
-### Composition / crop
-
-Whether the AI may suggest a crop:
-- **No crop** — never adjusts framing.
-- **Subtle crop** — only if clearly beneficial for composition.
-- **Aggressive crop** — freely crops to improve composition.
-
-Default: Subtle crop.
-
-### Creative Controls
-
-Each checkbox switches off a whole family of adjustments, so you can let the AI
-work on tone but keep your own color, or the other way round:
-
-- Adjust white balance
-- Adjust basic tone (exposure/contrast/highlights/shadows/whites/blacks)
-- Adjust presence (texture/clarity/dehaze)
-- Adjust color mix (vibrance/saturation/HSL)
-- Do color grading
-- Use tone curve, and within it Use point curve
-- Adjust detail, Adjust effects, Adjust lens corrections
-- Include local masks
-
-Anything you switch off is stripped from the recipe before it reaches your
-photo, whatever the model proposed.
+Read-only. Shows how many training examples the backend holds and what that
+means for the match quality, so you can tell an unconvincing result caused by a
+thin style profile from one caused by an unusual photo.
 
 ### Review each proposed edit before applying it
 
 When enabled, a **review dialog** opens for each photo before the edit is applied. You see:
 
-- The proposed develop values, plus which engine produced them and how confident it was.
+- The proposed develop values, plus how confident the style match was and which of your saved edits it drew on.
 - Any guardrail explanations — what the frame allowed, and what got capped.
 - Options to **Apply** or **Skip**.
 
@@ -117,24 +106,39 @@ When enabled, a **review dialog** opens for each photo before the edit is applie
 
 > **No before/after preview yet.** The review dialog lists values; it does not render a comparison. A rendered before/after is planned. Until then, Lightroom's own History panel is the fastest way to judge a result — every run is a single undo step named *Apply AI Lightroom develop settings*.
 
-### Per-photo instruction
+### Apply the edit to a new virtual copy
 
-If **Allow per-photo instructions** is enabled, a free-text field opens *before* the edit is generated — for example "Make the sky more dramatic" or "Reduce noise in shadows". A checkbox carries the same instruction to all following photos.
+Off by default. When enabled, each photo that is actually going to be edited
+gets a virtual copy named *AI Edit* first, and the recipe is applied to that
+copy — your original keeps whatever settings it had.
 
-Note this happens before generation, not after: there is currently no way to re-run a single photo from the review dialog with a changed instruction. Skip the photo and run it again to do that.
+The copy is created *after* the review dialog, so a photo you skip leaves
+nothing behind. If Lightroom refuses to create the copy, the photo is reported
+as an error and skipped; the edit is never redirected onto the original.
 
----
-
-## Training the AI on your style
-
-If you want AI Edit to match your personal editing style, use **Save Edits as AI Training Examples** to feed your existing edits back to the AI as few-shot examples. See [Help: Train from Edits](Help-Train-From-Edits).
+Two side effects come from Lightroom's own API here: copying works on the
+current selection, so your grid selection changes as the run walks through the
+photos, and if a photo is not part of the folder or collection you are looking
+at, the plugin switches the source to *All Photographs* to reach it.
 
 ---
 
 ## Tips for best results
 
 - Start with **Review each proposed edit** enabled — review the first batch before applying to hundreds of photos.
-- Choose a preset that matches your genre (portrait, landscape, wedding, etc.) rather than using *Custom* initially.
-- **Style strength 40–60%** is a good starting range. Higher values push the style harder; lower values stay close to a neutral technical correction.
-- If results are inconsistent, try a higher-quality model (e.g. `gemini-2.5-pro` or `gpt-5.4-pro`).
-- Use **Save Edits as AI Training Examples** after a manual editing session to teach the AI your preferences.
+- Train on the kind of photo you are about to edit. The style profile is matched per photo, so a profile built only from bright studio work has little to offer a night shot.
+- Keep feeding it: run **Save Edits as AI Training Examples** after a manual editing session. Match quality improves with the number and variety of examples.
+- A low confidence in the review dialog means the photo did not resemble anything you have trained on. That is the moment to edit it by hand — and then save that edit as a training example.
+
+---
+
+## Where the LLM went
+
+Earlier versions offered a second, prompt-driven path: pick a provider and
+model, write a system instruction, choose a look preset, and let a vision LLM
+propose the develop settings. That path is no longer reachable from the plugin.
+The backend still implements it (`POST /edit`), so it can come back, but the AI
+Edit dialog no longer configures it and no run reaches an LLM.
+
+Model choice now only affects [Analyze & Index](Help-Analyze-and-Index) —
+tagging, descriptions and keywords.

--- a/docs/wiki/Help-Choosing-AI-Model.md
+++ b/docs/wiki/Help-Choosing-AI-Model.md
@@ -148,7 +148,7 @@ significantly faster than the GGUF builds. See [LM Studio Setup](Help-LM-Studio-
 
 ## Practical recommendation
 
-The dropdown in *Analyze & Index* and *AI Edit* always reflects what the
+The dropdown in *Analyze & Index* always reflects what the
 backend currently advertises — newer models that ship with future backend
 updates will appear automatically. If a model you expect is missing, check
 that the corresponding API key or local server is configured and reachable

--- a/docs/wiki/Help-Local-AI-Models.md
+++ b/docs/wiki/Help-Local-AI-Models.md
@@ -33,8 +33,8 @@ not arise.
    approximate download size; the models are several gigabytes, so this takes a
    while on a slow connection.
 4. When the download finishes, the **Installed** line lists the model.
-5. In *Analyze & Index Photos* (or *AI Edit*), choose the model from the **AI
-   Model** dropdown — it appears as `mlx: <model>` or `llamacpp: <model>`.
+5. In *Analyze & Index Photos*, choose the model from the **AI Model**
+   dropdown — it appears as `mlx: <model>` or `llamacpp: <model>`.
 
 The curated lists are short on purpose: every entry is an ungated repository
 (no Hugging Face token needed) and a **vision** model, since a text-only model

--- a/docs/wiki/Help-Performance-Tips.md
+++ b/docs/wiki/Help-Performance-Tips.md
@@ -12,7 +12,7 @@ which, and what you can tune to make the slow ones faster.
 | Feature | Calls an LLM? | What drives the time |
 |---|---|---|
 | **Analyze & Index — AI metadata** (keywords/title/caption/alt text) | **Yes, once per photo** | Model choice, export size, prompt options |
-| **AI Edit Photos** | **Yes, once per photo** | Model choice, export size, review dialog |
+| **AI Edit Photos** | No — matches your saved edits locally | Export size, review dialog |
 | **Deduplicate Keyword Synonyms** | Optional, once per cluster (not per photo) | Number of keyword clusters, not catalog size |
 | Analyze & Index — **search embeddings** (SigLIP2) | No — local ONNX model, always | Photo count only; same speed regardless of LLM choice |
 | **Cull Photos** | No | Runs on metrics already computed during indexing |
@@ -20,7 +20,7 @@ which, and what you can tune to make the slow ones faster.
 | **Find Similar Images** | No | Vector lookup (CLIP) or perceptual hash (phash) |
 | **Advanced Search** | No | Vector lookup against existing embeddings |
 
-The practical upshot: **Analyze & Index and AI Edit are the only features
+The practical upshot: **Analyze & Index is the only per-photo feature
 where your LLM choice matters for speed.** Everything else is bounded by
 local compute on the backend machine and is fast regardless of whether you
 picked a cheap cloud model or a big local one — but those features all
@@ -184,9 +184,10 @@ These are secondary compared to §2–4, but worth knowing:
    LLM at request time, so they're cheap to re-run as often as you like once
    indexing is done.
 6. **For AI Edit**, keep **Review each proposed edit** on until you've
-   validated a model+preset combination on your shooting style, then turn it
-   off for large batches — it doesn't change compute cost, but it does gate
-   throughput on how fast you click through the review dialog.
+   validated the results against your shooting style, then turn it off for
+   large batches — it doesn't change compute cost, but it does gate throughput
+   on how fast you click through the review dialog. The generation itself is
+   local and needs no LLM at all.
 
 ---
 

--- a/docs/wiki/Help-Train-From-Edits.md
+++ b/docs/wiki/Help-Train-From-Edits.md
@@ -1,6 +1,6 @@
 # Help: Save Edits as AI Training Examples
 
-The **Save Edits as AI Training Examples** workflow lets you teach LrGeniusAI your personal editing style. Your current Lightroom develop settings for selected photos are saved to the backend as few-shot examples. The next time you run **AI Edit Photos**, these examples are injected into the AI prompt as context, so the AI produces results closer to your style.
+The **Save Edits as AI Training Examples** workflow lets you teach LrGeniusAI your personal editing style. Your current Lightroom develop settings for selected photos are saved to the backend as labeled examples. They are what **AI Edit Photos** builds its recipes from — without them AI Edit has nothing to work with and refuses to run, so this workflow is the prerequisite for that one, not an optional refinement of it.
 
 ## How to use it
 
@@ -38,28 +38,31 @@ A free-text summary of what this edit style represents. Helps the AI understand 
 
 ## How it affects AI Edit
 
-Training examples feed two different mechanisms:
+Training examples are the entire input to **AI Edit Photos**. The backend finds
+the closest examples by image similarity, re-scores them on exposure, scene type
+and time of day, and interpolates their develop settings into a recipe for the
+photo in front of it. No language model is involved.
 
-**As few-shot context for the LLM.** When you run **AI Edit Photos** with a
-cloud or local model, the backend retrieves the stored examples most similar to
-the photo being edited and puts their actual develop values into the prompt, so
-the model has your numbers to anchor on rather than only the style preset.
+That has two consequences worth knowing:
 
-**As the Style Engine.** The backend can also produce an edit with no LLM at
-all: it finds the closest training examples by image similarity, re-scores them
-on exposure, scene type and time of day, and interpolates their develop
-settings. This needs at least **five** training examples before it will return
-anything, and it gets noticeably better with more.
+- **Below five examples, AI Edit will not run.** It stops in the plugin with a
+  pointer back to this workflow. Five is the floor; the style profile is
+  reported as *Building up* below ten and *Active* from fifty, and the match
+  quality follows that curve.
+- **Variety matters as much as volume.** Matching is per photo, so a profile
+  built only from bright studio work has little to offer a night shot. Train on
+  the kinds of photos you actually want edited.
 
-Both paths match examples by image similarity, so a training photo has to have
-been indexed with **Enable smart photo search** for it to be findable. Saving an
-example for a photo without an embedding still works, but that example will
-never be retrieved — the plugin shows a warning when this happens.
+Matching runs on image similarity, so a training photo has to have been indexed
+with **Enable smart photo search** for it to be findable. Saving an example for
+a photo without an embedding still works, but that example will never be
+retrieved — the plugin shows a warning when this happens.
 
 The same applies to the photo being edited: if it is not indexed, there is no
-embedding to compare your saved edits against. AI Edit then falls back to the
-plain style preset and says so in the result, rather than silently producing a
-generic edit.
+embedding to compare your saved edits against. The backend then falls back to
+scoring recent examples on exposure, scene and time of day alone, which is a
+weaker match — the review dialog reports the lower confidence rather than
+hiding it.
 
 ## Raw and non-raw examples are kept apart
 

--- a/docs/wiki/Plugin-Guide.md
+++ b/docs/wiki/Plugin-Guide.md
@@ -30,7 +30,7 @@ All actions are available under `Library → Plug-in Extras`:
 Passes photos to the AI backend to generate keywords, title, caption, and alt text. Simultaneously creates SigLIP2 semantic embeddings so photos can be found via Advanced Search. Configurable scope (selected, current view, entire catalog), metadata toggles, and extra context options (folder name, date, GPS). See [Help: Analyze and Index](Help-Analyze-and-Index).
 
 ### AI Edit Photos
-For each photo, the backend generates a structured Lightroom develop recipe (global adjustments + optional masks) which the plugin applies via the Lightroom SDK. Supports style presets, style strength, composition/crop modes, per-photo review, and per-photo instruction overrides. See [Help: AI Edit Photos](Help-AI-Edit).
+For each photo, the backend builds a structured Lightroom develop recipe out of your own saved edits — no language model involved — which the plugin applies via the Lightroom SDK. Needs at least five training examples from *Save Edits as AI Training Examples*. Offers per-photo review and can put the edit on a virtual copy instead of the original. See [Help: AI Edit Photos](Help-AI-Edit).
 
 ### Advanced Search
 Translates a natural language query into vector embeddings and compares them against your indexed photos. Results are placed into a new Lightroom Collection sorted by relevance. See [Help: Advanced Search](Help-Advanced-Search).

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -163,14 +163,33 @@ Local AI models can take significantly longer than cloud APIs, especially withou
 
 ---
 
-### 13. AI Edit Produces 500 Internal Server Error
+### 13. AI Edit Fails Per Photo
 
-- **Symptom:** AI Edit fails with "HTTP status: 500" from the backend.
-- **Resolution:**
-  1. Check the backend terminal log for the full error message.
-  2. Common cause: the selected model returned a response that doesn't match the expected edit schema. Try a different (more capable) model — `gemini-2.5-flash` or `gpt-5-mini` are reliable choices.
-  3. If you are using a local model, the 4B models sometimes produce malformed JSON. Try the 8B variant or switch to a cloud model.
-  4. If the error mentions "schema validation", it usually means the model returned prose instead of structured JSON. Custom system prompts that break the format can cause this — reset to the default system prompt and try again.
+AI Edit builds every recipe from your saved training examples and never calls a
+language model, so its failures are about the style profile, not about models
+or prompts.
+
+- **Symptom:** "Style engine inactive: only N training example(s) available".
+- **Resolution:** Save more edits via *Save Edits as AI Training Examples*. Five
+  is the minimum; ten or more gives a usable match. The plugin normally stops
+  before the run and tells you this — seeing it per photo means examples were
+  removed while the run was in progress.
+
+- **Symptom:** "Style engine could not produce a result" or "Style engine returned an empty recipe".
+- **Resolution:** Your training examples carry no usable develop settings for
+  this photo — most often because they were all saved from photos on the other
+  side of the raw/JPEG divide, which keeps their white balance (and little else)
+  from being carried over. Save examples edited from the same kind of file you
+  are trying to edit.
+
+- **Symptom:** Low confidence in the review dialog, edits that don't feel like yours.
+- **Resolution:** The photo did not resemble anything you trained on. Make sure
+  the photos are indexed (**Enable smart photo search**) so the visual match has
+  an embedding to work with, and train on the kind of material you want edited.
+
+- **Symptom:** "HTTP status: 500" with "database not initialized".
+- **Resolution:** The backend has no catalog database bound yet. Open the
+  Plug-in Manager and let it initialize, then retry.
 
 ---
 

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -896,6 +896,11 @@ end
 --   - folder_names string: Folder path
 --   - user_context string: Additional context for the photo
 -- @return boolean success, table|string response - Returns success status and response data or error message
+--
+-- No task calls this any more: AI Edit runs on the style engine
+-- (`SearchIndexAPI.styleEdit`) alone. `/edit` and `/edit_base64` are still
+-- served by the backend, so this wrapper stays as the way back to the
+-- prompt-driven LLM edit rather than being deleted with it.
 ---
 
 function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
@@ -4340,15 +4345,15 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	addStr("aperture")
 	addStr("shutter_speed")
 
-	-- Standard edit options forwarded for LLM fallback compatibility.
+	-- Standard edit options, kept for the backend's LLM-fallback contract.
 	--
-	-- The fallback fires exactly when the style engine cannot answer — which for a
-	-- new user with no training examples is the *first* run, since
-	-- `aiEditUseTrainingStyle` defaults on. It used to omit `api_key` entirely, and
-	-- there is no environment-variable fallback in `provider.rs`/`openai.rs`, so
-	-- that first run reached the provider with an empty bearer token and 401'd.
-	-- Everything `generateEditRecipePhoto` sends has to travel here too, or the
-	-- fallback silently produces a different edit than the direct path would.
+	-- `TaskAiEditPhotos` no longer asks for that fallback — it never sends
+	-- `use_llm_fallback`, so the backend's default (off) applies and a photo the
+	-- style engine cannot answer for comes back as an error rather than as an
+	-- LLM edit. The fields stay because `/style_edit` still accepts them and a
+	-- caller that does want the fallback has to be able to send everything
+	-- `generateEditRecipePhoto` sends; `addEditOpt` skips whatever is absent,
+	-- so the style-engine-only path pays nothing for them.
 	local function addEditOpt(key, value)
 		if value ~= nil then
 			table.insert(mimeChunks, { name = key, value = tostring(value) })

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua
@@ -1,5 +1,20 @@
 require("DevelopEditManager")
 
+-- AI Edit runs on the Style Engine only. The LLM edit path (`/edit`, provider
+-- and model choice, prompts, intent presets, creative controls, per-photo
+-- instructions) is gone from this task: none of it reached the style engine,
+-- which builds a recipe purely by matching the photo against the training
+-- examples the user saved from their own edits. The backend still serves
+-- `/edit`, and `SearchIndexAPI.generateEditRecipePhoto` still speaks to it —
+-- nothing here calls either.
+
+-- Mirrors `MIN_TRAINING_EXAMPLES` in
+-- `server-rs/crates/lrg-analysis/src/style_engine.rs`. Below it the style
+-- engine declines to answer, and with the LLM fallback no longer requested
+-- there is nothing behind it — so the run is stopped here rather than
+-- exporting and uploading every photo for a guaranteed 422.
+local MIN_TRAINING_EXAMPLES = 5
+
 local function copyOptions(source)
 	local copied = {}
 	for key, value in pairs(source or {}) do
@@ -8,135 +23,96 @@ local function copyOptions(source)
 	return copied
 end
 
-local function safePromptTable(rawPrompts)
-	if type(rawPrompts) ~= "table" then
-		log:warn(
-			"AI Edit prompt table invalid type: " .. tostring(type(rawPrompts)) .. ". Falling back to default prompt."
-		)
-		return { Default = Defaults.defaultEditSystemInstruction }
+-- Same wording and thresholds as the Style Profile block in the plug-in
+-- manager (`PluginInfoDialogSections.lua`), reusing its `LOC` keys so the two
+-- places cannot drift apart.
+local function styleReadinessDisplay(stats)
+	if not stats then
+		return LOC(
+			"$$$/LrGeniusAI/TaskAiEditPhotos/StyleStatusUnknown=Unavailable — the backend did not report the style profile"
+		),
+			LrColor(0.7, 0.7, 0.7),
+			nil
 	end
-	return rawPrompts
+
+	local count = tonumber(stats.count) or 0
+	local readiness = stats.readiness or "cold_start"
+
+	if readiness == "active" then
+		return LOC("$$$/LrGeniusAI/Training/Status/Active=Active — matching your style precisely"),
+			LrColor(0.2, 0.8, 0.2),
+			count
+	elseif readiness == "limited" then
+		return LOC("$$$/LrGeniusAI/Training/Status/Limited=Learning — getting better with more examples"),
+			LrColor(0.8, 0.8, 0.2),
+			count
+	elseif readiness == "warming_up" then
+		return LOC("$$$/LrGeniusAI/Training/Status/WarmingUp=Building up — ^1 of 10 examples saved", tostring(count)),
+			LrColor(0.8, 0.4, 0.1),
+			count
+	end
+	return LOC("$$$/LrGeniusAI/Training/Status/ColdStart=Not started — save some edited photos to begin"),
+		LrColor(0.7, 0.7, 0.7),
+		count
 end
 
-local function buildModelItems()
-	local items = {}
-	local openaiKey = (prefs and not Util.nilOrEmpty(prefs.chatgptApiKey)) and prefs.chatgptApiKey or nil
-	local geminiKey = (prefs and not Util.nilOrEmpty(prefs.geminiApiKey)) and prefs.geminiApiKey or nil
-	local modelsResp = SearchIndexAPI.getModels(openaiKey, geminiKey)
-	if modelsResp and modelsResp.models then
-		for provider, modelList in pairs(modelsResp.models) do
-			for _, model in ipairs(modelList) do
-				table.insert(items, {
-					title = provider .. ": " .. model,
-					value = provider .. "::" .. model,
-				})
-			end
-		end
-	end
-	table.sort(items, function(a, b)
-		return a.title < b.title
+-- `catalog:createVirtualCopies` copies whatever is *selected* — it takes no
+-- photo argument — so the photo has to be selected first, and the selection has
+-- to be verified before anything is created. A photo that is not in the current
+-- source cannot be selected, and copying whatever was selected instead would be
+-- much worse than not copying at all.
+--
+-- Selecting works without a write gate (`focusPhotoInDevelop` in
+-- `DevelopEditManager` does the same); only creating the copy needs one. The
+-- switch to All Photographs is the same fallback that function uses, for the
+-- same reason: the scope may reach outside the folder or collection on screen.
+local function selectOnly(catalog, photo)
+	local ok = LrTasks.pcall(function()
+		catalog:setSelectedPhotos(photo, { photo })
 	end)
-	return items
+	if not ok then
+		return false
+	end
+	local selected = catalog:getTargetPhotos()
+	return type(selected) == "table" and #selected == 1 and selected[1] == photo
 end
 
-local function getEditIntentPresetInstruction(presetValue)
-	for _, preset in ipairs(Defaults.editIntentPresets or {}) do
-		if preset.value == presetValue then
-			return preset.instruction
+local function createVirtualCopyFor(photo)
+	local catalog = LrApplication.activeCatalog()
+
+	if not selectOnly(catalog, photo) then
+		local switched = LrTasks.pcall(function()
+			catalog:setActiveSources({ catalog.kAllPhotos })
+			LrTasks.sleep(0.2)
+		end)
+		if not switched or not selectOnly(catalog, photo) then
+			return nil, "the photo could not be selected in Lightroom"
 		end
 	end
-	return nil
-end
 
-local function hasEditIntentPresetValue(presetValue)
-	for _, preset in ipairs(Defaults.editIntentPresets or {}) do
-		if preset.value == presetValue then
-			return true
-		end
+	local copies
+	local ok, err = LrTasks.pcall(function()
+		catalog:withWriteAccessDo(
+			LOC("$$$/LrGeniusAI/TaskAiEditPhotos/VirtualCopyUndo=Create virtual copy for AI edit"),
+			function()
+				copies = catalog:createVirtualCopies(LOC("$$$/LrGeniusAI/TaskAiEditPhotos/VirtualCopyName=AI Edit"))
+			end,
+			Defaults.catalogWriteAccessOptions
+		)
+	end)
+	if not ok then
+		return nil, tostring(err)
 	end
-	return false
-end
-
-local function buildEditIntentPresetItems()
-	local items = {}
-	for _, preset in ipairs(Defaults.editIntentPresets or {}) do
-		table.insert(items, { title = preset.title, value = preset.value })
+	if type(copies) ~= "table" or #copies ~= 1 then
+		return nil, "Lightroom did not return exactly one virtual copy"
 	end
-	if #items == 0 then
-		table.insert(items, {
-			title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/Custom=Custom"),
-			value = Defaults.editIntentCustomValue or "custom",
-		})
+	if copies[1]:getRawMetadata("masterPhoto") ~= photo then
+		return nil, "Lightroom copied a different photo"
 	end
-	return items
+	return copies[1], nil
 end
 
-local function hasCompositionModeValue(value)
-	for _, item in ipairs(Defaults.compositionModes or {}) do
-		if item.value == value then
-			return true
-		end
-	end
-	return false
-end
-
-local function showPhotoInstructionDialog(ctx, photo)
-	local f = LrView.osFactory()
-	local bind = LrView.bind
-
-	local props = LrBinding.makePropertyTable(ctx)
-	props.photoContextData = photo:getPropertyForPlugin(_PLUGIN, "photoContext") or ""
-	props.skipFromHere = false
-
-	local dialogView = f:column({
-		bind_to_object = props,
-		spacing = f:control_spacing(),
-		f:row({
-			f:static_text({
-				title = photo:getFormattedMetadata("fileName") or "Photo",
-			}),
-		}),
-		f:row({
-			alignment = "center",
-			f:catalog_photo({
-				photo = photo,
-				width = 300,
-			}),
-		}),
-		f:row({
-			f:static_text({
-				title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/PerPhotoInstructions=Per-photo edit instructions"),
-			}),
-		}),
-		f:row({
-			f:edit_field({
-				value = bind("photoContextData"),
-				width_in_chars = 50,
-				height_in_lines = 10,
-			}),
-		}),
-		f:row({
-			f:checkbox({
-				value = bind("skipFromHere"),
-			}),
-			f:static_text({
-				title = LOC(
-					"$$$/LrGeniusAI/TaskAiEditPhotos/UseForFollowing=Use these instructions for all following photos."
-				),
-			}),
-		}),
-	})
-
-	local result = LrDialogs.presentModalDialog({
-		title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/PhotoSpecificInstructions=Photo-specific edit instructions"),
-		contents = dialogView,
-		actionVerb = LOC("$$$/LrGeniusAI/common/Continue=Continue"),
-	})
-
-	return result, props.photoContextData, props.skipFromHere
-end
-
-local function showAiEditDialog(ctx)
+local function showAiEditDialog(ctx, stats)
 	log:trace("showAiEditDialog: start")
 	local f = LrView.osFactory()
 	local bind = LrView.bind
@@ -144,115 +120,10 @@ local function showAiEditDialog(ctx)
 	local props = LrBinding.makePropertyTable(ctx)
 
 	props.scope = prefs.aiEditScope or "selected"
-	props.modelKey = prefs.aiEditModelKey or prefs.modelKey
-	props.temperature = prefs.aiEditTemperature or prefs.temperature or 0.1
-	props.language = prefs.aiEditLanguage or prefs.generateLanguage or "English"
-	props.styleStrength = prefs.aiEditStyleStrength or Defaults.defaultEditStyleStrength or 0.5
-	props.editIntentPresetItems = buildEditIntentPresetItems()
-	props.customEditIntentText = prefs.aiEditIntentCustomText or prefs.aiEditIntent or Defaults.defaultEditIntent
-	if type(props.customEditIntentText) ~= "string" or props.customEditIntentText == "" then
-		props.customEditIntentText = Defaults.defaultEditIntent
-	end
-	props.editIntentPreset = prefs.aiEditIntentPreset
-		or Defaults.defaultEditIntentPresetValue
-		or (Defaults.editIntentCustomValue or "custom")
-	if not hasEditIntentPresetValue(props.editIntentPreset) then
-		props.editIntentPreset = Defaults.editIntentCustomValue or "custom"
-	end
-	props.isCustomEditIntent = props.editIntentPreset == (Defaults.editIntentCustomValue or "custom")
-	if props.isCustomEditIntent then
-		props.editIntent = props.customEditIntentText
-	else
-		props.editIntent = getEditIntentPresetInstruction(props.editIntentPreset) or Defaults.defaultEditIntent
-	end
 	props.reviewBeforeApply = prefs.aiEditReviewBeforeApply ~= false
-	props.applyMasks = prefs.aiEditApplyMasks ~= false
-	props.adjustWhiteBalance = prefs.aiEditAdjustWhiteBalance ~= false
-	props.adjustBasicTone = prefs.aiEditAdjustBasicTone ~= false
-	props.adjustPresence = prefs.aiEditAdjustPresence ~= false
-	props.adjustColorMix = prefs.aiEditAdjustColorMix ~= false
-	props.doColorGrading = prefs.aiEditDoColorGrading ~= false
-	props.useToneCurve = prefs.aiEditUseToneCurve ~= false
-	props.usePointCurve = prefs.aiEditUsePointCurve ~= false
-	props.adjustDetail = prefs.aiEditAdjustDetail ~= false
-	props.adjustEffects = prefs.aiEditAdjustEffects ~= false
-	props.adjustLensCorrections = prefs.aiEditAdjustLensCorrections ~= false
-	props.allowAutoCrop = prefs.aiEditAllowAutoCrop ~= false
-	props.compositionModes = Defaults.compositionModes or {}
-	props.compositionMode = prefs.aiEditCompositionMode or Defaults.defaultCompositionMode or "subtle"
-	if not hasCompositionModeValue(props.compositionMode) then
-		props.compositionMode = Defaults.defaultCompositionMode or "subtle"
-	end
-	props.submitKeywords = prefs.aiEditSubmitKeywords ~= false
-	props.submitFolderName = prefs.aiEditSubmitFolderName or false
-	props.showPhotoContextDialog = prefs.aiEditShowPhotoContextDialog ~= false
-	props.useTrainingStyle = prefs.aiEditUseTrainingStyle ~= false
-	props.promptTitles = {}
-	props.prompts = safePromptTable(prefs.editPrompts or { Default = Defaults.defaultEditSystemInstruction })
-	log:trace("showAiEditDialog: prompt source type=" .. tostring(type(props.prompts)))
-	props.prompt = prefs.editPrompt or Defaults.defaultEditPromptName
-	if type(props.prompt) ~= "string" or props.prompt == "" then
-		props.prompt = Defaults.defaultEditPromptName
-	end
-	props.selectedPrompt = props.prompts[props.prompt]
-	if type(props.selectedPrompt) ~= "string" or props.selectedPrompt == "" then
-		props.prompt = Defaults.defaultEditPromptName
-		props.selectedPrompt = props.prompts[props.prompt] or Defaults.defaultEditSystemInstruction
-	end
+	props.createVirtualCopy = prefs.aiEditCreateVirtualCopy == true
 
-	for title, prompt in pairs(props.prompts) do
-		if type(title) == "string" and title ~= "" and type(prompt) == "string" then
-			table.insert(props.promptTitles, { title = title, value = title })
-		end
-	end
-	log:trace("showAiEditDialog: promptTitles count=" .. tostring(#props.promptTitles))
-	if #props.promptTitles == 0 then
-		props.prompts = { Default = Defaults.defaultEditSystemInstruction }
-		props.prompt = Defaults.defaultEditPromptName
-		props.selectedPrompt = Defaults.defaultEditSystemInstruction
-		table.insert(
-			props.promptTitles,
-			{ title = Defaults.defaultEditPromptName, value = Defaults.defaultEditPromptName }
-		)
-	end
-	table.sort(props.promptTitles, function(a, b)
-		return a.title < b.title
-	end)
-
-	props:addObserver("prompt", function(properties, key, newValue)
-		properties.selectedPrompt = properties.prompts[newValue]
-	end)
-	props:addObserver("selectedPrompt", function(properties, key, newValue)
-		properties.prompts[properties.prompt] = newValue
-	end)
-	props:addObserver("editIntentPreset", function(properties, key, newValue)
-		local customValue = Defaults.editIntentCustomValue or "custom"
-		properties.isCustomEditIntent = newValue == customValue
-		if properties.isCustomEditIntent then
-			properties.editIntent = properties.customEditIntentText or Defaults.defaultEditIntent
-		else
-			properties.editIntent = getEditIntentPresetInstruction(newValue) or Defaults.defaultEditIntent
-		end
-	end)
-	props:addObserver("editIntent", function(properties, key, newValue)
-		if properties.isCustomEditIntent then
-			properties.customEditIntentText = newValue
-		end
-	end)
-
-	local modelItems = buildModelItems()
-	log:trace("showAiEditDialog: modelItems count=" .. tostring(#modelItems))
-	if #modelItems == 0 then
-		table.insert(modelItems, { title = "chatgpt: gpt-4.1", value = "chatgpt::gpt-4.1" })
-	end
-	if not props.modelKey or props.modelKey == "" then
-		props.modelKey = modelItems[1].value
-	end
-
-	props.promptTitleMenu = f:popup_menu({
-		items = bind("promptTitles"),
-		value = bind("prompt"),
-	})
+	local readinessText, readinessColor, trainingCount = styleReadinessDisplay(stats)
 
 	local contents = f:column({
 		bind_to_object = props,
@@ -277,137 +148,38 @@ local function showAiEditDialog(ctx)
 			}),
 		}),
 		f:group_box({
-			title = LOC("$$$/LrGeniusAI/common/AiSettings=AI Settings"),
+			title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/StyleProfile=Style profile"),
 			fill_horizontal = 1,
 			f:row({
 				f:static_text({
-					title = LOC("$$$/LrGeniusAI/common/AiModel=AI model:"),
+					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/TrainingExamples=Training examples:"),
 					width = share("labelWidth"),
 				}),
-				f:popup_menu({
-					value = bind("modelKey"),
-					items = modelItems,
-					width = 300,
+				f:static_text({
+					title = trainingCount and tostring(trainingCount) or "—",
 				}),
 			}),
 			f:row({
 				f:static_text({
-					title = LOC("$$$/LrGeniusAI/common/Temperature=Temperature:"),
+					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/StyleStatus=Status:"),
 					width = share("labelWidth"),
 				}),
-				f:slider({
-					value = bind("temperature"),
-					min = 0.0,
-					max = 0.5,
-					integral = false,
-					width = 300,
-				}),
 				f:static_text({
-					title = bind("temperature"),
-					width = 40,
+					title = readinessText,
+					text_color = readinessColor,
 				}),
 			}),
 			f:row({
 				f:static_text({
-					width = share("labelWidth"),
-					title = LOC("$$$/LrGeniusAI/common/Prompt=Prompt:"),
-				}),
-				props.promptTitleMenu,
-				f:push_button({
-					title = LOC("$$$/LrGeniusAI/common/Add=Add"),
-					action = function()
-						local ok, err = LrTasks.pcall(function()
-							PromptConfigProvider.addPrompt(props)
-						end)
-						if not ok then
-							log:error("AI Edit prompt add failed: " .. tostring(err))
-							LrDialogs.showError(
-								LOC("$$$/LrGeniusAI/PromptConfig/AddFailed=Adding prompt failed: ^1"),
-								tostring(err)
-							)
-						end
-					end,
-				}),
-				f:push_button({
-					title = LOC("$$$/LrGeniusAI/common/Delete=Delete"),
-					action = function()
-						local ok, err = LrTasks.pcall(function()
-							PromptConfigProvider.deletePrompt(props)
-						end)
-						if not ok then
-							log:error("AI Edit prompt delete failed: " .. tostring(err))
-							LrDialogs.showError(
-								LOC("$$$/LrGeniusAI/PromptConfig/DeleteFailed=Deleting prompt failed: ^1"),
-								tostring(err)
-							)
-						end
-					end,
-				}),
-			}),
-			f:row({
-				f:static_text({
-					width = share("labelWidth"),
-					title = LOC("$$$/LrGeniusAI/common/SystemInstruction=System instruction:"),
-				}),
-				f:edit_field({
-					value = bind("selectedPrompt"),
-					width_in_chars = 50,
-					height_in_lines = 4,
-				}),
-			}),
-			f:row({
-				f:static_text({
-					title = LOC("$$$/LrGeniusAI/common/SummaryLanguage=Summary language:"),
-					width = share("labelWidth"),
-				}),
-				f:combo_box({
-					value = bind("language"),
-					items = Defaults.generateLanguages,
+					title = LOC(
+						"$$$/LrGeniusAI/TaskAiEditPhotos/StyleProfileHint=Edits are built from your own saved edits — the more examples, the closer the match."
+					),
 				}),
 			}),
 		}),
 		f:group_box({
-			title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/EditInstructions=Edit Instructions"),
+			title = LOC("$$$/LrGeniusAI/common/Options=Options"),
 			fill_horizontal = 1,
-			f:row({
-				f:static_text({
-					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/OverallLook=Overall look:"),
-					width = share("labelWidth"),
-				}),
-				f:popup_menu({
-					value = bind("editIntentPreset"),
-					items = bind("editIntentPresetItems"),
-					width = 300,
-				}),
-			}),
-			f:row({
-				f:static_text({
-					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/CustomIntent=Custom intent:"),
-					width = share("labelWidth"),
-				}),
-				f:edit_field({
-					value = bind("editIntent"),
-					width_in_chars = 50,
-					enabled = bind("isCustomEditIntent"),
-				}),
-			}),
-			f:row({
-				f:static_text({
-					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/StyleStrength=Style strength:"),
-					width = share("labelWidth"),
-				}),
-				f:slider({
-					value = bind("styleStrength"),
-					min = 0.0,
-					max = 1.0,
-					integral = false,
-					width = 300,
-				}),
-				f:static_text({
-					title = bind("styleStrength"),
-					width = 40,
-				}),
-			}),
 			f:row({
 				f:checkbox({
 					value = bind("reviewBeforeApply"),
@@ -420,182 +192,12 @@ local function showAiEditDialog(ctx)
 			}),
 			f:row({
 				f:checkbox({
-					value = bind("applyMasks"),
-				}),
-				f:static_text({
-					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/AskMasks=Ask the AI for subject/sky/background masks"),
-				}),
-			}),
-			f:row({
-				f:checkbox({
-					value = bind("showPhotoContextDialog"),
+					value = bind("createVirtualCopy"),
 				}),
 				f:static_text({
 					title = LOC(
-						"$$$/LrGeniusAI/TaskAiEditPhotos/AllowPerPhoto=Allow per-photo edit instructions before generation"
+						"$$$/LrGeniusAI/TaskAiEditPhotos/CreateVirtualCopy=Apply the edit to a new virtual copy (leaves the original untouched)"
 					),
-				}),
-			}),
-		}),
-		f:group_box({
-			title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/CreativeControls=Creative Controls"),
-			fill_horizontal = 1,
-			f:row({
-				f:column({
-					spacing = f:control_spacing(),
-					f:row({
-						f:checkbox({
-							value = bind("adjustWhiteBalance"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/AdjustWB=Adjust white balance"),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("adjustBasicTone"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/TaskAiEditPhotos/AdjustBasicTone=Adjust basic tone (exposure/contrast/highlights/shadows/whites/blacks)"
-							),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("adjustPresence"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/TaskAiEditPhotos/AdjustPresence=Adjust presence (texture/clarity/dehaze)"
-							),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("adjustColorMix"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/TaskAiEditPhotos/AdjustColorMix=Adjust color mix (vibrance/saturation/HSL)"
-							),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("doColorGrading"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/DoColorGrading=Do color grading"),
-						}),
-					}),
-				}),
-				f:column({
-					spacing = f:control_spacing(),
-					f:row({
-						f:checkbox({
-							value = bind("useToneCurve"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/UseToneCurve=Use tone curve"),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("usePointCurve"),
-							enabled = bind("useToneCurve"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/UsePointCurve=Use point curve"),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("adjustDetail"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/TaskAiEditPhotos/AdjustDetail=Adjust detail (sharpening/noise reduction)"
-							),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("adjustEffects"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/TaskAiEditPhotos/AdjustEffects=Adjust effects (vignette/grain)"
-							),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("adjustLensCorrections"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/AdjustLens=Adjust lens corrections"),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("allowAutoCrop"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/AllowAutoCrop=Allow AI auto crop"),
-						}),
-					}),
-				}),
-			}),
-			f:row({
-				f:static_text({
-					title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/CompositionMode=Composition mode:"),
-					width = share("labelWidth"),
-				}),
-				f:popup_menu({
-					value = bind("compositionMode"),
-					items = bind("compositionModes"),
-					width = 300,
-				}),
-			}),
-		}),
-		f:group_box({
-			title = LOC("$$$/LrGeniusAI/common/Context=Context"),
-			fill_horizontal = 1,
-			f:row({
-				f:column({
-					spacing = f:control_spacing(),
-					f:row({
-						f:checkbox({
-							value = bind("submitKeywords"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/TaskAiEditPhotos/SendKeywords=Send existing Lightroom keywords"
-							),
-						}),
-					}),
-				}),
-				f:column({
-					spacing = f:control_spacing(),
-					f:row({
-						f:checkbox({
-							value = bind("submitFolderName"),
-						}),
-						f:static_text({
-							title = LOC("$$$/LrGeniusAI/TaskAiEditPhotos/SendFolders=Send folder names"),
-						}),
-					}),
-					f:row({
-						f:checkbox({
-							value = bind("useTrainingStyle"),
-						}),
-						f:static_text({
-							title = LOC(
-								"$$$/LrGeniusAI/Training/UseTrainingCheckbox=Apply my saved edit style (training examples)"
-							),
-						}),
-					}),
 				}),
 			}),
 		}),
@@ -613,125 +215,27 @@ local function showAiEditDialog(ctx)
 	end
 
 	prefs.aiEditScope = props.scope
-	prefs.aiEditModelKey = props.modelKey
-	prefs.aiEditTemperature = props.temperature
-	prefs.aiEditLanguage = props.language
-	prefs.aiEditStyleStrength = props.styleStrength
-	prefs.aiEditIntent = props.editIntent
-	prefs.aiEditIntentPreset = props.editIntentPreset
-	prefs.aiEditIntentCustomText = props.customEditIntentText
 	prefs.aiEditReviewBeforeApply = props.reviewBeforeApply
-	prefs.aiEditApplyMasks = props.applyMasks
-	prefs.aiEditAdjustWhiteBalance = props.adjustWhiteBalance
-	prefs.aiEditAdjustBasicTone = props.adjustBasicTone
-	prefs.aiEditAdjustPresence = props.adjustPresence
-	prefs.aiEditAdjustColorMix = props.adjustColorMix
-	prefs.aiEditDoColorGrading = props.doColorGrading
-	prefs.aiEditUseToneCurve = props.useToneCurve
-	prefs.aiEditUsePointCurve = props.usePointCurve
-	prefs.aiEditAdjustDetail = props.adjustDetail
-	prefs.aiEditAdjustEffects = props.adjustEffects
-	prefs.aiEditAdjustLensCorrections = props.adjustLensCorrections
-	prefs.aiEditAllowAutoCrop = props.allowAutoCrop
-	prefs.aiEditCompositionMode = props.compositionMode
-	prefs.aiEditSubmitKeywords = props.submitKeywords
-	prefs.aiEditSubmitFolderName = props.submitFolderName
-	prefs.aiEditShowPhotoContextDialog = props.showPhotoContextDialog
-	prefs.aiEditUseTrainingStyle = props.useTrainingStyle
-	prefs.editPrompts = props.prompts
-	prefs.editPrompt = props.prompt
+	prefs.aiEditCreateVirtualCopy = props.createVirtualCopy
 
-	local providerFromKey, modelFromKey
-	local sep = props.modelKey and string.find(props.modelKey, "::", 1, true) or nil
-	if sep then
-		providerFromKey = string.sub(props.modelKey, 1, sep - 1)
-		modelFromKey = string.sub(props.modelKey, sep + 2)
-	else
-		providerFromKey = props.modelKey
-	end
-
-	local options = {
+	return {
 		scope = props.scope,
-		provider = providerFromKey,
-		model = modelFromKey,
-		language = props.language,
-		temperature = props.temperature,
-		prompt = props.selectedPrompt,
-		edit_intent = props.editIntent,
-		style_strength = props.styleStrength,
-		include_masks = props.applyMasks,
-		adjust_white_balance = props.adjustWhiteBalance,
-		adjust_basic_tone = props.adjustBasicTone,
-		adjust_presence = props.adjustPresence,
-		adjust_color_mix = props.adjustColorMix,
-		do_color_grading = props.doColorGrading,
-		use_tone_curve = props.useToneCurve,
-		use_point_curve = props.usePointCurve,
-		adjust_detail = props.adjustDetail,
-		adjust_effects = props.adjustEffects,
-		adjust_lens_corrections = props.adjustLensCorrections,
-		allow_auto_crop = props.allowAutoCrop,
-		composition_mode = props.compositionMode,
-		applyMasks = props.applyMasks,
 		reviewBeforeApply = props.reviewBeforeApply,
-		submit_keywords = props.submitKeywords,
-		submit_folder_names = props.submitFolderName,
-		showPhotoContextDialog = props.showPhotoContextDialog,
-		use_training_style = props.useTrainingStyle ~= false,
+		createVirtualCopy = props.createVirtualCopy,
 	}
-
-	if providerFromKey == "chatgpt" then
-		if prefs and not Util.nilOrEmpty(prefs.chatgptApiKey) then
-			options.api_key = prefs.chatgptApiKey
-		else
-			LrDialogs.showError(
-				LOC(
-					"$$$/LrGeniusAI/AnalyzeAndIndex/MissingChatGPTAPIKey=ChatGPT API key is not configured. Please set it in the plugin preferences."
-				)
-			)
-			return nil
-		end
-	elseif providerFromKey == "gemini" then
-		if prefs and not Util.nilOrEmpty(prefs.geminiApiKey) then
-			options.api_key = prefs.geminiApiKey
-		else
-			LrDialogs.showError(
-				LOC(
-					"$$$/LrGeniusAI/AnalyzeAndIndex/MissingGeminiAPIKey=Gemini API key is not configured. Please set it in the plugin preferences."
-				)
-			)
-			return nil
-		end
-	end
-	return options
 end
 
-local function enrichPhotoOptions(photo, baseOptions, userContext)
+local function enrichPhotoOptions(photo, baseOptions)
 	log:trace("enrichPhotoOptions: start for " .. tostring(photo and photo:getFormattedMetadata("fileName") or "nil"))
 	local photoOptions = copyOptions(baseOptions)
-	if photoOptions.submit_keywords then
-		local keywords = photo:getFormattedMetadata("keywordTagsForExport")
-		if keywords then
-			if type(keywords) == "string" then
-				photoOptions.existing_keywords = Util.string_split(keywords, ",")
-			else
-				photoOptions.existing_keywords = keywords
-			end
-		end
-	end
-	if photoOptions.submit_folder_names then
-		local originalFilePath = photo:getRawMetadata("path")
-		if originalFilePath then
-			photoOptions.folder_names = Util.getStringsFromRelativePath(originalFilePath)
-		end
-	end
+
 	local datetime = photo:getRawMetadata("dateTime")
 	if datetime ~= nil and type(datetime) == "number" then
 		photoOptions.date_time = LrDate.timeToW3CDate(datetime)
-		photoOptions.capture_time = datetime -- Unix timestamp for style engine
+		photoOptions.capture_time = datetime -- feeds the style engine's time-of-day bucket
 	end
 
-	-- Add EXIF fields for style engine matching using standardized utility.
+	-- EXIF context for style matching (focal length, capture time, camera, ISO).
 	local exif = Util.getPhotoExif(photo)
 	for k, v in pairs(exif) do
 		photoOptions[k] = v
@@ -740,10 +244,11 @@ local function enrichPhotoOptions(photo, baseOptions, userContext)
 	-- The backend receives a normalised JPEG, so the original encoding is no
 	-- longer visible in the bytes it gets. Lightroom knows, and the edit
 	-- guardrails need it: blown highlights are recoverable on a raw file and
-	-- gone on a rendered one, which changes how far the white point may go.
+	-- gone on a rendered one, which changes how far the white point may go. It
+	-- also decides whether a training example's Kelvin temperature may be
+	-- carried over at all.
 	photoOptions.is_raw = Util.isRawPhoto(photo)
 
-	photoOptions.user_context = userContext or photo:getPropertyForPlugin(_PLUGIN, "photoContext") or ""
 	return photoOptions
 end
 
@@ -752,13 +257,37 @@ LrTasks.startAsyncTask(function()
 		LrDialogs.attachErrorDialogToFunctionContext(ctx)
 		log:info("AI Edit task started")
 
-		-- Check server connection and health (ensure AI providers are configured)
-		if not Util.waitForServerDialog({ requireProviders = true }) then
+		-- No `requireProviders` any more: the style engine needs no LLM
+		-- provider, so a missing API key must not block this task.
+		if not Util.waitForServerDialog() then
 			log:warn("AI Edit task aborted: backend server unavailable")
 			return
 		end
 
-		local options = showAiEditDialog(ctx)
+		-- A backend that could not answer is not a backend reporting zero: fall
+		-- through and let the per-photo errors say what actually went wrong,
+		-- rather than telling the user their style profile is empty when it may
+		-- be full.
+		local stats, statsErr = SearchIndexAPI.getTrainingStats()
+		if not stats then
+			log:warn("AI Edit could not read the style profile stats: " .. tostring(statsErr))
+		end
+		local trainingCount = (stats and tonumber(stats.count)) or 0
+		if stats and trainingCount < MIN_TRAINING_EXAMPLES then
+			log:warn("AI Edit task aborted: only " .. tostring(trainingCount) .. " training example(s) available")
+			LrDialogs.message(
+				LOC("$$$/LrGeniusAI/TaskAiEditPhotos/NoStyleProfileTitle=Style profile not ready"),
+				LOC(
+					"$$$/LrGeniusAI/TaskAiEditPhotos/NoStyleProfile=AI Edit builds every recipe from your own saved edits, and it needs at least ^1 training examples to do that. You currently have ^2.\n\nEdit a handful of photos the way you like them, then run Library → Plug-in Extras → Save Edits as AI Training Examples and start AI Edit again.",
+					tostring(MIN_TRAINING_EXAMPLES),
+					tostring(trainingCount)
+				),
+				"info"
+			)
+			return
+		end
+
+		local options = showAiEditDialog(ctx, stats)
 		if not options then
 			log:info("AI Edit task canceled by user in options dialog")
 			return
@@ -766,40 +295,10 @@ LrTasks.startAsyncTask(function()
 		log:trace(
 			"AI Edit options selected: scope="
 				.. tostring(options.scope)
-				.. " provider="
-				.. tostring(options.provider)
-				.. " model="
-				.. tostring(options.model)
 				.. " review="
 				.. tostring(options.reviewBeforeApply)
-				.. " styleStrength="
-				.. tostring(options.style_strength)
-				.. " masks="
-				.. tostring(options.applyMasks)
-				.. " wb="
-				.. tostring(options.adjust_white_balance)
-				.. " basicTone="
-				.. tostring(options.adjust_basic_tone)
-				.. " presence="
-				.. tostring(options.adjust_presence)
-				.. " colorMix="
-				.. tostring(options.adjust_color_mix)
-				.. " grading="
-				.. tostring(options.do_color_grading)
-				.. " toneCurve="
-				.. tostring(options.use_tone_curve)
-				.. " pointCurve="
-				.. tostring(options.use_point_curve)
-				.. " detail="
-				.. tostring(options.adjust_detail)
-				.. " effects="
-				.. tostring(options.adjust_effects)
-				.. " lens="
-				.. tostring(options.adjust_lens_corrections)
-				.. " crop="
-				.. tostring(options.allow_auto_crop)
-				.. " composition="
-				.. tostring(options.composition_mode)
+				.. " virtualCopy="
+				.. tostring(options.createVirtualCopy)
 		)
 
 		local photos = PhotoSelector.getPhotosInScope(options.scope)
@@ -824,8 +323,6 @@ LrTasks.startAsyncTask(function()
 		local errorCount = 0
 		local errorMessages = {}
 		local backendWarnings = {}
-		local reuseContext = false
-		local sharedContext = ""
 
 		for index, photo in ipairs(photos) do
 			if progressScope:isCanceled() then
@@ -839,29 +336,7 @@ LrTasks.startAsyncTask(function()
 			progressScope:setPortionComplete(index - 1, #photos)
 			local continueProcessing = true
 
-			local userContext = photo:getPropertyForPlugin(_PLUGIN, "photoContext") or ""
-			log:trace(
-				"AI Edit photo loop start: index="
-					.. tostring(index)
-					.. " photo="
-					.. tostring(fileName)
-					.. " initialContextLen="
-					.. tostring(type(userContext) == "string" and #userContext or 0)
-			)
-			if options.showPhotoContextDialog then
-				if not reuseContext then
-					local result
-					result, sharedContext, reuseContext = showPhotoInstructionDialog(ctx, photo)
-					if result == "cancel" then
-						progressScope:done()
-						return
-					end
-				end
-				userContext = sharedContext or ""
-				LrApplication.activeCatalog():withPrivateWriteAccessDo(function()
-					photo:setPropertyForPlugin(_PLUGIN, "photoContext", userContext)
-				end, Defaults.catalogWriteAccessOptions)
-			end
+			log:trace("AI Edit photo loop start: index=" .. tostring(index) .. " photo=" .. tostring(fileName))
 
 			local photoId, photoIdErr = SearchIndexAPI.getPhotoIdForPhoto(photo)
 			if not photoId then
@@ -875,7 +350,7 @@ LrTasks.startAsyncTask(function()
 
 			local response = nil
 			if continueProcessing then
-				local photoOptions = enrichPhotoOptions(photo, options, userContext)
+				local photoOptions = enrichPhotoOptions(photo, options)
 				local exportedPath = SearchIndexAPI.exportPhotoForIndexing(photo)
 				if not exportedPath then
 					log:error("Failed to export photo for AI edit generation: " .. fileName)
@@ -887,15 +362,7 @@ LrTasks.startAsyncTask(function()
 				if continueProcessing then
 					log:trace("AI Edit calling API for " .. fileName .. " exportedPath=" .. tostring(exportedPath))
 					local ok, apiOk, apiResponse = LrTasks.pcall(function()
-						if options.use_training_style then
-							-- Route to the new Style Engine (LLM-free matching)
-							-- Fallback to LLM is handled server-side if use_llm_fallback is true
-							photoOptions.use_llm_fallback = true
-							return SearchIndexAPI.styleEdit(photoId, exportedPath, photoOptions)
-						else
-							-- Regular LLM edit (prompt-driven)
-							return SearchIndexAPI.generateEditRecipePhoto(photoId, exportedPath, photoOptions)
-						end
+						return SearchIndexAPI.styleEdit(photoId, exportedPath, photoOptions)
 					end)
 					LrTasks.pcall(function()
 						if exportedPath and LrFileUtils.exists(exportedPath) then
@@ -950,20 +417,9 @@ LrTasks.startAsyncTask(function()
 			end
 
 			if continueProcessing and response then
-				log:trace("Persisting generated recipe for " .. fileName)
-				local okPersist, persistErr = LrTasks.pcall(function()
-					DevelopEditManager.persistEditRecipe(photo, response, nil, "generated")
-				end)
-				if not okPersist then
-					log:error("Persist generated recipe threw for " .. fileName .. ": " .. tostring(persistErr))
-					table.insert(errorMessages, fileName .. ": could not persist recipe: " .. tostring(persistErr))
-					errorCount = errorCount + 1
-					continueProcessing = false
-				end
-
 				local applyOptions = {
 					applyGlobal = true,
-					applyMasks = options.applyMasks,
+					applyMasks = true,
 				}
 
 				if options.reviewBeforeApply then
@@ -983,6 +439,41 @@ LrTasks.startAsyncTask(function()
 					continueProcessing = false
 				end
 
+				-- Only now, once the edit is actually going to be applied: a
+				-- photo the user skipped in the review dialog must not leave a
+				-- virtual copy behind.
+				local target = photo
+				if continueProcessing and options.createVirtualCopy then
+					local copy, copyErr = createVirtualCopyFor(photo)
+					if copy then
+						target = copy
+						log:trace("Created virtual copy for " .. fileName)
+					else
+						-- Deliberately not falling back to the original: the
+						-- user asked for it to stay untouched.
+						log:error("Failed to create virtual copy for " .. fileName .. ": " .. tostring(copyErr))
+						table.insert(
+							errorMessages,
+							fileName .. ": could not create virtual copy: " .. tostring(copyErr)
+						)
+						errorCount = errorCount + 1
+						continueProcessing = false
+					end
+				end
+
+				if continueProcessing then
+					log:trace("Persisting generated recipe for " .. fileName)
+					local okPersist, persistErr = LrTasks.pcall(function()
+						DevelopEditManager.persistEditRecipe(target, response, nil, "generated")
+					end)
+					if not okPersist then
+						log:error("Persist generated recipe threw for " .. fileName .. ": " .. tostring(persistErr))
+						table.insert(errorMessages, fileName .. ": could not persist recipe: " .. tostring(persistErr))
+						errorCount = errorCount + 1
+						continueProcessing = false
+					end
+				end
+
 				if continueProcessing then
 					log:trace(
 						"Applying recipe for "
@@ -992,7 +483,7 @@ LrTasks.startAsyncTask(function()
 							.. " applyMasks="
 							.. tostring(applyOptions.applyMasks)
 					)
-					local applied, warnings = DevelopEditManager.applyRecipe(photo, response, applyOptions)
+					local applied, warnings = DevelopEditManager.applyRecipe(target, response, applyOptions)
 					log:trace(
 						"Apply result for "
 							.. fileName

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -43,9 +43,10 @@ The plugin is designed to work with local and cloud providers, while keeping Lig
 
 ### AI Develop Edits
 
-- Generate a Develop recipe per photo and apply it non-destructively
-- Choose an overall look, or let the backend match the photo against edits you
-  saved yourself
+- Generate a Develop recipe per photo and apply it non-destructively, either to
+  the photo itself or to a virtual copy
+- No LLM involved: the backend matches the photo against the edits you saved
+  yourself and interpolates theirs
 - Recipes are constrained to what the frame can take: the backend measures the
   image and caps contrast, clarity, shadow lift and whites accordingly, and
   reports why
@@ -53,7 +54,7 @@ The plugin is designed to work with local and cloud providers, while keeping Lig
 ### Style Training
 
 - Save your own Develop settings as labeled training examples
-- Used both as few-shot context for the LLM and by the LLM-free Style Engine
+- The sole input to AI Develop Edits, which needs at least five of them
 
 ### Keyword Dedup & Declutter
 


### PR DESCRIPTION
## Summary

AI Edit now runs exclusively on the style engine, matching photos against user-saved training examples instead of calling language models. The LLM edit path (`/edit`, provider/model selection, prompts, intent presets, creative controls, per-photo instructions) has been removed from the plugin entirely.

## Key Changes

**Plugin (`TaskAiEditPhotos.lua`)**
- Removed all LLM-related UI: model dropdown, temperature slider, prompt management, intent presets, creative controls (white balance, tone curve, masks, etc.), composition modes, context submission options
- Added style profile readiness display showing training example count and status (cold start → warming up → limited → active)
- Enforced minimum training example threshold (5 examples); task aborts with user-friendly message if below threshold
- Simplified dialog to show only scope selection, review-before-apply toggle, and virtual copy option
- Removed per-photo instruction dialog and all user context handling
- Changed API call from `generateEditRecipePhoto` (LLM) to `styleEdit` (style engine only)
- Added `createVirtualCopyFor()` function to safely create virtual copies with proper selection verification
- Removed model/provider/API key validation logic
- Simplified `enrichPhotoOptions()` to remove keywords, folder names, and user context; kept only EXIF and file type info needed by style engine

**Backend API wrapper (`APISearchIndex.lua`)**
- Added comment documenting that `generateEditRecipePhoto` is no longer called by any task (kept for backward compatibility)
- Updated `styleEdit` call to remove LLM fallback option

**Documentation**
- Rewrote `Help-AI-Edit.md` to explain style engine matching algorithm (visual similarity 50%, exposure 25%, scene tags 15%, time of day 10%)
- Updated training example requirements and readiness levels
- Removed all references to model selection, prompts, style presets, creative controls
- Clarified that recipes come from user's own edits, not language models
- Updated `Help-Train-From-Edits.md` to emphasize training examples are the entire input to AI Edit, not optional context
- Updated troubleshooting, FAQ, performance tips, and backend API docs to reflect style-engine-only approach
- Removed references to local/cloud model selection in getting started and plugin guide

## Implementation Details

- Minimum training examples threshold (5) mirrors `MIN_TRAINING_EXAMPLES` in `server-rs/crates/lrg-analysis/src/style_engine.rs`
- Style readiness display reuses localization keys from plugin manager's Style Profile block to prevent drift
- Virtual copy creation includes fallback to All Photographs scope if photo cannot be selected in current source
- No API key validation needed; task works with all cloud providers disabled
- Backend still serves `/edit` endpoint and `generateEditRecipePhoto` wrapper for potential future use, but plugin no longer reaches either

https://claude.ai/code/session_0113aRuzznjG1xrdVKoXDDWZ