### PR TITLE
Fix four places where a problem never reached the user

### DIFF
--- a/.github/workflows/golden-tests-full.yml
+++ b/.github/workflows/golden-tests-full.yml
@@ -1,0 +1,87 @@
+name: "Golden tests (all model assets)"
+
+# The ML golden tests skip when their model files are absent, and a skipped
+# test is reported as a pass. `server-rs-tests.yml` closes that hole for the
+# face family (89 MB, cheap enough per PR), but BioCLIP (834 MB) and SigLIP2
+# (2.2 GB) are too heavy to fetch on every push. This job fetches all three
+# and runs with LRG_REQUIRE_GOLDENS=all, so a missing asset fails instead of
+# skipping — the numerical checks either run or the job goes red.
+#
+# Deliberately *not* cached. A fresh download each night also verifies that
+# the published release assets are still present and fetchable, which is what
+# the plugin's own download-on-first-run depends on; a cache hit would hide
+# exactly that failure.
+
+on:
+  schedule:
+    # 04:30 UTC daily — after the usual merge window, before the workday.
+    - cron: '30 4 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  golden-tests:
+    name: Goldens with real model assets
+    runs-on: ubuntu-latest
+    # 3 GB of model downloads plus ONNX inference on CPU; the default 360 min
+    # is far more than needed, but the fetch alone can be several minutes.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: server-rs
+
+      # Asset names and tags mirror the download routes, which are the
+      # authority: routes/clip.rs (MODEL_ASSETS_RELEASE_TAG), routes/assets.rs
+      # (FACE_ASSETS_RELEASE_TAG) and routes/bioclip.rs
+      # (BIOCLIP_ASSETS_RELEASE_TAG). They land in the same
+      # ~/.cache/lrgenius/models directory model_paths.rs falls back to, so no
+      # LRG_*_ONNX overrides are needed.
+      - name: Download all model assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          dest=~/.cache/lrgenius/models
+          mkdir -p "$dest"
+
+          gh release download face-assets-v1 --repo "$GITHUB_REPOSITORY" --dir "$dest" \
+            --pattern 'yunet_face_detection.onnx' \
+            --pattern 'facenet_vggface2.onnx'
+
+          gh release download bioclip-assets-v1 --repo "$GITHUB_REPOSITORY" --dir "$dest" \
+            --pattern 'bioclip2_image_fp16.onnx' \
+            --pattern 'bioclip2_taxa.bin' \
+            --pattern 'bioclip2_taxa.json'
+
+          gh release download model-assets-v1 --repo "$GITHUB_REPOSITORY" --dir "$dest" \
+            --pattern 'siglip2_image_fp16.onnx' \
+            --pattern 'siglip2_text_fp16.onnx' \
+            --pattern 'tokenizer.json'
+
+          # The release assets carry an fp16 suffix the resolver does not
+          # expect; model_paths.rs looks for these names.
+          mv "$dest/siglip2_image_fp16.onnx" "$dest/siglip2_image.onnx"
+          mv "$dest/siglip2_text_fp16.onnx" "$dest/siglip2_text.onnx"
+          mv "$dest/bioclip2_image_fp16.onnx" "$dest/bioclip2_image.onnx"
+
+          ls -lh "$dest"
+          df -h .
+
+      - name: Run goldens with every family required
+        working-directory: server-rs
+        env:
+          LRG_REQUIRE_GOLDENS: all
+        run: cargo test --workspace

--- a/.github/workflows/server-rs-tests.yml
+++ b/.github/workflows/server-rs-tests.yml
@@ -26,6 +26,36 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: server-rs
+      # The face pair is 89 MB — small enough to fetch on every PR, unlike
+      # BioCLIP (834 MB) and SigLIP2 (2.2 GB), which the nightly job covers.
+      # Without this the face golden test takes its skip branch, and a skip
+      # is reported as a pass: CI would be green on a build whose face
+      # embeddings were numerically wrong. LRG_REQUIRE_GOLDENS below is what
+      # makes that impossible — if this download breaks, the test fails
+      # rather than quietly going back to skipping.
+      - name: Cache face model assets
+        id: face-assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/lrgenius/models
+          key: face-assets-v1
+      - name: Download face model assets
+        if: steps.face-assets.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/lrgenius/models
+          gh release download face-assets-v1 \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'yunet_face_detection.onnx' \
+            --pattern 'facenet_vggface2.onnx' \
+            --dir ~/.cache/lrgenius/models
+          ls -lh ~/.cache/lrgenius/models
       - name: Run cargo test
         working-directory: server-rs
+        # Asserts the face assets above were really used. Any other family
+        # still skips here; the nightly job runs those with LRG_REQUIRE_GOLDENS=all.
+        env:
+          LRG_REQUIRE_GOLDENS: face
         run: cargo test --workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,15 @@ cargo test --workspace
 cargo run -p lrg-server -- --db-path /path/to/lrgenius.db --debug
 ```
 
+**The ML golden tests skip when their model files are absent, and a skip is
+reported as a pass.** Set `LRG_REQUIRE_GOLDENS` to the families whose assets
+are present (`face`, `siglip`, `bioclip`, or `all`) to turn that skip into a
+failure — this is what stops CI being green on numerical checks that never ran.
+PR CI provisions the face pair (89 MB) and requires it; the nightly
+`golden-tests-full.yml` fetches all three. If you add a golden test, gate it
+through `crates/lrg-ml/tests/common/assets_ready` rather than an early
+`return`.
+
 ### Plugin — load into Lightroom
 
 Add (or symlink) `plugin/LrGeniusAI.lrdevplugin` via Lightroom **Plug-in Manager**. Smoke tests run inside Lightroom via `TaskAutomatedTests.lua`.

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -85,7 +85,10 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 
 `warnings` is where a *degraded success* is reported: the photo was indexed, but
 an optional signal was lost — most often `"<file> faces: face model is not
-downloaded yet …"` or the same for species. These never fail the photo
+downloaded yet …"` or the same for species. Metadata generation reports here
+too: when the LLM returns `success` but omits a field that was asked for, the
+provider says so in its own `warning` and it arrives as
+`"<file>: the model returned no caption for this photo — the rest was kept …"`. These never fail the photo
 (`success_count` still counts it), so a caller that ignores `warnings` shows the
 user a clean run that silently produced worse data. Each entry also rides on its
 own photo's `results` element as `warnings`, so a grouped caller can attribute it.

--- a/docs/wiki/Dev-Server-README.md
+++ b/docs/wiki/Dev-Server-README.md
@@ -40,6 +40,33 @@ cargo build --release -p lrg-server
 `cargo test --workspace` and `cargo clippy --workspace --all-targets` should
 both be clean before sending changes.
 
+### Golden tests and `LRG_REQUIRE_GOLDENS`
+
+The ML golden tests — SigLIP2, BioCLIP 2 and the face pipeline — compare real
+inference against torch-computed reference values. They need their model files
+on disk and **skip when those are absent**, which the Rust test harness reports
+as a pass. That is fine on a working copy, and dangerous in CI: a green run is
+otherwise indistinguishable from one where the numerical checks never executed.
+
+`LRG_REQUIRE_GOLDENS` turns the skip into a failure for the families you name,
+so a job that provisions assets can prove it used them:
+
+```bash
+LRG_REQUIRE_GOLDENS=face          cargo test --workspace   # one family
+LRG_REQUIRE_GOLDENS=face,siglip   cargo test --workspace   # a subset
+LRG_REQUIRE_GOLDENS=all           cargo test --workspace   # every family
+```
+
+Family names are `face`, `siglip` and `bioclip`. Per-family rather than a
+single switch because they differ in cost by more than an order of magnitude
+(89 MB, 2.2 GB and 834 MB respectively).
+
+CI uses both halves: `server-rs-tests.yml` downloads the face pair on every PR
+and sets `LRG_REQUIRE_GOLDENS=face`, while the nightly `golden-tests-full.yml`
+fetches all three and runs with `all`. The models resolve through the same
+`LRG_*_ONNX` env vars and `~/.cache/lrgenius/models/` fallback the server uses,
+so a machine that has run the plugin's model download needs no extra setup.
+
 ### Optional feature: `llamacpp`
 
 The in-process local LLM is behind a cargo feature that is **off by default**.

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -195,8 +195,12 @@ local function parseCompletedMigrations(raw)
 	local inProgress = false
 	local inProgressSince = nil
 	if raw and raw ~= "" then
-		for part in string.gmatch(raw, "([^,]+)") do
-			part = part:match("^%s*(.-)%s*$") or part
+		-- Trimmed into a fresh local rather than reassigning the loop
+		-- variable: Lightroom's Lua 5.1 allows that, but 5.3+ makes the
+		-- generic-for control variable const, and the headless `busted` suite
+		-- runs on the system Lua — where the whole module failed to load.
+		for rawPart in string.gmatch(raw, "([^,]+)") do
+			local part = rawPart:match("^%s*(.-)%s*$") or rawPart
 			if part == MIGRATION_IN_PROGRESS_PREFIX then
 				-- Legacy unversioned marker (pre-timestamp plugin version): treat as stale.
 				inProgress = true
@@ -921,6 +925,146 @@ end
 -- served by the backend, so this wrapper stays as the way back to the
 -- prompt-driven LLM edit rather than being deleted with it.
 ---
