### PR TITLE
Stop walking the catalog a photo at a time before any progress shows

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -1432,9 +1432,13 @@ function SearchIndexAPI.getPhotoData(photoId)
 	log:trace("Retrieving photo data for photo_id: " .. photoId)
 
 	local result, err = _request("POST", url, body)
+	-- The transport failure is returned, not just logged: "the backend is
+	-- unreachable" and "this photo was never indexed" both arrive here as a
+	-- nil record, and a caller that cannot tell them apart reports a dead
+	-- server as several thousand photos quietly having no data.
 	if err then
 		log:error("Failed to retrieve photo data: " .. err)
-		return nil
+		return nil, err
 	end
 
 	if result and result.status == "success" then

--- a/plugin/LrGeniusAI.lrdevplugin/PhotoSelector.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PhotoSelector.lua
@@ -1,12 +1,44 @@
 PhotoSelector = {}
 
-local function filterPhotos(photos)
+---
+-- Drops videos from a photo list.
+--
+-- `isVideo` is read for the whole list in one catalog call. Asking each photo
+-- on its own is a separate trip into the catalog per photo, and for the "all"
+-- scope that runs over the entire catalog before the caller has put a progress
+-- scope on screen — so a large catalog looks for minutes like the plugin did
+-- nothing at all.
+--
+-- Falls back to the per-photo read if the batch call is unavailable or throws,
+-- because getting this wrong means videos reach a backend that rejects them.
+--
+local function filterPhotos(catalog, photos)
 	if not photos then
 		return {}
 	end
+
+	local batch
+	if catalog then
+		local ok, result = LrTasks.pcall(function()
+			return catalog:batchGetRawMetadata(photos, { "isVideo" })
+		end)
+		if ok then
+			batch = result
+		else
+			log:warn("batchGetRawMetadata failed; falling back to per-photo reads: " .. tostring(result))
+		end
+	end
+
 	local filteredPhotos = {}
 	for _, photo in ipairs(photos) do
-		if not photo:getRawMetadata("isVideo") then
+		local entry = batch and batch[photo]
+		local isVideo
+		if entry ~= nil then
+			isVideo = entry.isVideo
+		else
+			isVideo = photo:getRawMetadata("isVideo")
+		end
+		if not isVideo then
 			table.insert(filteredPhotos, photo)
 		end
 	end
@@ -27,7 +59,7 @@ function PhotoSelector.getPhotosInScope(scope, taskOptions, lookupProgressScope)
 	local status = "ok"
 
 	if scope == "selected" then
-		photosToProcess = filterPhotos(catalog:getTargetPhotos())
+		photosToProcess = filterPhotos(catalog, catalog:getTargetPhotos())
 	elseif scope == "view" then
 		local sources = catalog:getActiveSources()
 		if not sources or #sources == 0 then
@@ -38,10 +70,10 @@ function PhotoSelector.getPhotosInScope(scope, taskOptions, lookupProgressScope)
 		for _, source in ipairs(sources) do
 			if type(source) == "string" then
 				if source == "kAllPhotos" then
-					photosToProcess = filterPhotos(catalog:getAllPhotos())
+					photosToProcess = filterPhotos(catalog, catalog:getAllPhotos())
 					break -- No need to process other sources
 				elseif source == "kPreviousImport" then
-					local previousImport = filterPhotos(catalog:getPreviousImport())
+					local previousImport = filterPhotos(catalog, catalog:getPreviousImport())
 					if previousImport then
 						for _, photo in ipairs(previousImport) do
 							local photoId = photo:getRawMetadata("uuid")
@@ -62,7 +94,7 @@ function PhotoSelector.getPhotosInScope(scope, taskOptions, lookupProgressScope)
 					or source:type() == "LrPublishedCollection"
 				)
 			then
-				local photos = filterPhotos(source:getPhotos())
+				local photos = filterPhotos(catalog, source:getPhotos())
 				for _, photo in ipairs(photos) do
 					local photoId = photo:getRawMetadata("uuid")
 					if not addedPhotos[photoId] then
@@ -91,7 +123,7 @@ function PhotoSelector.getPhotosInScope(scope, taskOptions, lookupProgressScope)
 			return nil, "Invalid view"
 		end
 	elseif scope == "all" then
-		photosToProcess = filterPhotos(catalog:getAllPhotos())
+		photosToProcess = filterPhotos(catalog, catalog:getAllPhotos())
 	elseif scope == "missing" then
 		local success
 		success, photosToProcess = SearchIndexAPI.getMissingPhotosFromIndex(taskOptions, lookupProgressScope)

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -954,7 +954,7 @@ LrTasks.startAsyncTask(function()
 		-- terms instead of inventing near-synonyms with different casing. Counting
 		-- keyword usage walks the whole keyword tree, so it runs under the progress
 		-- scope rather than silently freezing the UI on a large catalog.
-		if props.generateKeywords and props.keywordAliases and props.enableMetadata then
+		if props.generateKeywords and props.enableMetadata then
 			progressScope:setCaption(
 				LOC("$$$/LrGeniusAI/AnalyzeAndIndex/ReadingCatalogKeywords=Reading catalog keywords...")
 			)

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -954,7 +954,7 @@ LrTasks.startAsyncTask(function()
 		-- terms instead of inventing near-synonyms with different casing. Counting
 		-- keyword usage walks the whole keyword tree, so it runs under the progress
 		-- scope rather than silently freezing the UI on a large catalog.
-		if props.generateKeywords then
+		if props.generateKeywords and props.keywordAliases and props.enableMetadata then
 			progressScope:setCaption(
 				LOC("$$$/LrGeniusAI/AnalyzeAndIndex/ReadingCatalogKeywords=Reading catalog keywords...")
 			)

--- a/plugin/LrGeniusAI.lrdevplugin/TaskRetrieveMetadata.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskRetrieveMetadata.lua
@@ -173,9 +173,19 @@ LrTasks.startAsyncTask(function()
 			return
 		end
 
+		-- Created before the scope is resolved, not after. Collecting the "all"
+		-- scope walks the whole catalog, and with the scope created afterwards
+		-- Lightroom showed nothing at all while it did — indistinguishable from
+		-- the command having been ignored.
+		local progressScope = LrProgressScope({
+			title = LOC("$$$/LrGeniusAI/RetrieveMetadata/ProgressTitle=Retrieving Metadata from Backend"),
+		})
+		progressScope:setCaption(LOC("$$$/LrGeniusAI/RetrieveMetadata/CollectingPhotos=Collecting photos..."))
+
 		-- Get photos based on scope
 		local photos = PhotoSelector.getPhotosInScope(options.scope)
 		if not photos or #photos == 0 then
+			progressScope:done()
 			LrDialogs.message(
 				LOC("$$$/LrGeniusAI/RetrieveMetadata/NoPhotos=No Photos"),
 				LOC("$$$/LrGeniusAI/RetrieveMetadata/NoPhotosMessage=No photos found in the selected scope."),
@@ -185,11 +195,6 @@ LrTasks.startAsyncTask(function()
 		end
 
 		log:info(string.format("Starting metadata retrieval for %d photos", #photos))
-
-		-- Progress indicator
-		local progressScope = LrProgressScope({
-			title = LOC("$$$/LrGeniusAI/RetrieveMetadata/ProgressTitle=Retrieving Metadata from Backend"),
-		})
 
 		local successCount = 0
 		local skipCount = 0
@@ -217,7 +222,17 @@ LrTasks.startAsyncTask(function()
 
 			local photoId, photoIdErr = SearchIndexAPI.getPhotoIdForPhoto(photo)
 			if photoId then
-				if not SearchIndexAPI.pingServer() then
+				-- Retrieve data from backend
+				log:trace("Retrieving data for photo_id: " .. photoId)
+				local retrievedData, err = SearchIndexAPI.getPhotoData(photoId)
+
+				log:trace("Retrieved data: " .. Util.dumpTable(retrievedData))
+
+				-- Only ping once the real request has already failed at the
+				-- transport level. This used to run before every photo, which
+				-- doubled the round trips for the whole run in order to answer
+				-- a question that only matters when something went wrong.
+				if err and not SearchIndexAPI.pingServer() then
 					LrDialogs.message(
 						LOC("$$$/LrGeniusAI/RetrieveMetadata/ServerUnreachable=Server Unreachable"),
 						LOC(
@@ -228,11 +243,6 @@ LrTasks.startAsyncTask(function()
 					log:error("Backend server unreachable during metadata retrieval")
 					break
 				end
-				-- Retrieve data from backend
-				log:trace("Retrieving data for photo_id: " .. photoId)
-				local retrievedData, err = SearchIndexAPI.getPhotoData(photoId)
-
-				log:trace("Retrieved data: " .. Util.dumpTable(retrievedData))
 
 				if err then
 					log:error("Error retrieving metadata for " .. fileName .. ": " .. tostring(err))


### PR DESCRIPTION
## What

*Retrieve Metadata* with scope **all** looked like it did nothing, then took a long time to start. Two causes stacked on top of each other:

- `PhotoSelector.filterPhotos` asked each photo for `isVideo` individually — a separate trip into the catalog per photo. Over a whole catalog that is essentially the entire cost of the "collect photos" step.
- `TaskRetrieveMetadata` created its `LrProgressScope` **after** resolving the scope, so Lightroom had nothing on screen while that ran.

Together they are indistinguishable from the command having been ignored.

## Changes

- `PhotoSelector.lua` — `isVideo` is read for the whole list in one `catalog:batchGetRawMetadata(photos, { "isVideo" })` call, falling back to the per-photo read if that throws. Getting this wrong would send videos to a backend that rejects them, so the fallback stays. `batchGetRawMetadata` was previously unused in the plugin; minimum SDK here is 14.0, so it is safely available.
- `TaskRetrieveMetadata.lua` — the progress scope is created before the scope is resolved, captioned "Collecting photos...".
- `TaskRetrieveMetadata.lua` — `pingServer()`, a full HTTP round trip, ran before **every single photo**, doubling the run's requests to answer a question that only matters once something has already failed. It now runs only after a failed request.
- `TaskAnalyzeAndIndex.lua` — collecting the catalog keyword vocabulary walks the whole keyword tree, which is a visible pause before the first photo is processed. It is now gated on `enableMetadata`, so a pass that only computes embeddings, faces or species skips it outright. Runs that do generate keywords still get the vocabulary, so the model keeps reusing existing terms rather than inventing near-synonyms.

## Incidental bug found while doing the above

`SearchIndexAPI.getPhotoData` returned a single value, so the caller's `local retrievedData, err = ...` left `err` permanently `nil` and the whole `if err then` branch was dead code. An unreachable backend was being counted as several thousand photos that happened to have no data. It now returns `nil, err` for a transport failure and keeps a bare `nil` for "not indexed", so the two stay distinguishable. The other three callers read one value and are unaffected.

## Verification

`luacheck`, `stylua` and `busted` (208 specs) all clean.

The speedup itself has **not** been measured against a real catalog — the changes are structural (N catalog round trips collapsed into one, progress shown before the work rather than after), but someone should confirm on a large library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXAj78XwjCXVbHWFobXTft
