### PR TITLE
Surface runs that silently lost a signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,42 @@ Cargo workspace, one binary (`geniusai-server`) across these crates:
 - Code must pass `cargo fmt` and `cargo clippy --workspace --all-targets` with zero warnings before considering a change done.
 - After changing an endpoint, prefer live-testing against the actual running binary (`cargo run -p lrg-server -- --db-path ... --debug` + `curl`) in addition to unit tests — this has repeatedly caught real bugs unit tests alone missed.
 
+### Errors must surface
+
+**A log line is not a report.** Anything that goes wrong — a failure, or a
+success that quietly lost a signal — has to travel all the way to a dialog in
+Lightroom. `log::warn!`/`log:warn` is for the record; it is never the only
+place a problem lands.
+
+The chain is: backend detects → puts it in the HTTP response (`error` /
+`error_messages` for failures, `warnings` for degradations) → the API wrapper
+in `APISearchIndex.lua` returns it → the `Task*.lua` caller collects it →
+`ErrorHandler.handleError` or `LrDialogs.message(..., "warning")` shows it.
+Every link is load-bearing; a caller that drops the response's `warnings`
+breaks the chain just as thoroughly as a backend that never sends them.
+
+Concretely, when writing or reviewing this path:
+
+- **A degraded success is not a success.** A photo that indexed without face
+  detection, species, or an embedding must say so. `success_count` going up
+  while the run silently produced worse data is the bug this rule exists for.
+- **Never swallow a response you asked for.** If a wrapper returns
+  `(ok, response)`, the caller reads `response.warnings` even when `ok` is
+  true. Grep for existing callers when you add a warning — a new one is
+  useless if nothing consumes it.
+- **Say what to do, not what happened.** "model not loaded" describes an
+  internal state; "face model is not downloaded yet — run "Download AI
+  models" in Plug-in Manager" is something the user can act on.
+- **Deduplicate and cap, don't drop.** A run-wide cause warns once per photo.
+  Show a handful and count the rest; hiding the rest entirely is not an
+  option.
+- **A single slot loses reports.** Accumulate warnings in a list. One
+  `Option<String>`/variable means the second problem erases the first.
+
+Silence is only acceptable for something the user did not ask for and cannot
+act on (e.g. Vertex AI embeddings when no project is configured) — and that
+decision belongs in a comment at the point where it is made.
+
 ### Docs
 
 - Backend port is 19819 by default

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -81,6 +81,15 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 `/index_by_reference` carries `exposure_bias` and `is_raw` per image inside the
 `images` array instead, since both are properties of the individual photo.
 
+**Response:** `{status, success_count, failure_count, error_messages, warnings, results}`.
+
+`warnings` is where a *degraded success* is reported: the photo was indexed, but
+an optional signal was lost — most often `"<file> faces: face model is not
+downloaded yet …"` or the same for species. These never fail the photo
+(`success_count` still counts it), so a caller that ignores `warnings` shows the
+user a clean run that silently produced worse data. Each entry also rides on its
+own photo's `results` element as `warnings`, so a grouped caller can attribute it.
+
 ### `POST /index_by_reference`
 Indexes photos using server-side file paths instead of uploading image data (for local-backend
 setups where the server has filesystem access).

--- a/docs/wiki/Help-Advanced-Search.md
+++ b/docs/wiki/Help-Advanced-Search.md
@@ -10,6 +10,18 @@ In Lightroom Classic:
 
 - `Library → Plug-in Extras → Advanced Search...`
 
+## What the search can see
+
+A text search only finds photos that carry a SigLIP embedding, so a
+half-indexed catalog answers "no results" for a subject that is sitting right
+there. The dialog says so before you type: if the search model is not
+downloaded, or some of the catalog has no search index yet, an orange note at
+the top gives the count and what to run to fix it.
+
+The check is two cheap lookups (`/db/stats` plus the catalog's photo count) and
+runs every time the dialog opens. It is a note, not a gate — the search still
+runs across whatever *is* indexed.
+
 ## Search term
 
 Free text. Describe what is in the photo, not how it was shot:

--- a/docs/wiki/Help-Analyze-and-Index.md
+++ b/docs/wiki/Help-Analyze-and-Index.md
@@ -53,6 +53,25 @@ appear depends on what is configured in the Plug-in Manager — see
     is all wildlife.
   - *Also write the taxonomy as keywords* (off by default) — see below.
 
+### If a model is not downloaded yet
+
+Pressing **Start** checks that the on-device models the selected tasks need are
+actually on disk, and asks before spending the indexing time if one is not:
+
+- **Download now** — starts the download (it reports its own progress) and
+  stops this run. Start it again once the download finishes and the photos are
+  processed with everything you selected.
+- **Continue without it** — indexes anyway. The photos are processed without
+  that model's contribution, and the completion dialog reports it as a warning
+  naming the **Download AI models** button. Running Analyze & Index over the
+  same photos later fills in what was skipped.
+- **Cancel** — nothing runs.
+
+Only the models the run actually needs are checked: a search-only run is not
+stopped by a missing species model, and tasks that run on an LLM or in the
+cloud need nothing downloaded. If the check itself cannot reach the backend the
+run proceeds, and any real failure is reported as usual.
+
 ---
 
 ## Species identification

--- a/docs/wiki/Help-Cull-Photos.md
+++ b/docs/wiki/Help-Cull-Photos.md
@@ -105,6 +105,16 @@ Typical reason codes include:
 
 These help explain why a specific frame was chosen as a pick or flagged as a reject candidate.
 
+## "Some culling signals are missing"
+
+When the selected photos have no culling data yet, the plugin offers to prepare
+them — a fast pass that computes only what culling reads. If a signal could not
+be computed, the plugin says so before the culling run starts instead of quietly
+grading photos without it. The usual cause is that the on-device models are not
+downloaded yet: open **File → Plug-in Manager → LrGeniusAI** and press
+**Download AI models**, then run culling again. Culling still works in the
+meantime, but face-aware ranking (eyes open, sharpness, occlusion) is inactive.
+
 ## Tips for best results
 
 - Run culling after you have narrowed down an initial selection for a shoot (for example by folder or date range).

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -3952,6 +3952,81 @@ function SearchIndexAPI.startAssetDownload()
 	end)
 end
 
