### PR TITLE
Let a species-only run start

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -773,11 +773,17 @@ LrTasks.startAsyncTask(function()
 			return
 		end
 
-		-- Validate that at least one task is selected
+		-- Validate that at least one task is selected.
+		--
+		-- `enableSpecies` counts: identifying species is a complete run on its
+		-- own, and the save pass below covers exactly that case (species on,
+		-- metadata off). Leaving it out of this list is what made a
+		-- species-only run refuse to start.
 		if
 			not props.enableEmbeddings
 			and not props.enableMetadata
 			and not props.enableFaces
+			and not props.enableSpecies
 			and not props.enableVertexAI
 		then
 			LrDialogs.showError(


### PR DESCRIPTION
Ticking **Identify species** and nothing else in Analyze & Index was rejected with *"Please select at least one task to perform."*

The guard predates the species feature and was never extended — it asks about `enableEmbeddings`, `enableMetadata`, `enableFaces` and `enableVertexAI`, but not `enableSpecies`:

```lua
if
    not props.enableEmbeddings
    and not props.enableMetadata
    and not props.enableFaces
    and not props.enableVertexAI
then
```

Everything downstream already supports the run. Twenty lines later the task array is built with `if props.enableSpecies then table.insert(tasks, "species") end`, and `TaskAnalyzeAndIndex.lua:1066` carries a save pass written for exactly this case — species on, metadata off — because every other save path is gated on `enableMetadata`. The pre-filter degrades correctly too: `identify_species` in `index_upload.rs` gates on the stored SigLIP embedding when there is one and runs BioCLIP anyway when there is not.

So the run was supported end to end; only the door was locked. One line, plus a comment saying why species belongs in the list.

Independent of #285 — that one adds the look-up links, this is a pre-existing gate. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYQVqsfjcySg8iHqsh1GH1