### PR TITLE
Docs: catch README and the wiki up with AI Edit and species

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 ## ✨ Core Features
 
 - **🤖 AI-Powered Tagging & Describing:** Uses advanced LLMs to accurately recognize image content, generate metadata, and provide detailed descriptions of your photos.
-- **🎛️ AI Lightroom Edit (Develop) *(beta)*:** Generates a structured Lightroom edit recipe per photo (global adjustments and optional masks) and can apply it directly in Develop mode. Includes per-photo review, style presets, style strength, composition/crop mode, and per-photo instruction overrides.
+- **🎛️ AI Lightroom Edit (Develop) *(beta)*:** Generates a Lightroom edit recipe per photo and applies it in Develop, either to the photo itself or to a new virtual copy. No language model is involved: the recipe is interpolated from the edits you saved yourself (see *Style Training*), so at least five training examples are required. Per-photo review is on by default.
 - **🔍 Semantic Free-Text Search (Advanced Search):** Find images naturally through descriptive queries (e.g., *"Red sports car parked in front of a garage"* or *"Sunset over the mountains"*). LrGeniusAI automatically creates a relevance-sorted Collection in Lightroom based on your prompt.
 - **📸 Image Culling *(beta)*:** Group similar photos into bursts or near-duplicate stacks, automatically pick the strongest frames, and create Lightroom collections for picks, alternates, reject candidates, and optional duplicates.
 - **👥 People & Faces:** Detect and cluster faces, assign names to persons, browse person collections, and find similar faces across your catalog.
+- **🦋 Species Identification (on-device):** Identify animals, plants and fungi down to the species with **BioCLIP 2**, running entirely on your machine — no LLM, so no invented binomials. Results land in searchable metadata fields (kingdom → species) and, optionally, as a keyword branch under `Species`. An uncertain call stops at the rank it is sure of rather than guessing. Enable it in *Analyze & Index Photos* after downloading the model in the Plug-in Manager.
 - **🔎 Find Similar Images:** Find near-duplicate or visually similar photos for any selected image using perceptual hash or semantic CLIP comparison.
 - **🏠 Built-In Local AI (no external app):** The backend runs vision models itself, using whichever engine suits the platform — **MLX** on macOS (Apple silicon, via a small Metal helper process) and **llama.cpp** in-process on Windows (GGUF, Vulkan). Pick a model in the Plug-in Manager, click *Download*, and analysis runs entirely on your machine. Models you already have in LM Studio (or the Hugging Face cache) are picked up without a second copy.
 - **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI** and **Google Gemini**. (~~**Vertex AI**~~ — *removed*, see below.)