+---
+-- Preflight gate: stop a run that is about to lose a signal it was asked for.
+--
+-- /assets/status already knew the models were missing, but nothing consulted
+-- it when a run started, so the first sign of trouble was a warning after the
+-- indexing time had already been spent. This asks before, while the answer is
+-- still cheap.
+--
+-- Deliberately never blocks on its own failure: if the status call does not
+-- answer, the run proceeds and reports whatever actually goes wrong. A gate
+-- that turns a flaky health check into "you cannot index" would be worse than
+-- the problem it guards.
+--
+-- @param tasks table The run's `tasks` array (see Util.requiredModelFamilies).
+-- @return boolean proceed True to run, false when the user chose to stop.
+--
+function SearchIndexAPI.confirmModelsReadyForTasks(tasks)
+	local required = Util.requiredModelFamilies(tasks)
+	if #required == 0 then
+		return true
+	end
+
+	local status, err = SearchIndexAPI.getAssetStatus()
+	if not status or type(status.families) ~= "table" then
+		log:warn("Model readiness preflight skipped: " .. tostring(err or "no families in /assets/status"))
+		return true
+	end
+
+	local missing = Util.missingModelFamilies(status.families, required)
+	if #missing == 0 then
+		return true
+	end
+
+	local names = {}
+	local bytes = 0
+	for _, family in ipairs(missing) do
+		table.insert(names, family.name)
+		bytes = bytes + (family.approx_bytes or 0)
+	end
+	log:warn("Model readiness preflight: missing " .. table.concat(names, ", "))
+
+	local answer = LrDialogs.confirm(
+		LOC("$$$/LrGeniusAI/ModelPreflight/Title=Some AI models are not downloaded yet"),
+		LOC(
+			"$$$/LrGeniusAI/ModelPreflight/Message=This run needs ^1, which is not on disk yet. The photos would be processed without it, and you would have to run this again afterwards to fill in what was skipped.\n\nThe download is about ^2 and only happens once.",
+			table.concat(names, ", "),
+			Util.formatDownloadSize(bytes)
+		),
+		LOC("$$$/LrGeniusAI/ModelPreflight/Download=Download now"),
+		LOC("$$$/LrGeniusAI/common/Cancel=Cancel"),
+		LOC("$$$/LrGeniusAI/ModelPreflight/Continue=Continue without it")
+	)
+
+	if answer == "other" then
+		log:info("Model readiness preflight: user chose to continue without " .. table.concat(names, ", "))
+		return true
+	end
+
+	if answer == "ok" then
+		-- The download reports through its own progress bar and finishes with
+		-- its own dialog, so this run stands down rather than waiting: the
+		-- photos are still selected and the same menu item picks up where the
+		-- user left off.
+		SearchIndexAPI.startAssetDownload()
+		LrDialogs.message(
+			LOC("$$$/LrGeniusAI/ModelPreflight/StartedTitle=Downloading AI models"),
+			LOC(
+				"$$$/LrGeniusAI/ModelPreflight/StartedMessage=The download has started. Run this again once it finishes and the photos will be processed with everything you selected."
+			)
+		)
+	end
+
+	return false
+end
+
 local lastBioclipReadyStatus = nil
 
 ---

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -843,6 +843,14 @@ LrTasks.startAsyncTask(function()
 			table.insert(tasks, "vertexai")
 		end
 
+		-- Asked here, before a single photo is exported: an on-device model
+		-- that is not downloaded yet does not fail the run, it silently drops
+		-- whatever it was for, and finding that out from the completion dialog
+		-- means the whole indexing time has already been spent.
+		if not SearchIndexAPI.confirmModelsReadyForTasks(tasks) then
+			return
+		end
+
 		-- Parse provider and model from unified modelKey (format: provider::model)
 		local providerFromKey, modelFromKey = nil, nil
 		if props.modelKey then

--- a/plugin/LrGeniusAI.lrdevplugin/TaskCullPhotos.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskCullPhotos.lua
@@ -146,12 +146,19 @@ end
 -- Originals are sent by path when the backend is on this machine; otherwise
 -- each photo is exported to a temporary JPEG and uploaded, and the temp file
 -- is removed afterwards.
--- @return number|nil processed count, string|nil error
+-- @return number|nil processed count, string|nil error, string|nil warnings
 local function cullPrepare(missingIds, photoById, progressScope)
 	local total = #missingIds
 	local processed = 0
 	local failures = 0
 	local byReference = SearchIndexAPI.isLocalBackend()
+	-- A photo that indexes successfully can still have lost a signal culling
+	-- reads — a face model that is not downloaded yet is the common one, and
+	-- it costs every photo its face-quality score. Dropping these on the floor
+	-- meant the run looked clean and the picks were quietly worse.
+	local warningsSeen = {}
+	local warningsList = {}
+	local warningsTotal = 0
 
 	for i, photoId in ipairs(missingIds) do
 		if progressScope and progressScope:isCanceled() then
@@ -169,24 +176,35 @@ local function cullPrepare(missingIds, photoById, progressScope)
 			if type(exposureBias) == "number" then
 				indexOptions.exposure_bias = exposureBias
 			end
-			local ok, err
+			-- `result` is the decoded response on success and an error string
+			-- on failure; both matter here, so it is read either way.
+			local ok, result
 			if byReference then
 				local path = photo:getRawMetadata("path")
-				ok, err = SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, path, indexOptions)
+				ok, result = SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, path, indexOptions)
 			else
 				local exported = SearchIndexAPI.exportPhotoForIndexing(photo)
 				if exported then