+-- Reduces a run's raw tallies into the status + message pair the Task layer shows.
+--
+-- Extracted from analyzeAndIndexSelectedPhotos so the dedup/cap rules can be
+-- tested directly; they are what decides whether a user hears about a problem
+-- at all.
+--
+-- Both lists are deduplicated (a run-wide cause otherwise repeats once per
+-- photo) and capped, and the cap *counts* what it hides rather than dropping
+-- it silently — "show a handful and count the rest" per the escalation rules
+-- in CLAUDE.md. Warnings previously had no cap at all, so a large run could
+-- produce a dialog thousands of lines long; errors were capped at 5 but said
+-- nothing about the remainder.
+--
+-- @param stats table { processed = number, failed = number }
+-- @param errorMessages table Array of raw error strings.
+-- @param warningsList table Array of raw warning strings.
+-- @return string status "success" | "somefailed" | "allfailed"
+-- @return string|nil combinedError
+-- @return string|nil combinedWarnings
+function SearchIndexAPI.summarizeRun(stats, errorMessages, warningsList)
+	local status
+	if stats.failed == 0 then
+		status = "success"
+	elseif stats.failed >= stats.processed and stats.processed > 0 then
+		status = "allfailed"
+	else
+		status = "somefailed"
+	end
+
+	return status, SearchIndexAPI.condenseMessages(errorMessages), SearchIndexAPI.condenseMessages(warningsList)
+end
+
+-- How many distinct messages a summary shows before it starts counting.
+local MAX_SUMMARY_MESSAGES = 5
+
+---
+-- Deduplicates a message list, keeps the first few, and counts the remainder.
+--
+-- @param messages table|nil Array of strings.
+-- @return string|nil nil when there is nothing to report.
+function SearchIndexAPI.condenseMessages(messages)
+	if type(messages) ~= "table" or #messages == 0 then
+		return nil
+	end
+	local seen = {}
+	local unique = {}
+	for _, msg in ipairs(messages) do
+		local text = tostring(msg)
+		if not seen[text] then
+			seen[text] = true
+			table.insert(unique, text)
+		end
+	end
+	if #unique == 0 then
+		return nil
+	end
+
+	local shown = {}
+	for i = 1, math.min(#unique, MAX_SUMMARY_MESSAGES) do
+		table.insert(shown, unique[i])
+	end
+	local hidden = #unique - #shown
+	if hidden > 0 then
+		table.insert(shown, LOC("$$$/LrGeniusAI/common/AndNMore=...and ^1 more", tostring(hidden)))
+	end
+	return table.concat(shown, "\n")
+end
+
+---
+-- Interprets an /edit response into the (ok, valueOrError) pair the callers use.
+--
+-- Extracted from generateEditRecipePhoto so it can be unit tested: the
+-- surrounding function builds a multipart body and does HTTP, but every bug
+-- this file has had on the edit path was in *reading the reply* — a status
+-- spelled differently, a non-table body, an error field nobody forwarded.
+--
+-- @param response table|nil Decoded response body, or nil on transport failure.
+-- @param err string|nil Transport error, when response is nil.
+-- @return boolean ok
+-- @return table|string responseOrError
+function SearchIndexAPI.interpretEditResponse(response, err)
+	if not response then
+		log:error("Failed to generate AI edit recipe: " .. tostring(err))
+		return false, err or "Unknown error"
+	end
+	if type(response) ~= "table" then
+		log:error(
+			"AI edit recipe response has unexpected type: "
+				.. tostring(type(response))
+				.. " value="
+				.. tostring(response)
+		)
+		return false, "Invalid response type from /edit endpoint: " .. tostring(type(response))
+	end
+	if response.status == "success" then
+		return true, response
+	end
+	log:error("Unexpected response status for AI edit recipe: " .. tostring(response.status))
+	return false, response.error or "Unexpected response status"
+end
+
+---
+-- Interprets an /index response for a single photo.
+--
+-- Extracted from analyzeAndIndexPhoto for the same reason as
+-- interpretEditResponse. Returns the whole response on success so the caller
+-- can read `warnings` off it — a success here can still be degraded.
+--
+-- @param response table|nil Decoded response body, or nil on transport failure.
+-- @param err string|nil Transport error, when response is nil.
+-- @param filename string For log lines only.
+-- @return boolean ok
+-- @return table|string responseOrError
+function SearchIndexAPI.interpretIndexResponse(response, err, filename)
+	if not response then
+		log:error("Failed to analyze/index photo: " .. tostring(err))
+		return false, err or "Unknown error"
+	end
+	if type(response) ~= "table" then
+		log:error("Index response has unexpected type: " .. tostring(type(response)))
+		return false, "Invalid response type from /index endpoint: " .. tostring(type(response))
+	end
+
+	if response.status == "processed" then
+		local success_count = response.success_count or 0
+
+		if success_count > 0 then
+			log:trace("Successfully processed photo: " .. tostring(filename))
+			return true, response
+		else
+			log:error("Photo processing failed: " .. tostring(filename))
+			return false, response.error or "Processing failed"
+		end
+	else
+		log:error("Unexpected response status: " .. tostring(response.status))
+		return false, "Unexpected response status"
+	end
+end
+
+---
 
 function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 	if filepath == nil then
@@ -1036,24 +1180,7 @@ function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 
 	log:trace("Generating AI edit recipe for photo: " .. filename .. " with id " .. photoId)
 	local response, err = _requestMultipart(url, mimeChunks, 720)
-	if not response then
-		log:error("Failed to generate AI edit recipe: " .. tostring(err))
-		return false, err or "Unknown error"
-	end
-	if type(response) ~= "table" then
-		log:error(
-			"AI edit recipe response has unexpected type: "
-				.. tostring(type(response))
-				.. " value="
-				.. tostring(response)
-		)
-		return false, "Invalid response type from /edit endpoint: " .. tostring(type(response))
-	end
-	if response.status == "success" then
-		return true, response
-	end
-	log:error("Unexpected response status for AI edit recipe: " .. tostring(response.status))
-	return false, response.error or "Unexpected response status"
+	return SearchIndexAPI.interpretEditResponse(response, err)
 end
 
 function SearchIndexAPI.analyzeAndIndexPhoto(photoId, filepath, options)
@@ -1198,26 +1325,7 @@ function SearchIndexAPI.analyzeAndIndexPhoto(photoId, filepath, options)
 
 	local response, err = _requestMultipart(url, mimeChunks, 720)
 
-	if not response then
-		log:error("Failed to analyze/index photo: " .. tostring(err))
-		return false, err or "Unknown error"
-	end
-
-	-- Check response status
-	if response.status == "processed" then
-		local success_count = response.success_count or 0
-
-		if success_count > 0 then
-			log:trace("Successfully processed photo: " .. filename)
-			return true, response
-		else
-			log:error("Photo processing failed: " .. filename)
-			return false, response.error or "Processing failed"
-		end
-	else
-		log:error("Unexpected response status: " .. tostring(response.status))
-		return false, "Unexpected response status"
-	end
+	return SearchIndexAPI.interpretIndexResponse(response, err, filename)
 end
 
 ---
@@ -2405,44 +2513,7 @@ function SearchIndexAPI.analyzeAndIndexSelectedPhotos(selectedPhotos, progressSc
 		return "canceled", stats.processed, stats.failed, processedPhotos
 	end
 
-	local status
-	if stats.failed == 0 then
-		status = "success"
-	elseif stats.failed >= stats.processed and stats.processed > 0 then
-		status = "allfailed"
-	else
-		status = "somefailed"
-	end
-
-	local combinedError
-	if #errorMessages > 0 then
-		local uniqueErrors = {}
-		local errorList = {}
-		for _, msg in ipairs(errorMessages) do
-			if not uniqueErrors[msg] then
-				uniqueErrors[msg] = true
-				table.insert(errorList, msg)
-				if #errorList >= 5 then
-					break
-				end
-			end
-		end
-		combinedError = table.concat(errorList, "\n")
-	end
-
-	local combinedWarnings
-	if #warningsList > 0 then
-		local uniqueWarnings = {}
-		local warningListStrings = {}
-		for _, w in ipairs(warningsList) do
-			if not uniqueWarnings[w] then
-				uniqueWarnings[w] = true
-				table.insert(warningListStrings, w)
-			end
-		end
-		combinedWarnings = table.concat(warningListStrings, "\n")
-	end
-
+	local status, combinedError, combinedWarnings = SearchIndexAPI.summarizeRun(stats, errorMessages, warningsList)
 	return status, stats.processed, stats.failed, processedPhotos, combinedError, combinedWarnings
 end
 

--- a/plugin/spec/api_search_index_spec.lua
+++ b/plugin/spec/api_search_index_spec.lua
@@ -1,0 +1,186 @@
+-- Unit tests for the pure response/summary logic in APISearchIndex.lua.
+--
+-- That file is the plugin's busiest source of bug fixes and had no test file
+-- at all. The three functions under test here are the parts that decide what
+-- the user is told: whether a reply counts as success, and which errors and
+-- warnings survive into the dialog. Everything around them is HTTP and
+-- Lightroom state, which is why these were pulled out to be reachable.
+
+require("APISearchIndex")
+
+describe("SearchIndexAPI.interpretIndexResponse", function()
+	it("treats a processed response with successes as success", function()
+		local response = { status = "processed", success_count = 1 }
+		local ok, value = SearchIndexAPI.interpretIndexResponse(response, nil, "a.jpg")
+		assert.is_true(ok)
+		-- The whole response comes back, not just a flag: the caller reads
+		-- `warnings` off it, and a success here can still be degraded.
+		assert.are.equal(response, value)
+	end)
+
+	it("passes warnings through on success so the caller can surface them", function()
+		local response = {
+			status = "processed",
+			success_count = 1,
+			warnings = { "a.jpg faces: face model is not downloaded yet" },
+		}
+		local ok, value = SearchIndexAPI.interpretIndexResponse(response, nil, "a.jpg")
+		assert.is_true(ok)
+		assert.are.same({ "a.jpg faces: face model is not downloaded yet" }, value.warnings)
+	end)
+
+	it("fails a processed response that indexed nothing", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse(
+			{ status = "processed", success_count = 0, error = "unsupported format" },
+			nil,
+			"a.jpg"
+		)
+		assert.is_false(ok)
+		assert.are.equal("unsupported format", err)
+	end)
+
+	it("falls back to a generic message when a failure carries no error text", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse({ status = "processed", success_count = 0 }, nil, "a.jpg")
+		assert.is_false(ok)
+		assert.are.equal("Processing failed", err)
+	end)
+
+	it("treats a missing success_count as zero rather than as success", function()
+		local ok = SearchIndexAPI.interpretIndexResponse({ status = "processed" }, nil, "a.jpg")
+		assert.is_false(ok)
+	end)
+
+	it("reports the transport error when there is no response", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse(nil, "connection refused", "a.jpg")
+		assert.is_false(ok)
+		assert.are.equal("connection refused", err)
+	end)
+
+	it("still fails when there is neither a response nor an error", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse(nil, nil, "a.jpg")
+		assert.is_false(ok)
+		assert.are.equal("Unknown error", err)
+	end)
+
+	it("rejects a non-table body instead of indexing into it", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse("<html>502</html>", nil, "a.jpg")
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("Invalid response type", 1, true))
+	end)
+
+	it("rejects an unexpected status", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse({ status = "queued" }, nil, "a.jpg")
+		assert.is_false(ok)
+		assert.are.equal("Unexpected response status", err)
+	end)
+end)
+
+describe("SearchIndexAPI.interpretEditResponse", function()
+	it("accepts a success response and returns the whole body", function()
+		local response = { status = "success", recipe = { Exposure2012 = 0.3 } }
+		local ok, value = SearchIndexAPI.interpretEditResponse(response, nil)
+		assert.is_true(ok)
+		assert.are.equal(response, value)
+	end)
+
+	it("reports the server's error for a non-success status", function()
+		local ok, err = SearchIndexAPI.interpretEditResponse({ status = "error", error = "no model" }, nil)
+		assert.is_false(ok)
+		assert.are.equal("no model", err)
+	end)
+
+	it("falls back to a generic message when the error field is absent", function()
+		local ok, err = SearchIndexAPI.interpretEditResponse({ status = "error" }, nil)
+		assert.is_false(ok)
+		assert.are.equal("Unexpected response status", err)
+	end)
+
+	it("rejects a non-table body", function()
+		local ok, err = SearchIndexAPI.interpretEditResponse("not json", nil)
+		assert.is_false(ok)
+		assert.is_truthy(tostring(err):find("Invalid response type", 1, true))
+	end)
+
+	it("reports the transport error when there is no response", function()
+		local ok, err = SearchIndexAPI.interpretEditResponse(nil, "timeout")
+		assert.is_false(ok)
+		assert.are.equal("timeout", err)
+	end)
+end)
+
+describe("SearchIndexAPI.condenseMessages", function()
+	it("returns nil for nothing to report", function()
+		assert.is_nil(SearchIndexAPI.condenseMessages({}))
+		assert.is_nil(SearchIndexAPI.condenseMessages(nil))
+	end)
+
+	it("collapses a run-wide cause repeated once per photo", function()
+		local repeated = {}
+		for _ = 1, 40 do
+			table.insert(repeated, "face model is not downloaded yet")
+		end
+		assert.are.equal("face model is not downloaded yet", SearchIndexAPI.condenseMessages(repeated))
+	end)
+
+	it("keeps distinct messages in first-seen order", function()
+		local got = SearchIndexAPI.condenseMessages({ "b", "a", "b", "c" })
+		assert.are.equal("b\na\nc", got)
+	end)
+
+	it("counts the remainder instead of dropping it", function()
+		local many = {}
+		for i = 1, 9 do
+			table.insert(many, "problem " .. i)
+		end
+		local got = SearchIndexAPI.condenseMessages(many)
+		local lines = {}
+		for line in got:gmatch("[^\n]+") do
+			table.insert(lines, line)
+		end
+		-- Five shown plus one counting line; the four hidden ones are named,
+		-- not silently discarded.
+		assert.are.equal(6, #lines)
+		assert.are.equal("problem 5", lines[5])
+		assert.is_truthy(lines[6]:find("4", 1, true))
+	end)
+
+	it("does not add a counting line when everything fits", function()
+		local got = SearchIndexAPI.condenseMessages({ "one", "two" })
+		assert.are.equal("one\ntwo", got)
+	end)
+end)
+
+describe("SearchIndexAPI.summarizeRun", function()
+	it("is a success when nothing failed", function()
+		local status = SearchIndexAPI.summarizeRun({ processed = 10, failed = 0 }, {}, {})
+		assert.are.equal("success", status)
+	end)
+
+	it("is allfailed when every processed photo failed", function()
+		local status = SearchIndexAPI.summarizeRun({ processed = 4, failed = 4 }, { "boom" }, {})
+		assert.are.equal("allfailed", status)
+	end)
+
+	it("is somefailed for a partial failure", function()
+		local status = SearchIndexAPI.summarizeRun({ processed = 10, failed = 3 }, { "boom" }, {})
+		assert.are.equal("somefailed", status)
+	end)
+
+	it("reports warnings even when the run fully succeeded", function()
+		-- The degraded-success case: nothing failed, but a signal was lost.
+		local status, err, warnings = SearchIndexAPI.summarizeRun(
+			{ processed = 3, failed = 0 },
+			{},
+			{ "a.jpg faces: model missing", "a.jpg faces: model missing", "b.jpg species: model missing" }
+		)
+		assert.are.equal("success", status)
+		assert.is_nil(err)
+		assert.are.equal("a.jpg faces: model missing\nb.jpg species: model missing", warnings)
+	end)
+
+	it("returns nil messages when there is nothing to say", function()
+		local _, err, warnings = SearchIndexAPI.summarizeRun({ processed = 1, failed = 0 }, {}, {})
+		assert.is_nil(err)
+		assert.is_nil(warnings)
+	end)
+end)

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -7,9 +7,26 @@
 --
 -- This helper is loaded by busted (see /.busted) before any spec runs.
 
--- LOC() in tests just returns the key/default string unchanged.
+-- LOC() mirrors what Lightroom actually does: strip the "$$$/path=" key
+-- prefix and substitute ^1..^9 with the trailing arguments.
+--
+-- It used to return the raw key string unchanged, which quietly made every
+-- assertion about user-facing text meaningless — a test could assert on
+-- "$$$/Foo/Bar=..." and pass while the real dialog said something else.
 _G.LOC = function(s, ...)
-	return s
+	if type(s) ~= "string" then
+		return s
+	end
+	local text = s:match("^%$%$%$/[^=]*=(.*)$") or s
+	local args = { ... }
+	text = text:gsub("%^(%d)", function(digit)
+		local value = args[tonumber(digit)]
+		if value == nil then
+			return "^" .. digit
+		end
+		return tostring(value)
+	end)
+	return text
 end
 
 -- import("LrFoo") returns a no-op stand-in. Any field access yields a function

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -36,6 +36,33 @@ cargo build --release -p lrg-server
 `cargo test --workspace` and `cargo clippy --workspace --all-targets` should
 both be clean before sending changes.
 
+### Golden tests and `LRG_REQUIRE_GOLDENS`
+
+The ML golden tests — SigLIP2, BioCLIP 2 and the face pipeline — compare real
+inference against torch-computed reference values. They need their model files
+on disk and **skip when those are absent**, which the Rust test harness reports
+as a pass. That is fine on a working copy, and dangerous in CI: a green run is
+otherwise indistinguishable from one where the numerical checks never executed.
+
+`LRG_REQUIRE_GOLDENS` turns the skip into a failure for the families you name,
+so a job that provisions assets can prove it used them:
+
+```bash
+LRG_REQUIRE_GOLDENS=face          cargo test --workspace   # one family
+LRG_REQUIRE_GOLDENS=face,siglip   cargo test --workspace   # a subset
+LRG_REQUIRE_GOLDENS=all           cargo test --workspace   # every family
+```
+
+Family names are `face`, `siglip` and `bioclip`. Per-family rather than a
+single switch because they differ in cost by more than an order of magnitude
+(89 MB, 2.2 GB and 834 MB respectively).
+
+CI uses both halves: `server-rs-tests.yml` downloads the face pair on every PR
+and sets `LRG_REQUIRE_GOLDENS=face`, while the nightly `golden-tests-full.yml`
+fetches all three and runs with `all`. The models resolve through the same
+`LRG_*_ONNX` env vars and `~/.cache/lrgenius/models/` fallback the server uses,
+so a machine that has run the plugin's model download needs no extra setup.
+
 ### Optional feature: `llamacpp`
 
 The in-process local LLM is behind a cargo feature that is **off by default**.

--- a/server-rs/crates/lrg-api/src/routes/edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/edit.rs
@@ -24,6 +24,7 @@ use lrg_providers::provider::{build_provider, ProviderSelection};
 use lrg_providers::types::{EditGenerationRequest, EditGenerationResponse};
 use lrg_store::{meta, Store, StoreRecord, IMAGE_TABLE, TRAINING_TABLE};
 
+use crate::routes::route_util::{parse_multipart, SinglePhotoForm};
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
@@ -760,45 +761,22 @@ fn guardrail_explanations(codes: &[String]) -> Vec<String> {
 async fn edit_multipart(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
     log::info!("Edit recipe request received");
 
-    let mut image_bytes: Option<Vec<u8>> = None;
-    let mut filename: Option<String> = None;
-    let mut photo_ids: Vec<String> = Vec::new();
-    let mut fields: HashMap<String, String> = HashMap::new();
-
-    loop {
-        let field = match multipart.next_field().await {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                return (
-                    axum::http::StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("invalid multipart body: {e}")})),
-                )
-                    .into_response()
-            }
-        };
-        let name = field.name().unwrap_or("").to_string();
-        match name.as_str() {
-            "image" => {
-                filename = field.file_name().map(str::to_string);
-                if let Ok(bytes) = field.bytes().await {
-                    image_bytes = Some(bytes.to_vec());
-                }
-            }
-            "photo_id" | "uuid" => {
-                if let Ok(text) = field.text().await {
-                    if !text.is_empty() {
-                        photo_ids.push(text);
-                    }
-                }
-            }
-            _ => {
-                if let Ok(text) = field.text().await {
-                    fields.insert(name, text);
-                }
-            }
+    let form = match parse_multipart(&mut multipart).await {
+        Ok(form) => form,
+        Err(e) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(json!({"error": e})),
+            )
+                .into_response()
         }
-    }
+    };
+    let SinglePhotoForm {
+        photo_ids,
+        image_bytes,
+        filename,
+        fields,
+    } = form.into_single_photo();
 
     if let Some(db_path) = fields.get("db_path") {
         if let Err(e) = state.ensure_db_path(db_path).await {

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -26,6 +26,7 @@ use lrg_providers::provider::{build_provider, ProviderSelection};
 use lrg_providers::types::{KeywordCategories, KeywordTree};
 use lrg_store::{meta, StoreRecord, FACE_TABLE, IMAGE_TABLE, SPECIES_TABLE, VERTEX_TABLE};
 
+use crate::routes::route_util::parse_multipart;
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
@@ -526,57 +527,28 @@ async fn load_and_normalize(
 async fn index_batch(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
     log::info!("Index request received");
 
-    let mut images: Vec<UploadedImage> = Vec::new();
-    let mut photo_ids: Vec<String> = Vec::new();
-    let mut uuids_fallback: Vec<String> = Vec::new();
-    let mut fields: HashMap<String, String> = HashMap::new();
-
-    loop {
-        let field = match multipart.next_field().await {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                return (
-                    axum::http::StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("invalid multipart body: {e}")})),
-                )
-                    .into_response()
-            }
-        };
-        let name = field.name().unwrap_or("").to_string();
-        match name.as_str() {
-            "image" => {
-                let filename = field.file_name().unwrap_or("photo").to_string();
-                match field.bytes().await {
-                    Ok(bytes) => images.push(UploadedImage {
-                        bytes: bytes.to_vec(),
-                        filename,
-                    }),
-                    Err(e) => log::warn!("Skipping unreadable image field: {e}"),
-                }
-            }
-            "photo_id" => {
-                if let Ok(text) = field.text().await {
-                    photo_ids.push(text);
-                }
-            }
-            "uuid" => {
-                if let Ok(text) = field.text().await {
-                    uuids_fallback.push(text);
-                }
-            }
-            _ => {
-                if let Ok(text) = field.text().await {
-                    fields.insert(name, text);
-                }
-            }
+    let form = match parse_multipart(&mut multipart).await {
+        Ok(form) => form,
+        Err(e) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(json!({"error": e})),
+            )
+                .into_response()
         }
-    }
-    let photo_ids = if photo_ids.is_empty() {
-        uuids_fallback
-    } else {
-        photo_ids
     };
+    let photo_ids = form.photo_ids_or_uuids();
+    let fields = form.fields;
+    // `"photo"` is this route's own default for an unnamed part; the parser
+    // keeps `filename` optional precisely so it does not impose one.
+    let images: Vec<UploadedImage> = form
+        .images
+        .into_iter()
+        .map(|img| UploadedImage {
+            bytes: img.bytes,
+            filename: img.filename.unwrap_or_else(|| "photo".to_string()),
+        })
+        .collect();
 
     // Multipart uploads carry no per-image context, so every photo falls back
     // to the batch-level options exactly as before.

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -1305,6 +1305,12 @@ async fn finish_one(
     let photo_id = photo_id.as_str();
     let filename = filename.as_str();
 
+    // A vec, not one slot: metadata generation, faces and species can each
+    // degrade independently, and a single `Option` meant whichever failed
+    // second erased the other's report — the user was told about the species
+    // model while the missing face model went unmentioned.
+    let mut warnings: Vec<String> = Vec::new();
+
     if llm_request.is_some() {
         let response =
             llm_response.ok_or_else(|| "metadata generation returned no response".to_string())?;
@@ -1312,6 +1318,14 @@ async fn finish_one(
             return Err(response
                 .error
                 .unwrap_or_else(|| "Unknown metadata generation error".to_string()));
+        }
+        // The provider says `success: true` even when it dropped a field the
+        // user asked for; `warning` is where it says so. Reading it here is
+        // the whole reason the field exists — it was written as `None` by
+        // every provider and read by nobody, so a photo that came back
+        // without its caption counted as a clean success.
+        if let Some(w) = response.warning.filter(|s| !s.trim().is_empty()) {
+            warnings.push(format!("{filename}: {w}"));
         }
         if let Some(title) = response.title.filter(|s| !s.is_empty()) {
             main_metadata.insert("title".into(), json!(title));
@@ -1386,11 +1400,6 @@ async fn finish_one(
     // themselves on the stale pre-catalog_id `record`, so indexing with
     // both faces and catalog_id set silently dropped the catalog_ids
     // field once face processing's write landed last.
-    // A vec, not one slot: faces and species can each degrade independently,
-    // and a single `Option` meant whichever failed second erased the other's
-    // report — the user was told about the species model while the missing
-    // face model went unmentioned.
-    let mut warnings: Vec<String> = Vec::new();
     if options.compute_faces {
         // "Checked" means checked *by the models this build runs*. A photo
         // whose faces were found by the retired SCRFD/ArcFace pair carries

--- a/server-rs/crates/lrg-api/src/routes/route_util.rs
+++ b/server-rs/crates/lrg-api/src/routes/route_util.rs
@@ -1,9 +1,11 @@
 //! Small helpers shared by `training.rs`, `style_edit.rs`, `group_similar.rs`
-//! and `index_upload.rs`: local-hour resolution for time-of-day bucketing,
-//! CLIP zero-shot scene-tag probing, and the CLIP-IQA prompt-set cache.
+//! and `index_upload.rs`: multipart request parsing, local-hour resolution for
+//! time-of-day bucketing, CLIP zero-shot scene-tag probing, and the CLIP-IQA
+//! prompt-set cache.
 
 use std::collections::HashMap;
 
+use axum::extract::Multipart;
 use chrono::{Local, TimeZone, Timelike};
 
 use lrg_analysis::training::{scene_tags_from_similarities, SCENE_PROBES};
@@ -88,4 +90,139 @@ pub(crate) fn compute_scene_tags(siglip: &SiglipModel, image_embedding: &[f32]) 
         })
         .collect();
     scene_tags_from_similarities(&sims)
+}
+
+/// One `image` part of an upload.
+///
+/// `filename` stays optional because the callers disagree about the default —
+/// `/index` substitutes `"photo"`, the edit routes keep `None` and let the
+/// image sniffer decide — and baking either one in here would silently change
+/// the other's behaviour.
+pub(crate) struct MultipartImage {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) filename: Option<String>,
+}
+
+/// Everything a multipart upload in this API can carry.
+///
+/// The four upload routes (`/edit`, `/style_edit`, `/index`, `/training/add`)
+/// had four copies of the same field loop — 49 duplicated lines, and the
+/// widest co-change surface in the crate: a change to how one route reads a
+/// part had to be remembered in three other files. They differ only in which
+/// parts they care about afterwards, which is what this shape captures.
+///
+/// The raw fields filter and default nothing: `photo_ids` and `uuids` stay
+/// separate (only `/index` distinguishes them), empty values are kept, and
+/// `filename` stays `None` rather than acquiring someone's default. Callers
+/// that want the tidied view take [`MultipartForm::photo_ids_or_uuids`] or
+/// [`MultipartForm::into_single_photo`], which do drop empties.
+pub(crate) struct MultipartForm {
+    pub(crate) images: Vec<MultipartImage>,
+    pub(crate) photo_ids: Vec<String>,
+    pub(crate) uuids: Vec<String>,
+    pub(crate) fields: HashMap<String, String>,
+}
+
+impl MultipartForm {
+    /// `photo_id` parts, falling back to `uuid` parts, with empties dropped.
+    ///
+    /// What the single-photo routes mean by "the photo this is about": they
+    /// accept either spelling and never both, so a fallback rather than a
+    /// concatenation keeps the result unambiguous if a client sends both.
+    pub(crate) fn photo_ids_or_uuids(&self) -> Vec<String> {
+        let ids: Vec<String> = self
+            .photo_ids
+            .iter()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .collect();
+        if !ids.is_empty() {
+            return ids;
+        }
+        self.uuids
+            .iter()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .collect()
+    }
+
+    /// Collapses the form to what a single-photo route actually uses.
+    ///
+    /// `/edit`, `/style_edit` and `/training/add` each take one image and one
+    /// id; this hands them that directly so the call site is a destructuring
+    /// `let` rather than four mutable accumulators.
+    pub(crate) fn into_single_photo(self) -> SinglePhotoForm {
+        let photo_ids = self.photo_ids_or_uuids();
+        let (image_bytes, filename) = match self.images.into_iter().next() {
+            Some(img) => (Some(img.bytes), img.filename),
+            None => (None, None),
+        };
+        SinglePhotoForm {
+            photo_ids,
+            image_bytes,
+            filename,
+            fields: self.fields,
+        }
+    }
+}
+
+/// [`MultipartForm`] as the single-photo routes see it.
+pub(crate) struct SinglePhotoForm {
+    pub(crate) photo_ids: Vec<String>,
+    pub(crate) image_bytes: Option<Vec<u8>>,
+    pub(crate) filename: Option<String>,
+    pub(crate) fields: HashMap<String, String>,
+}
+
+/// Reads a whole multipart body into [`MultipartForm`].
+///
+/// The `Err` is the human half of a 400 — callers wrap it in whatever error
+/// envelope they already use, since those differ across these routes.
+pub(crate) async fn parse_multipart(multipart: &mut Multipart) -> Result<MultipartForm, String> {
+    let mut form = MultipartForm {
+        images: Vec::new(),
+        photo_ids: Vec::new(),
+        uuids: Vec::new(),
+        fields: HashMap::new(),
+    };
+
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => return Err(format!("invalid multipart body: {e}")),
+        };
+        let name = field.name().unwrap_or("").to_string();
+        match name.as_str() {
+            "image" => {
+                let filename = field.file_name().map(str::to_string);
+                match field.bytes().await {
+                    Ok(bytes) => form.images.push(MultipartImage {
+                        bytes: bytes.to_vec(),
+                        filename,
+                    }),
+                    // Logged rather than dropped in silence: an image part the
+                    // server could not read means the user's photo did not get
+                    // indexed, and the count of successes would not say so.
+                    Err(e) => log::warn!("Skipping unreadable image field: {e}"),
+                }
+            }
+            "photo_id" => {
+                if let Ok(text) = field.text().await {
+                    form.photo_ids.push(text);
+                }
+            }
+            "uuid" => {
+                if let Ok(text) = field.text().await {
+                    form.uuids.push(text);
+                }
+            }
+            _ => {
+                if let Ok(text) = field.text().await {
+                    form.fields.insert(name, text);
+                }
+            }
+        }
+    }
+    Ok(form)
 }