@@ -51,7 +52,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
    - Optional troubleshooting: if you want to start it manually, run `lrgenius-server/lrgenius-server.cmd` on Windows or `lrgenius-server/lrgenius-server` on macOS.
 4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** section offers a curated list of vision models (Gemma 4, Ministral 3, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. The section shows the engine your platform ships: **MLX** on macOS, **llama.cpp** on Windows. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
 5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
-   - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
+   - **Analyze & Index Photos...** — AI tagging, descriptions, search index, faces, and optional species identification
    - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits learned from your own edits
    - **Advanced Search...** — semantic free-text search
    - **Cull Similar Photos...** *(beta)* — burst grouping and auto-ranking
@@ -84,6 +85,7 @@ This project is built on the belief that AI tooling for creatives should remain 
 - **Backend / Server:** `geniusai-server` — Rust (axum) for deterministic memory behavior
 - **AI & Embedding:** SigLIP2 via ONNX Runtime (`ort` crate)
 - **Identity & Faces:** InsightFace (ONNX)
+- **Species:** BioCLIP 2 (ONNX) with a pruned TreeOfLife taxonomy head
 - **Local Inference:** an MLX Swift helper (`lrgenius-mlx`) on macOS; llama.cpp compiled into the backend (Vulkan / CPU) on Windows
 - **Database:** LanceDB
 - **Supported Interfaces:** built-in MLX (macOS), built-in llama.cpp (Windows), Google Gemini, ChatGPT/OpenAI, Ollama, LM-Studio (~~Vertex AI~~ — *removed*)
@@ -104,6 +106,6 @@ Developed with a passion for photography and IT by:
 - **Community** – *Special thanks to all contributors and testers for your valuable input and support.*
 - **Various AI agents** - *For the great support in developing this project.*
 
-This project leverages many incredible open-source libraries, including **InsightFace**, **ONNX Runtime**, **LanceDB**, **llama.cpp**, and **MLX / mlx-swift-lm**. 
+This project leverages many incredible open-source libraries and models, including **InsightFace**, **BioCLIP 2 / TreeOfLife-200M**, **OpenCLIP**, **ONNX Runtime**, **LanceDB**, **llama.cpp**, and **MLX / mlx-swift-lm**. See the [Credits wiki page](https://github.com/LrGenius/LrGeniusAI/wiki/Credits) for the full list and licences. 
 
 A huge thank you to the open-source community and the developers of the underlying AI frameworks that make this integration possible!

--- a/docs/wiki/Dev-Project-README.md
+++ b/docs/wiki/Dev-Project-README.md
@@ -28,10 +28,11 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
 ## ✨ Core Features
 
 - **🤖 AI-Powered Tagging & Describing:** Uses advanced LLMs to accurately recognize image content, generate metadata, and provide detailed descriptions of your photos.
-- **🎛️ AI Lightroom Edit (Develop) *(beta)*:** Generates a structured Lightroom edit recipe per photo (global adjustments and optional masks) and can apply it directly in Develop mode. Includes per-photo review, style presets, style strength, composition/crop mode, and per-photo instruction overrides.
+- **🎛️ AI Lightroom Edit (Develop) *(beta)*:** Generates a Lightroom edit recipe per photo and applies it in Develop, either to the photo itself or to a new virtual copy. No language model is involved: the recipe is interpolated from the edits you saved yourself (see *Style Training*), so at least five training examples are required. Per-photo review is on by default.
 - **🔍 Semantic Free-Text Search (Advanced Search):** Find images naturally through descriptive queries (e.g., *"Red sports car parked in front of a garage"* or *"Sunset over the mountains"*). LrGeniusAI automatically creates a relevance-sorted Collection in Lightroom based on your prompt.
 - **📸 Image Culling *(beta)*:** Group similar photos into bursts or near-duplicate stacks, automatically pick the strongest frames, and create Lightroom collections for picks, alternates, reject candidates, and optional duplicates.
 - **👥 People & Faces:** Detect and cluster faces, assign names to persons, browse person collections, and find similar faces across your catalog.
+- **🦋 Species Identification (on-device):** Identify animals, plants and fungi down to the species with **BioCLIP 2**, running entirely on your machine — no LLM, so no invented binomials. Results land in searchable metadata fields (kingdom → species) and, optionally, as a keyword branch under `Species`. An uncertain call stops at the rank it is sure of rather than guessing. Enable it in *Analyze & Index Photos* after downloading the model in the Plug-in Manager.
 - **🔎 Find Similar Images:** Find near-duplicate or visually similar photos for any selected image using perceptual hash or semantic CLIP comparison.
 - **🏠 Built-In Local AI (no external app):** The backend runs vision models itself, using whichever engine suits the platform — **MLX** on macOS (Apple silicon, via a small Metal helper process) and **llama.cpp** in-process on Windows (GGUF, Vulkan). Pick a model in the Plug-in Manager, click *Download*, and analysis runs entirely on your machine. Models you already have in LM Studio (or the Hugging Face cache) are picked up without a second copy.
 - **☁️ Local & Cloud Models:** Also supports local AI models via **Ollama** and **LM Studio**, as well as integration with cloud providers like **ChatGPT/OpenAI** and **Google Gemini**. (~~**Vertex AI**~~ — *removed*, see below.)
@@ -55,7 +56,7 @@ Whether you prefer running local models to ensure maximum privacy or want to lev
    - Optional troubleshooting: if you want to start it manually, run `lrgenius-server/lrgenius-server.cmd` on Windows or `lrgenius-server/lrgenius-server` on macOS.
 4. **Pick an AI model.** Either enter a cloud API key in the **Plug-in Manager**, or stay fully local: the **Local AI Model** section offers a curated list of vision models (Gemma 4, Ministral 3, Qwen3-VL, Qwen2.5-VL) — choose one and click *Download*. The section shows the engine your platform ships: **MLX** on macOS, **llama.cpp** on Windows. See [Local AI Models](https://github.com/LrGenius/LrGeniusAI/wiki/Help-Local-AI-Models).
 5. Select photos in the library and choose one of the AI actions from **Library -> Plug-in Extras**:
-   - **Analyze & Index Photos...** — AI tagging, descriptions, and search index
+   - **Analyze & Index Photos...** — AI tagging, descriptions, search index, faces, and optional species identification
    - **AI Edit Photos...** *(beta)* — generate and apply Lightroom develop edits learned from your own edits
    - **Advanced Search...** — semantic free-text search
    - **Cull Similar Photos...** *(beta)* — burst grouping and auto-ranking
@@ -88,6 +89,7 @@ This project is built on the belief that AI tooling for creatives should remain 
 - **Backend / Server:** `geniusai-server` — Rust (axum) for deterministic memory behavior
 - **AI & Embedding:** SigLIP2 via ONNX Runtime (`ort` crate)
 - **Identity & Faces:** InsightFace (ONNX)
+- **Species:** BioCLIP 2 (ONNX) with a pruned TreeOfLife taxonomy head
 - **Local Inference:** an MLX Swift helper (`lrgenius-mlx`) on macOS; llama.cpp compiled into the backend (Vulkan / CPU) on Windows
 - **Database:** LanceDB
 - **Supported Interfaces:** built-in MLX (macOS), built-in llama.cpp (Windows), Google Gemini, ChatGPT/OpenAI, Ollama, LM-Studio (~~Vertex AI~~ — *removed*)
@@ -108,6 +110,6 @@ Developed with a passion for photography and IT by:
 - **Community** – *Special thanks to all contributors and testers for your valuable input and support.*
 - **Various AI agents** - *For the great support in developing this project.*
 
-This project leverages many incredible open-source libraries, including **InsightFace**, **ONNX Runtime**, **LanceDB**, **llama.cpp**, and **MLX / mlx-swift-lm**. 
+This project leverages many incredible open-source libraries and models, including **InsightFace**, **BioCLIP 2 / TreeOfLife-200M**, **OpenCLIP**, **ONNX Runtime**, **LanceDB**, **llama.cpp**, and **MLX / mlx-swift-lm**. See the [Credits wiki page](https://github.com/LrGenius/LrGeniusAI/wiki/Credits) for the full list and licences. 
 
 A huge thank you to the open-source community and the developers of the underlying AI frameworks that make this integration possible!

--- a/docs/wiki/Help-Keyword-Dedup-and-Declutter.md
+++ b/docs/wiki/Help-Keyword-Dedup-and-Declutter.md
@@ -61,7 +61,7 @@ A list of all proposed merge pairs is shown:
 
 Deselect any pair you want to keep separate. When satisfied, click Merge.
 
-There is also a **Sync backend** checkbox (recommended on). When checked, the backend's ChromaDB metadata is updated so that semantic search and future AI operations reflect the merged keywords.
+There is also a **Sync backend** checkbox (recommended on). When checked, the backend's stored metadata is updated so that semantic search and future AI operations reflect the merged keywords.
 
 #### Step 5 — Execution
 

--- a/docs/wiki/Help-Train-From-Edits.md
+++ b/docs/wiki/Help-Train-From-Edits.md
@@ -89,4 +89,4 @@ have stops working.
 - Save at least 5 well-edited photos per style — that is the Style Engine's minimum — and 10–20 for good results. More diverse examples generalize better.
 - Use consistent labels per shooting genre: one label for weddings, one for portraits, one for landscapes — rather than mixing everything.
 - Re-run the workflow after editing sessions to keep examples fresh and representative.
-- Training examples do not replace the **Overall look** preset — they augment it. Combining a matching preset with few-shot examples gives the best results.
+- Training examples are not one input among several — they are the only one. AI Edit has no look presets, no style-strength slider and no prompt to fall back on, so whatever the examples say is what the recipe does.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -44,7 +44,6 @@ Welcome to the project wiki.
 - [Build Environment Setup](Dev-Build-Environment-Setup) — Windows & macOS toolchain setup for `server-rs`, including the `llamacpp` feature and MLX sidecar
 - [Backend API Reference](Dev-Backend-API) — all REST endpoints documented
 - [Server Guide](Dev-Server-Guide) — backend architecture, database backup, lifecycle
-- [Dev: Testing the Update Mechanism](Dev-Testing-Update-Mechanism)
 - [Dev: Feature Priority Decision](Dev-Feature-Priority-Decision)
 - [Dev: Image Culling Implementation Plan](Dev-Image-Culling-Implementation-Plan)
 
@@ -61,13 +60,13 @@ Welcome to the project wiki.
 LrGeniusAI is an AI extension for Lightroom Classic. It runs a local backend server and connects it to the Lightroom plugin to provide:
 
 - **AI metadata generation** — keywords, titles, captions, alt text, via cloud APIs or models the backend runs locally itself
-- **AI develop edits** *(beta)* — per-photo Lightroom develop recipes with style presets
+- **AI develop edits** *(beta)* — per-photo Lightroom develop recipes interpolated from your own saved edits, no LLM involved
 - **Semantic free-text search** — find photos by describing them in natural language
 - **Species identification** — name the animals, plants and fungi in your photos down to species, on your own machine, with no cloud account
 - **Image culling** *(beta)* — burst grouping, scoring, Picks/Alternates/Rejects collections
 - **Face & person workflows** — face detection, clustering, named person collections
 - **Find similar images** — near-duplicate and visually similar search
 - **Keyword management** — automatic de-clutter and interactive synonym deduplication
-- **Style training** — save your own edits as AI few-shot examples
+- **Style training** — save your own edits as the examples AI develop edits are built from
 
 For project overview and release info, see [Project README](Dev-Project-README).

--- a/docs/wiki/Plugin-Guide.md
+++ b/docs/wiki/Plugin-Guide.md
@@ -12,7 +12,7 @@ All actions are available under `Library → Plug-in Extras`:
 
 | Menu item | What it does |
 |---|---|
-| Analyze & Index Photos... | AI metadata generation + search embeddings |
+| Analyze & Index Photos... | AI metadata generation + search embeddings, faces, optional species ID |
 | AI Edit Photos... | Generate and apply Lightroom develop recipes |
 | Advanced Search... | Semantic free-text photo search |
 | Cull Similar Photos... | Burst grouping, ranking, Picks/Alternates/Rejects |
@@ -55,7 +55,7 @@ See [Help: Keyword Deduplication and De-Clutter](Help-Keyword-Dedup-and-Declutte
 - **Retrieve Metadata from Backend** — pulls AI-generated metadata back into Lightroom if it was not written during indexing.
 
 ### Style Training
-**Save Edits as AI Training Examples** reads your current develop settings and stores them on the backend as labeled few-shot examples. On the next AI Edit run, these examples are injected as style context. See [Help: Train from Edits](Help-Train-From-Edits).
+**Save Edits as AI Training Examples** reads your current develop settings and stores them on the backend as labeled examples. They are the sole input to AI Edit: the backend matches a photo against them and interpolates their settings into a recipe. Below five examples AI Edit refuses to run. See [Help: Train from Edits](Help-Train-From-Edits).
 
 ### Error Management
 Batch tasks never fail silently. At the end of a run, a **Task Completion Dialog** aggregates successes and per-photo errors so you can see exactly what failed and why. See [Troubleshooting](Troubleshooting).


### PR DESCRIPTION
`scripts/check-docs.py --strict` was already clean — route coverage and the plugin/backend contract are in sync. Everything here is prose the mechanical checks cannot see: the places PR #274 (AI Edit becomes the style engine) and PR #275 (BioCLIP 2 species identification) did not reach.

## The root README

Two gaps, both from those PRs:

- The Core Features **AI Edit** bullet still advertised style presets, style strength, composition/crop mode and per-photo instruction overrides. None of those controls exist any more. Rewritten around the style engine, the five-example minimum and the new virtual-copy option.
- **Species identification was missing outright.** #275 updated every wiki page and both sub-READMEs but not the root one. Added a Core Features bullet, a tech-stack line (BioCLIP 2 + the pruned TreeOfLife head), the Analyze & Index menu description, and BioCLIP 2 / TreeOfLife-200M / OpenCLIP in the credits, with a pointer to the Credits page.

`docs/wiki/Dev-Project-README.md` is regenerated from it via `scripts/build-wiki-pages.sh`.

## Single stale sentences elsewhere

| Page | Was |
|---|---|
| `Help-Train-From-Edits.md` | told readers to pair examples with the **Overall look** preset |
| `Plugin-Guide.md` | described examples as few-shot context injected into the next AI Edit run |
| `Home.md` | "develop recipes with style presets", "few-shot examples" |
| `Help-Keyword-Dedup-and-Declutter.md` | "the backend's ChromaDB metadata" — the last such reference outside the genuinely migration-only ones |

`Home.md` also linked `Dev-Testing-Update-Mechanism`, a page deleted with the Python backend in #218. `publish-wiki.sh` rsyncs with `--delete`, so that has been a dead link on the live wiki ever since. The link is removed rather than the page restored — the mechanism it documented was the Python one.

## Deliberately untouched

`Dev-Backend-API.md` still documents `/edit` with `intent`, the creative-control flags and the few-shot path. That is correct: the endpoint and its LLM fallback still exist in `style_edit.rs`, and #274 already added the note that nothing calls them.

## Verification

- `scripts/check-docs.py --strict` — clean
- pre-commit hooks — StyLua / cargo fmt / cargo clippy all skipped (no code touched), docs check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ufwf1Wgqdxz63FqFnDWi18