-					ok, err = SearchIndexAPI.analyzeAndIndexPhoto(photoId, exported, indexOptions)
+					ok, result = SearchIndexAPI.analyzeAndIndexPhoto(photoId, exported, indexOptions)
 					LrFileUtils.delete(exported)
 				else
-					ok, err = false, "could not export photo for upload"
+					ok, result = false, "could not export photo for upload"
 				end
 			end
 			if ok then
 				processed = processed + 1
+				if type(result) == "table" and type(result.warnings) == "table" then
+					for _, w in ipairs(result.warnings) do
+						warningsTotal = warningsTotal + 1
+						if not warningsSeen[w] then
+							warningsSeen[w] = true
+							table.insert(warningsList, w)
+						end
+					end
+				end
 			else
 				failures = failures + 1
-				log:warn("Cull prepare failed for " .. tostring(photoId) .. ": " .. tostring(err))
+				log:warn("Cull prepare failed for " .. tostring(photoId) .. ": " .. tostring(result))
 			end
 		end
 		if progressScope then
@@ -203,7 +221,23 @@ local function cullPrepare(missingIds, photoById, progressScope)
 	if processed == 0 and failures > 0 then
 		return nil, LOC("$$$/LrGeniusAI/CullTask/PrepAllFailed=None of the photos could be prepared.")
 	end