--- a/server-rs/crates/lrg-api/src/routes/route_util.rs
+++ b/server-rs/crates/lrg-api/src/routes/route_util.rs
@@ -98,6 +98,7 @@ pub(crate) fn compute_scene_tags(siglip: &SiglipModel, image_embedding: &[f32]) 
 /// `/index` substitutes `"photo"`, the edit routes keep `None` and let the
 /// image sniffer decide — and baking either one in here would silently change
 /// the other's behaviour.
+#[derive(Debug)]
 pub(crate) struct MultipartImage {
     pub(crate) bytes: Vec<u8>,
     pub(crate) filename: Option<String>,
@@ -116,6 +117,7 @@ pub(crate) struct MultipartImage {
 /// `filename` stays `None` rather than acquiring someone's default. Callers
 /// that want the tidied view take [`MultipartForm::photo_ids_or_uuids`] or
 /// [`MultipartForm::into_single_photo`], which do drop empties.
+#[derive(Debug)]
 pub(crate) struct MultipartForm {
     pub(crate) images: Vec<MultipartImage>,
     pub(crate) photo_ids: Vec<String>,
@@ -167,6 +169,7 @@ impl MultipartForm {
 }
 
 /// [`MultipartForm`] as the single-photo routes see it.
+#[derive(Debug)]
 pub(crate) struct SinglePhotoForm {
     pub(crate) photo_ids: Vec<String>,
     pub(crate) image_bytes: Option<Vec<u8>>,
@@ -225,4 +228,166 @@ pub(crate) async fn parse_multipart(multipart: &mut Multipart) -> Result<Multipa
         }
     }
     Ok(form)
+}
+
+#[cfg(test)]
+mod multipart_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::extract::FromRequest;
+    use axum::http::{header, Request};
+
+    const BOUNDARY: &str = "----lrgtestboundary";
+
+    /// One part: field name, optional filename (which makes it a file part),
+    /// and the value.
+    type Part<'a> = (&'a str, Option<&'a str>, &'a str);
+
+    fn body_for(parts: &[Part<'_>]) -> Vec<u8> {
+        let mut body: Vec<u8> = Vec::new();
+        for (name, filename, value) in parts {
+            body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+            match filename {
+                Some(f) => body.extend_from_slice(
+                    format!(
+                        "Content-Disposition: form-data; name=\"{name}\"; filename=\"{f}\"\r\n\r\n"
+                    )
+                    .as_bytes(),
+                ),
+                None => body.extend_from_slice(
+                    format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+                ),
+            }
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+        body
+    }
+
+    async fn parse(parts: &[Part<'_>]) -> Result<MultipartForm, String> {
+        let request = Request::builder()
+            .method("POST")
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={BOUNDARY}"),
+            )
+            .body(Body::from(body_for(parts)))
+            .unwrap();
+        let mut multipart = Multipart::from_request(request, &())
+            .await
+            .expect("well-formed body");
+        parse_multipart(&mut multipart).await
+    }
+
+    #[tokio::test]
+    async fn sorts_parts_into_images_ids_and_fields() {
+        let form = parse(&[
+            ("image", Some("a.jpg"), "AAAA"),
+            ("photo_id", None, "id-a"),
+            ("image", Some("b.jpg"), "BBBB"),
+            ("photo_id", None, "id-b"),
+            ("uuid", None, "uuid-a"),
+            ("tasks", None, "embeddings"),
+        ])
+        .await
+        .expect("parses");
+
+        assert_eq!(form.images.len(), 2);
+        assert_eq!(form.images[0].filename.as_deref(), Some("a.jpg"));
+        assert_eq!(form.images[1].bytes, b"BBBB");
+        // photo_id and uuid stay apart: only `/index` distinguishes them, and
+        // merging here would take that choice away from it.
+        assert_eq!(form.photo_ids, vec!["id-a", "id-b"]);
+        assert_eq!(form.uuids, vec!["uuid-a"]);
+        assert_eq!(
+            form.fields.get("tasks").map(String::as_str),
+            Some("embeddings")
+        );
+    }
+
+    #[tokio::test]
+    async fn an_image_part_without_a_filename_keeps_none() {
+        // `/index` substitutes "photo" itself; the parser must not decide for it.
+        let form = parse(&[("image", Some(""), "AAAA")]).await.expect("parses");
+        assert_eq!(form.images.len(), 1);
+        assert_eq!(form.images[0].filename.as_deref(), Some(""));
+    }
+
+    #[tokio::test]
+    async fn photo_ids_win_over_uuids_when_both_are_sent() {
+        let form = parse(&[("photo_id", None, "id-a"), ("uuid", None, "uuid-a")])
+            .await
+            .expect("parses");
+        assert_eq!(form.photo_ids_or_uuids(), vec!["id-a"]);
+    }
+
+    #[tokio::test]
+    async fn uuids_are_the_fallback_when_no_photo_id_is_sent() {
+        let form = parse(&[("uuid", None, "uuid-a")]).await.expect("parses");
+        assert_eq!(form.photo_ids_or_uuids(), vec!["uuid-a"]);
+    }
+
+    #[tokio::test]
+    async fn an_empty_id_does_not_suppress_the_uuid_fallback() {
+        // The raw list keeps the empty value; the accessor drops it. Without
+        // that, an empty `photo_id` made the list non-empty and the real id in
+        // `uuid` was never reached.
+        let form = parse(&[("photo_id", None, ""), ("uuid", None, "uuid-a")])
+            .await
+            .expect("parses");
+        assert_eq!(form.photo_ids, vec![""]);
+        assert_eq!(form.photo_ids_or_uuids(), vec!["uuid-a"]);
+    }
+
+    #[tokio::test]
+    async fn single_photo_view_takes_the_first_image() {
+        let form = parse(&[
+            ("image", Some("a.jpg"), "AAAA"),
+            ("image", Some("b.jpg"), "BBBB"),
+            ("photo_id", None, "id-a"),
+            ("db_path", None, "/tmp/x.db"),
+        ])
+        .await
+        .expect("parses");
+
+        let single = form.into_single_photo();
+        assert_eq!(single.photo_ids, vec!["id-a"]);
+        assert_eq!(single.image_bytes.as_deref(), Some(&b"AAAA"[..]));
+        assert_eq!(single.filename.as_deref(), Some("a.jpg"));
+        assert_eq!(
+            single.fields.get("db_path").map(String::as_str),
+            Some("/tmp/x.db")
+        );
+    }
+
+    #[tokio::test]
+    async fn single_photo_view_reports_no_image_rather_than_failing() {
+        // `/edit` turns this into its "mismatch between images and photo IDs"
+        // reply; the parser's job is only to say the image is absent.
+        let form = parse(&[("photo_id", None, "id-a")]).await.expect("parses");
+        let single = form.into_single_photo();
+        assert!(single.image_bytes.is_none());
+        assert!(single.filename.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_malformed_body_is_an_error_not_a_panic() {
+        let request = Request::builder()
+            .method("POST")
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={BOUNDARY}"),
+            )
+            // A real boundary, but the body stops before the terminator —
+            // what a client that dies mid-upload actually sends.
+            .body(Body::from(format!(
+                "--{BOUNDARY}\r\nContent-Disposition: form-data; \
+                 name=\"image\"\r\n\r\ntruncated"
+            )))
+            .unwrap();
+        let mut multipart = Multipart::from_request(request, &()).await.unwrap();
+        let err = parse_multipart(&mut multipart).await.unwrap_err();
+        assert!(err.contains("invalid multipart body"), "{err}");
+    }
 }

--- a/server-rs/crates/lrg-api/src/routes/style_edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/style_edit.rs
@@ -6,7 +6,6 @@
 //! few-shot training injection) when confidence is too low and the
 //! caller opted in.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::extract::{Multipart, State};
@@ -25,7 +24,7 @@ use super::edit::{
     cosine_distance, generate_edit_recipe_for_photo, parse_edit_options_form, persist_edit_recipe,
     success_payload,
 };
-use crate::routes::route_util::{compute_scene_tags, local_hour};
+use crate::routes::route_util::{compute_scene_tags, local_hour, parse_multipart, SinglePhotoForm};
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
@@ -123,45 +122,16 @@ async fn fetch_style_candidates(
 async fn style_edit(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
     log::info!("Style edit request received");
 
-    let mut image_bytes: Option<Vec<u8>> = None;
-    let mut filename: Option<String> = None;
-    let mut photo_ids: Vec<String> = Vec::new();
-    let mut fields: HashMap<String, String> = HashMap::new();
-
-    loop {
-        let field = match multipart.next_field().await {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("invalid multipart body: {e}")})),
-                )
-                    .into_response()
-            }
-        };
-        let name = field.name().unwrap_or("").to_string();
-        match name.as_str() {
-            "image" => {
-                filename = field.file_name().map(str::to_string);
-                if let Ok(bytes) = field.bytes().await {
-                    image_bytes = Some(bytes.to_vec());
-                }
-            }
-            "photo_id" | "uuid" => {
-                if let Ok(text) = field.text().await {
-                    if !text.is_empty() {
-                        photo_ids.push(text);
-                    }
-                }
-            }
-            _ => {
-                if let Ok(text) = field.text().await {
-                    fields.insert(name, text);
-                }
-            }
-        }
-    }
+    let form = match parse_multipart(&mut multipart).await {
+        Ok(form) => form,
+        Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response(),
+    };
+    let SinglePhotoForm {
+        photo_ids,
+        image_bytes,
+        filename,
+        fields,
+    } = form.into_single_photo();
 
     if let Some(db_path) = fields.get("db_path") {
         if let Err(e) = state.ensure_db_path(db_path).await {

--- a/server-rs/crates/lrg-api/src/routes/training.rs
+++ b/server-rs/crates/lrg-api/src/routes/training.rs
@@ -18,7 +18,7 @@ use lrg_analysis::training::{
 };
 use lrg_store::TRAINING_TABLE;
 
-use crate::routes::route_util::{compute_scene_tags, local_hour};
+use crate::routes::route_util::{compute_scene_tags, local_hour, parse_multipart, SinglePhotoForm};
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
@@ -55,31 +55,16 @@ async fn add_training_example(
 ) -> Response {
     log::info!("Training add request received");
 
-    let mut fields: HashMap<String, String> = HashMap::new();
-    let mut image_bytes: Option<Vec<u8>> = None;
-    let mut filename: Option<String> = None;
-
-    loop {
-        let field = match multipart.next_field().await {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                return err(
-                    StatusCode::BAD_REQUEST,
-                    format!("invalid multipart body: {e}"),
-                )
-            }
-        };
-        let name = field.name().unwrap_or("").to_string();
-        if name == "image" {
-            filename = field.file_name().map(str::to_string);
-            if let Ok(bytes) = field.bytes().await {
-                image_bytes = Some(bytes.to_vec());
-            }
-        } else if let Ok(text) = field.text().await {
-            fields.insert(name, text);
-        }
-    }
+    let form = match parse_multipart(&mut multipart).await {
+        Ok(form) => form,
+        Err(e) => return err(StatusCode::BAD_REQUEST, e),
+    };
+    let SinglePhotoForm {
+        photo_ids,
+        image_bytes,
+        filename,
+        fields,
+    } = form.into_single_photo();
 
     if let Some(db_path) = fields.get("db_path") {
         if let Err(e) = state.ensure_db_path(db_path).await {
@@ -93,8 +78,11 @@ async fn add_training_example(
         );
     };
 
-    let photo_id = fields
-        .get("photo_id")
+    // Reads the parsed `photo_id` part rather than `fields`: the shared
+    // parser gives ids their own slot, so they no longer arrive in the
+    // catch-all map this used to search.
+    let photo_id = photo_ids
+        .first()
         .map(|s| s.trim().to_string())
         .unwrap_or_default();
     if photo_id.is_empty() {

--- a/server-rs/crates/lrg-ml/tests/bioclip_goldens.rs
+++ b/server-rs/crates/lrg-ml/tests/bioclip_goldens.rs
@@ -11,9 +11,24 @@
 //!
 //! Requires the exported assets; set `LRG_BIOCLIP_IMAGE_ONNX` (and the taxa
 //! files) or place them in `~/.cache/lrgenius/models/`. Skips when not found,
-//! like the face goldens — CI without model assets must not fail here.
+//! like the face goldens — at 834 MB this family is too heavy for every PR.
+//! The nightly full-assets job provisions it and sets
+//! `LRG_REQUIRE_GOLDENS=all`, which turns that skip into a failure; see
+//! `common::assets_ready`.
 
 use lrg_ml::bioclip::{BioclipModel, RANKS};
+
+mod common;
+
+/// The three files this family needs, for the gate's failure message.
+fn bioclip_missing(paths: &lrg_ml::bioclip::BioclipModelPaths) -> String {
+    format!(
+        "BioCLIP assets not found at {} / {} / {}",
+        paths.image_onnx.display(),
+        paths.taxa_bin.display(),
+        paths.taxa_json.display()
+    )
+}
 
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
     let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
@@ -53,8 +68,14 @@ fn golden_image(name: &str) -> (Vec<u8>, usize, usize) {
 #[test]
 fn image_tower_matches_open_clip() {
     let paths = lrg_ml::model_paths::resolve_bioclip();
-    if !paths.image_onnx.is_file() {
-        eprintln!("BioCLIP image tower not found; skipping golden test");
+    if !common::assets_ready(
+        "bioclip",
+        paths.image_onnx.is_file(),
+        &format!(
+            "BioCLIP image tower not found at {}",
+            paths.image_onnx.display()
+        ),
+    ) {
         return;
     }
     let golden_path = concat!(
@@ -62,7 +83,16 @@ fn image_tower_matches_open_clip() {
         "/../../testdata/bioclip_goldens.json"
     );
     let Ok(raw) = std::fs::read_to_string(golden_path) else {
-        eprintln!("bioclip_goldens.json missing; skipping golden test");
+        // Unlike the model files this one *is* checked in, so its absence is
+        // a broken checkout rather than an un-provisioned machine — but it is
+        // gated the same way so that one switch covers the whole family.
+        // Called for its panic-when-required side effect; the branch returns
+        // either way, so the "should I run?" answer has nothing left to decide.
+        let _ = common::assets_ready(
+            "bioclip",
+            false,
+            &format!("{golden_path} missing (it is checked in — is the tree intact?)"),
+        );
         return;
     };
     let goldens: serde_json::Value = serde_json::from_str(&raw).unwrap();
@@ -98,8 +128,7 @@ fn image_tower_matches_open_clip() {
 #[test]
 fn classification_is_a_consistent_lineage() {
     let paths = lrg_ml::model_paths::resolve_bioclip();
-    if !paths.all_exist() {
-        eprintln!("BioCLIP assets not found; skipping classification test");
+    if !common::assets_ready("bioclip", paths.all_exist(), &bioclip_missing(&paths)) {
         return;
     }
     let model = BioclipModel::new(paths);
@@ -166,8 +195,7 @@ fn classification_is_a_consistent_lineage() {
 #[test]
 fn an_unreachable_floor_reports_nothing() {
     let paths = lrg_ml::model_paths::resolve_bioclip();
-    if !paths.all_exist() {
-        eprintln!("BioCLIP assets not found; skipping floor test");
+    if !common::assets_ready("bioclip", paths.all_exist(), &bioclip_missing(&paths)) {
         return;
     }
     let model = BioclipModel::new(paths);

--- a/server-rs/crates/lrg-ml/tests/common/mod.rs
+++ b/server-rs/crates/lrg-ml/tests/common/mod.rs
@@ -1,0 +1,65 @@
+//! Shared gate for golden tests that need model files on disk.
+//!
+//! These tests used to `return` early when their ONNX assets were missing,
+//! which the harness reports as a pass. That made `cargo test` green on a
+//! machine — CI included — where the numerical checks never ran at all, and a
+//! wrong embedding is exactly the failure that produces no error of its own:
+//! search quietly gets worse, face clusters quietly get muddier. A skip that
+//! reports success is the same class of bug the backend's `warnings` plumbing
+//! exists to prevent, one level up.
+//!
+//! Skipping is still the right default for a working copy without multi-GB
+//! downloads, so the gate keeps it — but makes it *enforceable*. Set
+//! `LRG_REQUIRE_GOLDENS` to the families whose assets are expected to be
+//! present and a missing one becomes a failure instead of a silent pass:
+//!
+//! ```text
+//! LRG_REQUIRE_GOLDENS=face         # just the 89 MB face pair (what PR CI provisions)
+//! LRG_REQUIRE_GOLDENS=face,siglip  # a comma-separated subset
+//! LRG_REQUIRE_GOLDENS=all          # every family (the nightly full-assets job)
+//! ```
+//!
+//! Per-family rather than one global on/off because the families differ in
+//! cost by more than an order of magnitude — face is 89 MB, BioCLIP 834 MB,
+//! SigLIP2 2.2 GB. A single switch would force PR CI to choose between
+//! downloading 3 GB per run and enforcing nothing.
+
+/// Decides whether a golden test body should run.
+///
+/// Returns `true` when `present` (the caller's own "are my files here?"
+/// check) holds. Otherwise either panics — if `family` is named in
+/// `LRG_REQUIRE_GOLDENS` — or logs `detail` and returns `false` for the
+/// caller to return on.
+///
+/// `detail` should name the paths that were looked for, so a CI failure says
+/// where the download was expected to land rather than just that it is absent.
+#[must_use]
+pub fn assets_ready(family: &str, present: bool, detail: &str) -> bool {
+    if present {
+        return true;
+    }
+    if required(family) {
+        panic!(
+            "LRG_REQUIRE_GOLDENS demands the `{family}` golden assets, but they are missing: \
+             {detail}. Either provision them (the plugin's model download, or the CI step that \
+             fetches this family's release assets) or drop `{family}` from LRG_REQUIRE_GOLDENS."
+        );
+    }
+    eprintln!(
+        "skipping `{family}` golden test: {detail}. \
+         (Set LRG_REQUIRE_GOLDENS={family} to make this a failure instead.)"
+    );
+    false
+}
+
+/// Whether `LRG_REQUIRE_GOLDENS` names this family, either explicitly or via
+/// `all`. Entries are trimmed and matched case-insensitively so that
+/// `LRG_REQUIRE_GOLDENS="face, SigLIP"` behaves the way it reads.
+fn required(family: &str) -> bool {
+    let Ok(raw) = std::env::var("LRG_REQUIRE_GOLDENS") else {
+        return false;
+    };
+    raw.split(',')
+        .map(str::trim)
+        .any(|entry| entry.eq_ignore_ascii_case("all") || entry.eq_ignore_ascii_case(family))
+}

--- a/server-rs/crates/lrg-ml/tests/face_goldens.rs
+++ b/server-rs/crates/lrg-ml/tests/face_goldens.rs
@@ -7,9 +7,16 @@
 //! Requires the ONNX files `scripts/export_face_models.py` produces. They are
 //! looked up exactly where the server looks (`LRG_YUNET_ONNX` /
 //! `LRG_FACENET_ONNX`, else `~/.cache/lrgenius/models/`), so a machine that
-//! has run the plugin's model download already has them. Skips when not found.
+//! has run the plugin's model download already has them.
+//!
+//! Skips when not found — but see `common::assets_ready`. At 89 MB this is
+//! the one family cheap enough for every PR, so CI downloads it and sets
+//! `LRG_REQUIRE_GOLDENS=face`, making a broken download a test failure
+//! rather than a silent pass.
 
 use lrg_ml::faces::{FaceModel, FaceModelPaths};
+
+mod common;
 
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
     let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
@@ -33,12 +40,15 @@ fn iou(a: [i64; 4], b: &[f64]) -> f64 {
 #[test]
 fn detects_and_embeds_real_face_matching_reference_models() {
     let paths = lrg_ml::model_paths::resolve_face();
-    if !paths.all_exist() {
-        eprintln!(
-            "face ONNX models not found at {} / {}; skipping face golden test",
+    if !common::assets_ready(
+        "face",
+        paths.all_exist(),
+        &format!(
+            "face ONNX models not found at {} / {}",
             paths.det_onnx.display(),
             paths.rec_onnx.display()
-        );
+        ),
+    ) {
         return;
     }
     let model = FaceModel::new(FaceModelPaths {

--- a/server-rs/crates/lrg-ml/tests/goldens.rs
+++ b/server-rs/crates/lrg-ml/tests/goldens.rs
@@ -6,22 +6,18 @@
 //! pipeline, not just the exported ONNX graph — this is the full-stack
 //! check that spike S1 didn't cover).
 //!
-//! Requires local model files (from the M0 S1 spike export) — set:
-//!   LRG_SIGLIP_IMAGE_ONNX, LRG_SIGLIP_TEXT_ONNX, LRG_SIGLIP_TOKENIZER
-//! Skips (not fails) when unset, so CI without the multi-GB models stays
-//! green until M9 wires up model distribution.
+//! Requires the SigLIP2 ONNX files. They are looked up exactly where the
+//! server looks (`LRG_SIGLIP_IMAGE_ONNX` / `LRG_SIGLIP_TEXT_ONNX` /
+//! `LRG_SIGLIP_TOKENIZER`, else `~/.cache/lrgenius/models/`), so a machine
+//! that has run the plugin's model download already has them.
+//!
+//! Skips when they are absent — but see `common::assets_ready`: set
+//! `LRG_REQUIRE_GOLDENS=siglip` and the skip becomes a failure, which is how
+//! a job that *did* provision the assets proves they were actually used.
 
-use std::path::PathBuf;
+use lrg_ml::siglip::{l2_normalize, SiglipModel};
 
-use lrg_ml::siglip::{l2_normalize, ModelPaths, SiglipModel};
-
-fn env_paths() -> Option<ModelPaths> {
-    Some(ModelPaths {
-        image_onnx: PathBuf::from(std::env::var("LRG_SIGLIP_IMAGE_ONNX").ok()?),
-        text_onnx: PathBuf::from(std::env::var("LRG_SIGLIP_TEXT_ONNX").ok()?),
-        tokenizer_json: PathBuf::from(std::env::var("LRG_SIGLIP_TOKENIZER").ok()?),
-    })
-}
+mod common;
 
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
     let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
@@ -58,11 +54,19 @@ fn build_image(name: &str) -> (Vec<u8>, usize, usize) {
 
 #[test]
 fn image_and_text_embeddings_match_torch() {
-    let Some(paths) = env_paths() else {
-        eprintln!("LRG_SIGLIP_* env vars not set; skipping ONNX golden test");
+    let paths = lrg_ml::model_paths::resolve();
+    if !common::assets_ready(
+        "siglip",
+        paths.all_exist(),
+        &format!(
+            "SigLIP2 assets not found at {} / {} / {}",
+            paths.image_onnx.display(),
+            paths.text_onnx.display(),
+            paths.tokenizer_json.display()
+        ),
+    ) {
         return;
-    };
-    assert!(paths.all_exist(), "configured model paths do not exist");
+    }
     let model = SiglipModel::new(paths);
 
     let path = concat!(

--- a/server-rs/crates/lrg-providers/src/gemini.rs
+++ b/server-rs/crates/lrg-providers/src/gemini.rs
@@ -16,7 +16,7 @@ use crate::edit_recipe::{gemini_edit_recipe_schema, normalize_edit_recipe};
 use crate::gemini_schema::prepare_gemini_response_schema;
 use crate::image_encode::image_to_base64;
 use crate::keyword_taxonomy::KeywordLeafEncoding;
-use crate::normalize::{alt_text_from, normalize_keywords};
+use crate::normalize::{alt_text_from, missing_field_warning, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -305,24 +305,34 @@ impl GeminiProvider {
             None
         };
         let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
+        let title = if request.generate_title {
+            parsed
+                .get("title")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        // A requested field the model did not return is a degraded
+        // success, not a success: see `missing_field_warning`.
+        let warning = missing_field_warning(
+            request,
+            Some(&keywords),
+            caption.as_ref(),
+            title.as_ref(),
+            alt_text.as_ref(),
+        );
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
             caption,
-            title: if request.generate_title {
-                parsed
-                    .get("title")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            title,
             alt_text,
             input_tokens,
             output_tokens,
             error: None,
-            warning: None,
+            warning,
         }
     }
 

--- a/server-rs/crates/lrg-providers/src/lmstudio.rs
+++ b/server-rs/crates/lrg-providers/src/lmstudio.rs
@@ -17,7 +17,7 @@ use serde_json::{json, Value};
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
 use crate::keyword_taxonomy::KeywordLeafEncoding;
-use crate::normalize::{alt_text_from, normalize_keywords};
+use crate::normalize::{alt_text_from, missing_field_warning, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -248,24 +248,34 @@ impl LmStudioProvider {
             None
         };
         let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
+        let title = if request.generate_title {
+            parsed
+                .get("title")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        // A requested field the model did not return is a degraded
+        // success, not a success: see `missing_field_warning`.
+        let warning = missing_field_warning(
+            request,
+            Some(&keywords),
+            caption.as_ref(),
+            title.as_ref(),
+            alt_text.as_ref(),
+        );
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
             caption,
-            title: if request.generate_title {
-                parsed
-                    .get("title")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            title,
             alt_text,
             input_tokens,
             output_tokens,
             error: None,
-            warning: None,
+            warning,
         }
     }
 

--- a/server-rs/crates/lrg-providers/src/local_provider.rs
+++ b/server-rs/crates/lrg-providers/src/local_provider.rs
@@ -28,7 +28,7 @@ use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_rgb;
 use crate::keyword_taxonomy::KeywordLeafEncoding;
 use crate::local::{LocalImage, LocalRequest, SharedLocalEngine};
-use crate::normalize::{alt_text_from, normalize_keywords};
+use crate::normalize::{alt_text_from, missing_field_warning, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt_split, prepare_system_prompt,
     prepare_user_prompt_split,
@@ -123,17 +123,29 @@ impl LocalProvider {
         };
         let caption = field("caption", request.generate_caption);
         let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
+        let title = field("title", request.generate_title);
+        // A requested field the model did not return is a degraded
+        // success, not a success: see `missing_field_warning`. This matters
+        // more here than for the cloud providers — a small local model is the
+        // most likely of the five to silently drop a field.
+        let warning = missing_field_warning(
+            request,
+            Some(&keywords),
+            caption.as_ref(),
+            title.as_ref(),
+            alt_text.as_ref(),
+        );
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
             caption,
-            title: field("title", request.generate_title),
+            title,
             alt_text,
             input_tokens: prompt_tokens,
             output_tokens: completion_tokens,
             error: None,
-            warning: None,
+            warning,
         }
     }
 }

--- a/server-rs/crates/lrg-providers/src/normalize.rs
+++ b/server-rs/crates/lrg-providers/src/normalize.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use serde_json::{Map, Value};
 
 use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
-use crate::types::KeywordCategories;
+use crate::types::{KeywordCategories, MetadataGenerationRequest};
 
 /// Turn one positional keyword leaf back into the named form the rest of this
 /// module works in (`{name, synonyms, aliases, synonym_aliases}`).
@@ -360,6 +360,76 @@ pub fn normalize_keywords(
     }
 }
 
+/// Names the fields the caller asked for that the model did not deliver.
+///
+/// This is the metadata path's "degraded success": `success: true` with a
+/// caption the user requested and did not get. Nothing about the response
+/// distinguishes that from a photo the model simply had nothing to say about,
+/// and until this existed nothing reported it — the field was written as
+/// `warning: None` by every provider and the count of indexed photos went up
+/// either way.
+///
+/// Returns `None` when everything requested came back, so the common case
+/// stays quiet. Keywords count as missing when the container is empty, not
+/// just when the key is absent: an empty array is what a model returns when it
+/// declines, and `finish_one` drops it without storing anything.
+///
+/// Deliberately one shared function rather than a copy per provider. The five
+/// providers already parse their responses six near-identical ways, and a
+/// warning only some of them emit would be worse than none — the user would
+/// learn that Gemini sometimes skips captions and never that Ollama does too.
+pub fn missing_field_warning(
+    request: &MetadataGenerationRequest,
+    keywords: Option<&Value>,
+    caption: Option<&String>,
+    title: Option<&String>,
+    alt_text: Option<&String>,
+) -> Option<String> {
+    fn empty(text: Option<&String>) -> bool {
+        text.map(|s| s.trim().is_empty()).unwrap_or(true)
+    }
+    let keywords_empty = match keywords {
+        None => true,
+        Some(Value::Array(a)) => a.is_empty(),
+        Some(Value::Object(o)) => o.is_empty(),
+        Some(_) => false,
+    };
+
+    let mut missing = Vec::new();
+    if request.generate_keywords && keywords_empty {
+        missing.push("keywords");
+    }
+    if request.generate_caption && empty(caption) {
+        missing.push("caption");
+    }
+    if request.generate_title && empty(title) {
+        missing.push("title");
+    }
+    if request.generate_alt_text && empty(alt_text) {
+        missing.push("alt text");
+    }
+    if missing.is_empty() {
+        return None;
+    }
+    // Phrased as something to act on rather than as an internal state: the
+    // two fixes that actually work are a different model and a longer token
+    // budget, so the message names them.
+    Some(format!(
+        "the model returned no {} for this photo — the rest was kept. \
+         A stronger model, or a higher Max Tokens setting, usually fixes this.",
+        join_human(&missing)
+    ))
+}
+
+/// "a", "a and b", "a, b and c" — so the warning reads like a sentence.
+fn join_human(items: &[&str]) -> String {
+    match items {
+        [] => String::new(),
+        [one] => (*one).to_string(),
+        [rest @ .., last] => format!("{} and {last}", rest.join(", ")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -599,5 +669,84 @@ mod tests {
         let input = json!({"name": "Sunset"});
         let out = normalize_keywords_structure(&input);
         assert_eq!(out, json!({"name": "Sunset"}));
+    }
+
+    /// A request that asked for everything, so each case below only has to say
+    /// what came back.
+    fn asked_for_everything() -> MetadataGenerationRequest {
+        MetadataGenerationRequest {
+            generate_keywords: true,
+            generate_caption: true,
+            generate_title: true,
+            generate_alt_text: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_complete_response_warns_about_nothing() {
+        let got = missing_field_warning(
+            &asked_for_everything(),
+            Some(&json!(["berg"])),
+            Some(&"a caption".to_string()),
+            Some(&"a title".to_string()),
+            Some(&"alt text".to_string()),
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn a_field_that_was_not_requested_is_not_missing() {
+        // The all-false default: nothing was asked for, so nothing can be
+        // absent — this is the path a keywords-only run takes.
+        let got = missing_field_warning(
+            &MetadataGenerationRequest::default(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn a_requested_field_that_came_back_empty_is_reported() {
+        let got = missing_field_warning(
+            &asked_for_everything(),
+            Some(&json!(["berg"])),
+            Some(&"   ".to_string()),
+            Some(&"a title".to_string()),
+            Some(&"alt text".to_string()),
+        )
+        .expect("whitespace is not a caption");
+        assert!(got.contains("caption"), "{got}");
+        assert!(!got.contains("title"), "{got}");
+    }
+
+    #[test]
+    fn empty_keyword_containers_count_as_missing() {
+        // An empty array is what a model returns when it declines, and
+        // `finish_one` stores nothing for it — so it must not read as success.
+        for empty in [json!([]), json!({})] {
+            let got = missing_field_warning(
+                &asked_for_everything(),
+                Some(&empty),
+                Some(&"c".to_string()),
+                Some(&"t".to_string()),
+                Some(&"a".to_string()),
+            )
+            .unwrap_or_else(|| panic!("{empty} should count as missing keywords"));
+            assert!(got.contains("keywords"), "{got}");
+        }
+    }
+
+    #[test]
+    fn several_missing_fields_read_as_a_sentence() {
+        let got = missing_field_warning(&asked_for_everything(), None, None, None, None)
+            .expect("everything is missing");
+        assert!(
+            got.contains("keywords, caption, title and alt text"),
+            "{got}"
+        );
     }
 }

--- a/server-rs/crates/lrg-providers/src/ollama.rs
+++ b/server-rs/crates/lrg-providers/src/ollama.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
 use crate::keyword_taxonomy::KeywordLeafEncoding;
-use crate::normalize::{alt_text_from, normalize_keywords};
+use crate::normalize::{alt_text_from, missing_field_warning, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -315,23 +315,33 @@ fn build_success(
         None
     };
     let alt_text = alt_text_from(parsed, request.generate_alt_text, caption.as_ref());
+    let title = if request.generate_title {
+        parsed
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    } else {
+        None
+    };
+    // A requested field the model did not return is a degraded
+    // success, not a success: see `missing_field_warning`.
+    let warning = missing_field_warning(
+        request,
+        Some(&keywords),
+        caption.as_ref(),
+        title.as_ref(),
+        alt_text.as_ref(),
+    );
     MetadataGenerationResponse {
         uuid: request.uuid.clone(),
         success: true,
         keywords: Some(keywords),
         caption,
-        title: if request.generate_title {
-            parsed
-                .get("title")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        } else {
-            None
-        },
+        title,
         alt_text,
         input_tokens: 0,
         output_tokens: 0,
         error: None,
-        warning: None,
+        warning,
     }
 }

--- a/server-rs/crates/lrg-providers/src/openai.rs
+++ b/server-rs/crates/lrg-providers/src/openai.rs
@@ -12,7 +12,7 @@ use tokio::sync::Mutex;
 use crate::edit_recipe::{normalize_edit_recipe, openai_edit_recipe_schema};
 use crate::image_encode::image_to_base64;
 use crate::keyword_taxonomy::KeywordLeafEncoding;
-use crate::normalize::{alt_text_from, normalize_keywords};
+use crate::normalize::{alt_text_from, missing_field_warning, normalize_keywords};
 use crate::prompts::{
     prepare_edit_system_prompt, prepare_edit_user_prompt, prepare_system_prompt,
     prepare_user_prompt,
@@ -240,24 +240,34 @@ impl OpenAiProvider {
             None
         };
         let alt_text = alt_text_from(&parsed, request.generate_alt_text, caption.as_ref());
+        let title = if request.generate_title {
+            parsed
+                .get("title")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        } else {
+            None
+        };
+        // A requested field the model did not return is a degraded
+        // success, not a success: see `missing_field_warning`.
+        let warning = missing_field_warning(
+            request,
+            Some(&keywords),
+            caption.as_ref(),
+            title.as_ref(),
+            alt_text.as_ref(),
+        );
         MetadataGenerationResponse {
             uuid: request.uuid.clone(),
             success: true,
             keywords: Some(keywords),
             caption,
-            title: if request.generate_title {
-                parsed
-                    .get("title")
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-            } else {
-                None
-            },
+            title,
             alt_text,
             input_tokens,
             output_tokens,
             error: None,
-            warning: None,
+            warning,
         }
     }
 


### PR DESCRIPTION
Follow-up to a repowise-driven assessment of the repo. Each of these is a case
where something went wrong — or a signal was lost — and nothing said so: three
in the product, one in CI.

Four commits, each independently buildable, in the order the assessment ranked
them.

## 1. Skipped golden tests reported as passes

The ML golden tests returned early when their model files were missing, which
the Rust harness reports as `ok`. CI never provisions those files, so
`cargo test --workspace` was green on a build whose SigLIP2, BioCLIP and face
numerics had not been checked at all. That is the failure class that produces
no error of its own — just quietly worse search and muddier face clusters.

`LRG_REQUIRE_GOLDENS` turns the skip into a failure for the families you name
(`face`, `siglip`, `bioclip`, `all`). Per-family because the three differ in
cost by more than an order of magnitude, so PR CI can require the 89 MB face
pair it downloads without also demanding 3 GB.

- PR CI fetches the face assets and sets `LRG_REQUIRE_GOLDENS=face`
- A new nightly job fetches all three and runs with `all`, deliberately
  uncached so it also proves the published release assets are still
  fetchable — which is what the plugin's download-on-first-run depends on

Side effect worth calling out: the SigLIP goldens now resolve through
`model_paths::resolve()` instead of `LRG_SIGLIP_*` alone, so they were
skipping even on machines that had the models. On this one they went from
0.00s to 5.37s of real verification, and passed.

## 2. `MetadataGenerationResponse.warning` was dead at both ends

No provider ever set it; `index_upload` never read it. A photo whose caption
the user asked for and the model omitted counted as a clean success. The edit
half of the same struct has been wired the whole time.

`missing_field_warning` is now called from all five providers, so what the user
hears does not depend on which one they picked, and `finish_one` folds it into
the per-photo list that already carries the face and species reports.

## 3. Multipart parsing lived in four copies

49 duplicated lines across `/edit`, `/style_edit`, `/index` and `/training/add`
— the widest co-change surface in the crate. Now one `parse_multipart`, with
the parts the callers genuinely disagree about (id handling, filename defaults,
empty-value treatment) left at the call sites.

## 4. The plugin's busiest bug source had no tests

`APISearchIndex.lua`: 31 bug fixes in six months, most recent three days ago,
no test file. It *could not* have had one — the module failed to load headlessly
because line 199 reassigned a generic-for control variable, which Lightroom's
Lua 5.1 permits and 5.3+ does not. One fresh local makes all 4,468 lines
reachable from `busted`.

The three functions that decide what the user is told are extracted and covered
by 24 tests. Two behaviour fixes fell out of writing them down:

- `condenseMessages` counts what the cap hides instead of dropping it. Errors
  capped at 5 and said nothing about the rest; warnings had no cap at all, so a
  large run could produce a dialog thousands of lines long.
- `interpretIndexResponse` rejects a non-table body instead of indexing into
  it, matching the edit path. An HTML error page from a proxy used to read as
  "unexpected status".

## 5. Tests for the new shared parser

Added after #294's bot ran against this branch and flagged `route_util.rs` as
a hotspot with no paired test file and five dependents — fair, since commit 3
is what gave it those dependents. Eight tests over the decisions the callers
disagree about; the branch now reports zero newly-introduced findings.

## Verification

| | before | after |
|---|---|---|
| `cargo test --workspace` | 461 passed | **485 passed**, 0 failed |
| `busted` | 217 passed | **241 passed**, 0 failed |
| `cargo clippy --workspace --all-targets` | clean | clean |
| `check-docs.py` | 0 hard errors | 0 hard errors |

Per the repo's rule for endpoint changes, all four multipart routes were also
driven against a running `geniusai-server`:

- `/index` with two images + two `photo_id` parts → both paired and embedded
- `/index` with `uuid` only → fallback path
- `/training/add` → example stored; 400 for both missing and empty `photo_id`
- `/edit`, `/style_edit` → parse through to business logic
- malformed body → shared 400, `invalid multipart body: ...`
- face model pointed at a nonexistent path → warning surfaced in both
  `results[].warnings` and the run-level `warnings`, confirming the moved
  declaration still collects

Docs updated in the same change: `LRG_REQUIRE_GOLDENS` in `server-rs/README.md`
(regenerated into the wiki), the new warning source in `Dev-Backend-API.md`,
and a note in `CLAUDE.md` so future golden tests get gated rather than
early-returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gY9osZuR2Eo5msotWpjsM