-	return processed, nil
+	-- One missing model warns once per photo, so the dialog shows a handful
+	-- and counts the rest: a wall of identical lines is as unreadable as no
+	-- message at all.
+	local combinedWarnings
+	if #warningsList > 0 then
+		local shown = {}
+		for i = 1, math.min(5, #warningsList) do
+			table.insert(shown, warningsList[i])
+		end
+		combinedWarnings = table.concat(shown, "\n")
+		if warningsTotal > #shown then
+			combinedWarnings = combinedWarnings
+				.. "\n"
+				.. LOC("$$$/LrGeniusAI/common/MoreWarnings=... and ^1 more warnings", tostring(warningsTotal - #shown))
+		end
+	end
+	return processed, nil, combinedWarnings
 end
 
 local function joinReasonCodes(reasonCodes)
@@ -291,15 +325,32 @@ LrTasks.startAsyncTask(function()
 				LOC("$$$/LrGeniusAI/CullTask/NeedsPrepSkip=Cull without them")
 			)
 			if answer == "ok" then
+				-- Same gate as Analyze & Index, for the same reason: the prep
+				-- pass scores face quality, and without the face model it
+				-- produces photos culling can only grade on technical metrics.
+				if not SearchIndexAPI.confirmModelsReadyForTasks({ "cull" }) then
+					return
+				end
 				local prepScope = LrProgressScope({
 					title = LOC("$$$/LrGeniusAI/CullTask/PrepProgressTitle=Preparing photos for culling..."),
 					functionContext = context,
 				})
-				local prepared, prepErr = cullPrepare(missing, photoById, prepScope)
+				local prepared, prepErr, prepWarnings = cullPrepare(missing, photoById, prepScope)
 				prepScope:done()
 				if prepErr then
 					ErrorHandler.handleError(LOC("$$$/LrGeniusAI/CullTask/PrepErrorTitle=Preparation failed"), prepErr)
 					return
+				end
+				if prepWarnings then
+					log:warn("Cull prepare warnings: " .. prepWarnings)
+					LrDialogs.message(
+						LOC("$$$/LrGeniusAI/CullTask/PrepWarningTitle=Some culling signals are missing"),
+						LOC(
+							"$$$/LrGeniusAI/CullTask/PrepWarningMessage=The photos were prepared, but not every signal could be computed. Culling will run without them.\n\n^1",
+							prepWarnings
+						),
+						"warning"
+					)
 				end
 				log:info("Cull prepare completed for " .. tostring(prepared) .. " photo(s)")
 			end

--- a/plugin/LrGeniusAI.lrdevplugin/TaskSemanticSearch.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskSemanticSearch.lua
@@ -3,7 +3,65 @@
     If the search term is empty, it performs a quality-only search.
 ]]
 
-local function showAdvancedSearchDialog(ctx)
+---
+-- Lines warning that this search cannot see everything, or nil when it can.
+--
+-- Built before the dialog opens and shown inside it rather than as a modal of
+-- its own: an empty result set is indistinguishable from an empty catalog, so
+-- the caveat has to be on screen while the search is being typed — but not at
+-- the cost of a click every single time.
+--
+-- @return string|nil Warning text, already line-broken.
+--
+local function buildCoverageWarning()
+	local lines = {}
+
+	-- The model first: without it the semantic half of the search returns
+	-- nothing at all, which makes the coverage number below beside the point.
+	local assets = SearchIndexAPI.getAssetStatus()
+	if assets and type(assets.families) == "table" then
+		local missing = Util.missingModelFamilies(assets.families, { "clip" })
+		if #missing > 0 then
+			table.insert(
+				lines,
+				LOC(
+					'$$$/LrGeniusAI/AdvancedSearchTask/WarnModelMissing=The AI search model is not downloaded yet, so searching by subject will find nothing.\nDownload it in File > Plug-in Manager > LrGeniusAI, under "Download AI models".'
+				)
+			)
+		end
+	end
+
+	-- One /db/stats call, measured at ~95 ms over 14,000 photos, plus the
+	-- catalog count the search itself already pays for further down. Cheap
+	-- enough to run before every search; if it ever is not, the number it
+	-- produces is the one worth waiting for.
+	local stats = SearchIndexAPI.getStats()
+	local catalogCount
+	local okCount = LrTasks.pcall(function()
+		catalogCount = #LrApplication.activeCatalog():getAllPhotos()
+	end)
+	if not okCount then
+		catalogCount = nil
+	end
+	local coverage = Util.searchCoverage(stats, catalogCount)
+	if coverage and coverage.unsearchable > 0 then
+		table.insert(
+			lines,
+			LOC(
+				'$$$/LrGeniusAI/AdvancedSearchTask/WarnUnindexed=^1 of ^2 photos have no search index yet and cannot be found by a search.\nRun Library > Plug-in Extras > Analyze & Index Photos with "Enable smart photo search" to include them.',
+				tostring(coverage.unsearchable),
+				tostring(coverage.total)
+			)
+		)
+	end
+
+	if #lines == 0 then
+		return nil
+	end
+	return table.concat(lines, "\n\n")
+end
+
+local function showAdvancedSearchDialog(ctx, coverageWarning)
 	local props = LrBinding.makePropertyTable(ctx)
 	props.searchTerm = ""
 	-- Scope and search-in options from prefs (persisted)
@@ -24,9 +82,28 @@ local function showAdvancedSearchDialog(ctx)
 	local bind = LrView.bind
 	local share = LrView.share
 
+	local layout = f:column({
+		spacing = f:control_spacing(),
+	})
+
+	if coverageWarning then
+		-- Manual line breaks, not `wrap = true` — that property has no effect
+		-- on static_text in this SDK, so a long line would run off the dialog.
+		table.insert(
+			layout,
+			f:static_text({
+				title = coverageWarning,
+				text_color = LrColor(0.8, 0.5, 0),
+				height_in_lines = -1,
+			})
+		)
+		table.insert(layout, f:separator({ fill_horizontal = 1 }))
+	end
+
 	local contents = f:view({
 		bind_to_object = props,
 		spacing = f:control_spacing(),
+		layout,
 		f:column({
 			spacing = f:control_spacing(),
 			f:row({
@@ -203,7 +280,7 @@ LrTasks.startAsyncTask(function()
 			return
 		end
 
-		local props = showAdvancedSearchDialog(context)
+		local props = showAdvancedSearchDialog(context, buildCoverageWarning())
 		if props == nil then
 			return
 		end

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -1877,4 +1877,145 @@ function Util.rankKeywordsByUsage(entries, limit, options)
 	return result
 end
 
+---
+-- The on-device model families an indexing run needs, given its `tasks` array.
+--
+-- Only the models the backend loads itself are listed. `metadata` runs on an
+-- LLM and `vertexai` in the cloud, so neither has an entry — a run of those
+-- alone needs nothing downloaded.
+--
+-- `cull` maps to the face model because the fast cull ingest still scores face
+-- quality (the backend's `compute_faces = has_task("faces") || cull_pass`);
+-- it deliberately skips the embedding, so it does not need `clip`.
+--
+-- @param tasks table Array of task names as sent to /index.
+-- @return table Array of family ids, in the order /assets/status reports them.
+--
+function Util.requiredModelFamilies(tasks)
+	if type(tasks) ~= "table" then
+		return {}
+	end
+	local needed = {}
+	for _, task in ipairs(tasks) do
+		if task == "embeddings" then
+			needed.clip = true
+		elseif task == "faces" or task == "cull" then
+			needed.face = true
+		elseif task == "species" then
+			needed.bioclip = true
+		end
+	end
+	-- Fixed order rather than pairs(): the result reaches a dialog, and a list
+	-- that reshuffles between runs reads like a different problem each time.
+	local result = {}
+	for _, id in ipairs({ "clip", "face", "bioclip" }) do
+		if needed[id] then
+			table.insert(result, id)
+		end
+	end
+	return result
+end
+
+---
+-- Which of the families a run needs are not downloaded yet.
+--
+-- Takes the `families` array from /assets/status. A family the run does not
+-- need is ignored however unready it is, and a required family the backend
+-- does not report at all is treated as present: an older backend that has
+-- never heard of it must not block a run it can perform perfectly well.
+--
+-- @param families table `families` from /assets/status.
+-- @param requiredIds table Array of family ids from Util.requiredModelFamilies.
+-- @return table Array of { id, name, approx_bytes } per missing family, in required order.
+--
+function Util.missingModelFamilies(families, requiredIds)
+	if type(families) ~= "table" or type(requiredIds) ~= "table" then
+		return {}
+	end
+	local byId = {}
+	for _, family in ipairs(families) do
+		if type(family) == "table" and family.id then
+			byId[family.id] = family
+		end
+	end
+	local missing = {}
+	for _, id in ipairs(requiredIds) do
+		local family = byId[id]
+		if family ~= nil and not family.ready then
+			table.insert(missing, {
+				id = id,
+				name = family.name or id,
+				approx_bytes = tonumber(family.approx_bytes) or 0,
+			})
+		end
+	end
+	return missing
+end
+
+---
+-- How much of the catalog a text search can actually reach.
+--
+-- A semantic search only sees photos that have a SigLIP embedding, so a
+-- half-indexed catalog answers "nothing found" for a subject that is sitting
+-- right there. The search dialog says so up front instead of letting an empty
+-- result read as an empty catalog.
+--
+-- The catalog's own count is the denominator when it is known: the backend's
+-- `total` counts only photos it has already seen, which by definition cannot
+-- reveal the ones that were never indexed at all. Falls back to the backend's
+-- figure when the catalog count is unavailable.
+--
+-- @param stats table|nil The /db/stats response.
+-- @param catalogPhotoCount number|nil Photos in the Lightroom catalog.
+-- @return table|nil { total, searchable, unsearchable }, or nil when unknown.
+--
+function Util.searchCoverage(stats, catalogPhotoCount)
+	local photos = type(stats) == "table" and stats.photos or nil
+	if type(photos) ~= "table" then
+		return nil
+	end
+	local withEmbedding = tonumber(photos.with_embedding)
+	local backendTotal = tonumber(photos.total)
+	if withEmbedding == nil then
+		return nil
+	end
+	local total = tonumber(catalogPhotoCount) or backendTotal
+	if total == nil then
+		return nil
+	end
+	-- Clamped rather than trusted: rows survive the photos they describe (the
+	-- backend never physically deletes), so a catalog that has shrunk can
+	-- report more embeddings than photos, and a negative "missing" count would
+	-- be worse than no warning at all.
+	local searchable = math.min(withEmbedding, total)
+	if searchable < 0 then
+		searchable = 0
+	end
+	return {
+		total = total,
+		searchable = searchable,
+		unsearchable = total - searchable,
+	}
+end
+
+---
+-- A download size a person can judge a "download now?" prompt against.
+--
+-- Picks the unit rather than always reporting GB: the face model is ~0.09 GB,
+-- which reads as "nothing is there" next to a real figure of 94 MB.
+--
+-- @param bytes number Size in bytes.
+-- @return string e.g. "94 MB" or "2.3 GB".
+--
+function Util.formatDownloadSize(bytes)
+	local n = tonumber(bytes) or 0
+	if n < 0 then
+		n = 0
+	end
+	if n >= 1e9 then
+		return string.format("%.1f GB", n / 1e9)
+	end
+	return string.format("%.0f MB", n / 1e6)
+end
+
 return Util

--- a/plugin/spec/util_model_readiness_spec.lua
+++ b/plugin/spec/util_model_readiness_spec.lua
@@ -1,0 +1,165 @@
+-- Unit tests for the model-readiness preflight helpers in Util.lua.
+--
+-- These decide whether a run is about to produce silently degraded data
+-- because a model it needs is not downloaded yet. The mapping is pure logic,
+-- so it is tested headless here rather than only inside Lightroom.
+--
+-- Run from the repo root with:  busted
+
+local Util = require("Util")
+
+--- The `families` array as /assets/status reports it, with the given ids unready.
+local function families(unready)
+	local notReady = {}
+	for _, id in ipairs(unready) do
+		notReady[id] = true
+	end
+	return {
+		{ id = "clip", name = "Smart photo search", ready = not notReady.clip, approx_bytes = 2310000000 },
+		{ id = "bioclip", name = "Species identification", ready = not notReady.bioclip, approx_bytes = 876000000 },
+		{ id = "face", name = "Face detection", ready = not notReady.face, approx_bytes = 94200000 },
+	}
+end
+
+describe("Util.requiredModelFamilies", function()
+	it("maps each task to the model the backend loads for it", function()
+		assert.are.same({ "clip" }, Util.requiredModelFamilies({ "embeddings" }))
+		assert.are.same({ "face" }, Util.requiredModelFamilies({ "faces" }))
+		assert.are.same({ "bioclip" }, Util.requiredModelFamilies({ "species" }))
+	end)
+
+	it("requires the face model for a cull run", function()
+		-- The fast cull ingest still scores face quality, which is the whole
+		-- point of face-aware ranking. Missing it does not fail the run, it
+		-- just quietly makes the picks worse — exactly what the gate is for.
+		assert.are.same({ "face" }, Util.requiredModelFamilies({ "cull" }))
+	end)
+
+	it("requires nothing on-device for LLM or cloud tasks", function()
+		assert.are.same({}, Util.requiredModelFamilies({ "metadata" }))
+		assert.are.same({}, Util.requiredModelFamilies({ "vertexai" }))
+		assert.are.same({}, Util.requiredModelFamilies({ "metadata", "vertexai" }))
+	end)
+
+	it("reports a stable order regardless of task order", function()
+		local expected = { "clip", "face", "bioclip" }
+		assert.are.same(expected, Util.requiredModelFamilies({ "embeddings", "faces", "species" }))
+		assert.are.same(expected, Util.requiredModelFamilies({ "species", "faces", "embeddings" }))
+	end)
+
+	it("does not list a family twice when two tasks need it", function()
+		assert.are.same({ "face" }, Util.requiredModelFamilies({ "faces", "cull" }))
+	end)
+
+	it("tolerates missing or malformed input", function()
+		assert.are.same({}, Util.requiredModelFamilies(nil))
+		assert.are.same({}, Util.requiredModelFamilies({}))
+		assert.are.same({}, Util.requiredModelFamilies("faces"))
+		assert.are.same({}, Util.requiredModelFamilies({ "nonsense" }))
+	end)
+end)
+
+describe("Util.missingModelFamilies", function()
+	it("names the required families that are not ready", function()
+		local missing = Util.missingModelFamilies(families({ "face" }), { "clip", "face" })
+		assert.are.same({ { id = "face", name = "Face detection", approx_bytes = 94200000 } }, missing)
+	end)
+
+	it("ignores an unready family the run does not need", function()
+		-- A photographer indexing only for search should not be stopped by the
+		-- species model they never asked for.
+		assert.are.same({}, Util.missingModelFamilies(families({ "bioclip", "face" }), { "clip" }))
+	end)
+
+	it("returns nothing when everything the run needs is ready", function()
+		assert.are.same({}, Util.missingModelFamilies(families({}), { "clip", "face", "bioclip" }))
+	end)
+
+	it("keeps the required order so the dialog reads the same every run", function()
+		local missing =
+			Util.missingModelFamilies(families({ "clip", "face", "bioclip" }), { "clip", "face", "bioclip" })
+		assert.are.same({ "clip", "face", "bioclip" }, { missing[1].id, missing[2].id, missing[3].id })
+	end)
+
+	it("treats a family the backend never reports as present", function()
+		-- An older backend that predates a family must not block a run it can
+		-- perform perfectly well.
+		local older = { { id = "clip", name = "Smart photo search", ready = true } }
+		assert.are.same({}, Util.missingModelFamilies(older, { "clip", "bioclip" }))
+	end)
+
+	it("falls back to the family id when the backend sends no name", function()
+		local unnamed = { { id = "face", ready = false } }
+		assert.are.same(
+			{ { id = "face", name = "face", approx_bytes = 0 } },
+			Util.missingModelFamilies(unnamed, { "face" })
+		)
+	end)
+
+	it("tolerates missing or malformed input", function()
+		assert.are.same({}, Util.missingModelFamilies(nil, { "face" }))
+		assert.are.same({}, Util.missingModelFamilies(families({ "face" }), nil))
+		assert.are.same({}, Util.missingModelFamilies({ "junk", 7 }, { "face" }))
+	end)
+end)
+
+describe("Util.formatDownloadSize", function()
+	it("reports a small model in MB, not a rounded-away fraction of a GB", function()
+		assert.are.equal("94 MB", Util.formatDownloadSize(94200000))
+	end)
+
+	it("reports a large model in GB", function()
+		assert.are.equal("2.3 GB", Util.formatDownloadSize(2310000000))
+	end)
+
+	it("tolerates missing or nonsensical sizes", function()
+		assert.are.equal("0 MB", Util.formatDownloadSize(nil))
+		assert.are.equal("0 MB", Util.formatDownloadSize(-5))
+	end)
+end)
+
+describe("Util.searchCoverage", function()
+	local stats = { photos = { total = 14070, with_embedding = 9066 } }
+
+	it("counts photos a text search cannot reach", function()
+		local coverage = Util.searchCoverage(stats, 14070)
+		assert.are.equal(14070, coverage.total)
+		assert.are.equal(9066, coverage.searchable)
+		assert.are.equal(5004, coverage.unsearchable)
+	end)
+
+	it("measures against the catalog, not against what the backend has seen", function()
+		-- Photos that were never indexed are absent from the backend's own
+		-- total, so using it as the denominator would hide exactly the photos
+		-- the warning exists for.
+		local coverage = Util.searchCoverage(stats, 20000)
+		assert.are.equal(20000, coverage.total)
+		assert.are.equal(10934, coverage.unsearchable)
+	end)
+
+	it("falls back to the backend total when the catalog count is unknown", function()
+		local coverage = Util.searchCoverage(stats, nil)
+		assert.are.equal(14070, coverage.total)
+		assert.are.equal(5004, coverage.unsearchable)
+	end)
+
+	it("reports full coverage when everything is indexed", function()
+		local coverage = Util.searchCoverage({ photos = { total = 12, with_embedding = 12 } }, 12)
+		assert.are.equal(0, coverage.unsearchable)
+	end)
+
+	it("never reports a negative gap after photos are removed", function()
+		-- The backend keeps rows for deleted photos, so embeddings can outnumber
+		-- the catalog.
+		local coverage = Util.searchCoverage(stats, 5000)
+		assert.are.equal(5000, coverage.searchable)
+		assert.are.equal(0, coverage.unsearchable)
+	end)
+
+	it("returns nil when the stats response is unusable", function()
+		assert.is_nil(Util.searchCoverage(nil, 100))
+		assert.is_nil(Util.searchCoverage({}, 100))
+		assert.is_nil(Util.searchCoverage({ photos = {} }, 100))
+		assert.is_nil(Util.searchCoverage({ photos = { with_embedding = 5 } }, nil))
+	end)
+end)

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -853,12 +853,17 @@ pub(crate) async fn process_batch(
             match finish_one(&state, store_ref, &options, photo, llm_response).await {
                 Ok(warn) => {
                     success_count += 1;
+                    // The photo's own warnings ride on its result too, not just
+                    // in the request-level list: a grouped caller reads
+                    // `results` per photo, and a degradation nobody can pin to
+                    // a photo is one nobody acts on.
                     results.push(json!({
-                        "photo_id": photo_id, "success": true, "error": Value::Null,
+                        "photo_id": photo_id,
+                        "success": true,
+                        "error": Value::Null,
+                        "warnings": &warn,
                     }));
-                    if let Some(w) = warn {
-                        warnings.push(w);
-                    }
+                    warnings.extend(warn);
                 }
                 Err(e) => {
                     failure_count += 1;
@@ -1230,7 +1235,7 @@ async fn finish_one(
     options: &ParsedOptions,
     prepared: PreparedPhoto,
     llm_response: Option<lrg_providers::types::MetadataGenerationResponse>,
-) -> Result<Option<String>, String> {
+) -> Result<Vec<String>, String> {
     let PreparedPhoto {
         photo_id,
         filename,
@@ -1325,7 +1330,11 @@ async fn finish_one(
     // themselves on the stale pre-catalog_id `record`, so indexing with
     // both faces and catalog_id set silently dropped the catalog_ids
     // field once face processing's write landed last.
-    let mut warning = None;
+    // A vec, not one slot: faces and species can each degrade independently,
+    // and a single `Option` meant whichever failed second erased the other's
+    // report — the user was told about the species model while the missing
+    // face model went unmentioned.
+    let mut warnings: Vec<String> = Vec::new();
     if options.compute_faces {
         // "Checked" means checked *by the models this build runs*. A photo
         // whose faces were found by the retired SCRFD/ArcFace pair carries
@@ -1351,7 +1360,16 @@ async fn finish_one(
             let face_result: Result<Vec<_>, String> = if !state.face.is_cached() {
                 // Checked before decoding: without the model files the detector
                 // fails anyway, and the decode would be pure waste.
-                Err("model not loaded".to_string())
+                //
+                // Names the fix, not the state. The overwhelmingly common
+                // cause is a run started before the models finished
+                // downloading, and "model not loaded" left the user with a
+                // symptom and nowhere to go.
+                Err(
+                    "face model is not downloaded yet — run \"Download AI models\" \
+                     in Plug-in Manager and index these photos again"
+                        .to_string(),
+                )
             } else {
                 match image::load_from_memory(&image_bytes).map(|img| img.to_rgb8()) {
                     Ok(decoded) => {
@@ -1528,7 +1546,7 @@ async fn finish_one(
                 }
                 Err(e) => {
                     log::warn!("Face detection/indexing failed for {photo_id}: {e}");
-                    warning = Some(format!("{filename} faces: {e}"));
+                    warnings.push(format!("{filename} faces: {e}"));
                 }
             }
         }
@@ -1562,7 +1580,7 @@ async fn finish_one(
                     // sink the photo, and `species_checked` stays unset so a
                     // later run retries rather than treating this as done.
                     log::warn!("Species identification failed for {photo_id}: {e}");
-                    warning = Some(format!("{filename} species: {e}"));
+                    warnings.push(format!("{filename} species: {e}"));
                 }
             }
         }
@@ -1637,7 +1655,7 @@ async fn finish_one(
         }
     }
 
-    Ok(warning)
+    Ok(warnings)
 }
 
 /// Run the organism gate and, if it passes, BioCLIP 2.
@@ -1655,7 +1673,12 @@ fn run_species(
     // Checked before decoding, like the face path: without the model files the
     // classifier fails anyway and the decode would be pure waste.
     if !state.bioclip.is_cached() {
-        return Err("model not downloaded".to_string());
+        // Names the fix, like the face path above.
+        return Err(
+            "species model is not downloaded yet — run \"Download AI models\" \
+                    in Plug-in Manager and index these photos again"
+                .to_string(),
+        );
     }
 
     if options.species_prefilter {


### PR DESCRIPTION
## The bug

```
08-19 08:58:32 WARNING Face detection/indexing failed for md5p:26917484:...: model not loaded
08-19 08:58:32 INFO    Batch processing complete. Success: 1, Failures: 0.
```

The face model had not been downloaded yet. The photo was indexed without face data, the run reported success, and nothing reached the user.

## What was actually wrong

Three separate holes on the same path:

1. **`TaskCullPhotos.cullPrepare` dropped the response.** It called `analyzeAndIndexPhotoByReference`, checked only the boolean, and threw away `response.warnings`. Culling then graded every photo with no face-quality signal. `TaskAnalyzeAndIndex` did surface warnings; culling never did.
2. **`finish_one` held warnings in one `Option<String>`.** A species failure erased a face failure.
3. **`"model not loaded"` named an internal state, not the fix.**

## Changes

**Backend** (`index_upload.rs`)
- Warnings are a `Vec`, so faces and species can both report.
- Each photo's warnings ride on its own `results` entry as well as the request-level list, so a grouped caller can attribute them.
- Messages name the action: *"face model is not downloaded yet — run \"Download AI models\" in Plug-in Manager and index these photos again"* (same for species).

**Preflight gate** — catch it before the indexing time is spent, not after
- `SearchIndexAPI.confirmModelsReadyForTasks(tasks)` checks `/assets/status` against the models the run's tasks actually need, and offers **Download now** / **Continue without it** / **Cancel**.
- Wired into Analyze & Index (on **Start**) and cull-prepare.
- Only the needed families are checked — a search-only run is not stopped by a missing species model. A failed check never blocks the run: an unreachable status endpoint must not turn into "you cannot index".

**Advanced Search** — the same honesty about coverage
- A note in the dialog when the search model is missing, and when part of the catalog has no embedding. A text search over a half-indexed catalog answers "no results" for a subject that is sitting right there, and an empty result set is indistinguishable from an empty catalog.
- Shown inside the dialog rather than as a modal, so it does not cost a click on every search.
- Cost: one `/db/stats` call plus the catalog photo count. **Measured at ~95 ms over 14,070 photos** against a real catalog. It scales linearly, so a very large catalog would pay proportionally more — flagging that as the one number worth revisiting.

**`CLAUDE.md`** — the general rule all three were violations of: a log line is not a report; every link from backend → response → API wrapper → `Task*.lua` → dialog is load-bearing; a degraded success is not a success; say what to do, not what happened; accumulate in a list, never one slot.

## Verification

Live-tested, not only unit-tested. A throwaway server on port 19899 with the face model paths pointed at nowhere, given a cull-shaped request:

```json
"success": true,
"warnings": ["astronaut.jpg faces: face model is not downloaded yet — run \"Download AI models\" in Plug-in Manager and index these photos again"]
```

- `cargo clippy --workspace --all-targets` — zero warnings
- `cargo test -p lrg-api` — 24 passed
- `busted` — 208 passed (22 new, in `plugin/spec/util_model_readiness_spec.lua`)
- `luacheck` / `stylua` / `scripts/check-docs.py` — clean

The new pure helpers (`Util.requiredModelFamilies`, `missingModelFamilies`, `searchCoverage`, `formatDownloadSize`) are unit-tested headless; the fixture uses the exact `/assets/status` payload the backend returns.

## Not verified

The three dialogs themselves have not been seen in Lightroom — no LrC available in this environment. The view construction follows the existing `Util.showHealthIssuesDialog` pattern (`table.insert` into an `f:column`), and everything lints, but the actual layout is unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrkFySXXjhztpjgijtLmd7