### PR TITLE
Catch the remaining docs up with YuNet + FaceNet

### DIFF
--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -13,7 +13,7 @@ Minimal liveness check. Returns `{"status": "ok"}`.
 
 ### `GET /health`
 Returns local model load state: `clip_model`/`clip_error` (SigLIP2) and
-`face_model`/`face_error` (SCRFD/ArcFace), each `"loaded"`, `"not_loaded"`, or
+`face_model`/`face_error` (YuNet/FaceNet), each `"loaded"`, `"not_loaded"`, or
 `"failed"`. It does **not** report cloud/local LLM provider availability —
 the backend has no stored API keys or base URLs to probe on a bare GET. The
 plugin checks provider availability itself (stored keys plus a direct ping to

--- a/docs/wiki/Dev-Image-Culling-Implementation-Plan.md
+++ b/docs/wiki/Dev-Image-Culling-Implementation-Plan.md
@@ -469,7 +469,7 @@ inline in a sequential loop.
 ### Landed
 
 - **`tasks=cull`** — a cull-only ingest computing pHash, image metrics and face
-  quality, skipping the embedding, the LLM, ArcFace and face thumbnails.
+  quality, skipping the embedding, the LLM, FaceNet and face thumbnails.
   `FacePass::QualityOnly` writes no `FACE_TABLE` rows and leaves `faces_checked`
   unset, so person clustering is untouched and a later `faces` run still does
   the real pass.
@@ -509,7 +509,7 @@ out of a real complaint about a soccer series.
 
 1. **A real eye-state classifier.** `blink_penalty` is still exactly
    `1 - eye_openness`, and the underlying signal is a mean vertical gradient in
-   a patch clamped to ≤8px radius that stops scaling with face size. SCRFD's
+   a patch clamped to ≤8px radius that stops scaling with face size. YuNet's
    single keypoint per eye cannot support an eye-aspect-ratio measure, so this
    needs a small ONNX eye-state model shipped as a new asset.
 2. **A noise estimator that does not compete with sharpness.** The current one
@@ -662,7 +662,7 @@ match the photographer's taste.
 
 ### Why that happens
 
-Players are small in frame and SCRFD runs on a 640×640 letterbox, so an action
+Players are small in frame and YuNet runs on a 640×640 letterbox, so an action
 burst usually detects **no faces** — which removes the entire face branch
 (expression, eyes, blink) from the score. What is left is:
 

--- a/docs/wiki/Dev-Image-Culling-Signal-Analysis.md
+++ b/docs/wiki/Dev-Image-Culling-Signal-Analysis.md
@@ -27,7 +27,7 @@ them as signposts rather than exact addresses.
    the sharp region alongside the global mean. The pair distinguishes "soft frame" from
    "correctly shallow".
 2. Where faces exist, measure sharpness on a **native-resolution eye-region crop**, not the
-   2048 px working image. Face boxes are already available from SCRFD.
+   2048 px working image. Face boxes are already available from YuNet.
 3. Add a **motion-blur direction** estimate (anisotropy of the gradient orientation histogram)
    so directional camera shake is separable from defocus and from intentional panning.
 
@@ -52,19 +52,20 @@ keep `max` only for prominence. Currently nothing is weighted by face size at al
 
 ### Blink detection itself is a ≤8 px gradient — OUTSTANDING
 `face_quality.rs:56-104`: mean absolute *vertical* gradient in a patch of radius
-`clamp(min(w,h) × 0.08, 2, 8)` around SCRFD's two eye keypoints.
+`clamp(min(w,h) × 0.08, 2, 8)` around YuNet's two eye keypoints.
 
 - The `EYE_PATCH_RADIUS_MAX: 8` clamp means the window **stops scaling with face size** — on a
   headshot where the face is 1200 px, the analysis window is a 17×17 px sliver.
-- SCRFD runs on a **640×640 letterbox** (`scrfd.rs:15`), so keypoints carry several pixels of
-  error when scaled back, and small faces in group shots go undetected.
+- YuNet runs on a **640×640 letterbox** (`yunet.rs:31`), so keypoints carry several pixels of
+  error when scaled back, and small faces in group shots go undetected. The letterbox size was
+  kept deliberately when the detector was swapped, so this limit is unchanged.
 - Eyelashes, eyeliner, glasses frames and dark eyebrows all produce strong vertical gradients on
   a *closed* eye; squinting in sunlight reads as closed.
 - **`blink_penalty` is literally `1.0 - eye_openness`** (`faces.rs:279`) — it carries no
   independent information, yet `reject_blink_penalty_threshold` is tuned as if it did.
 
 **Fix:** a small eye-state ONNX classifier on a native-resolution eye crop (24×24 or 32×32,
-1–3 MB, sub-millisecond). SCRFD's single point per eye cannot support an eye-aspect-ratio
+1–3 MB, sub-millisecond). YuNet's single point per eye cannot support an eye-aspect-ratio
 measure, so this genuinely needs a model. Remove `blink_penalty` as a separate field or derive
 it from the classifier's confidence.
 
@@ -81,6 +82,11 @@ gate. Either replace it with a real measurement or delete it and stop pretending
 > it — which is what a covered feature does to the detector's estimate) and **mirror asymmetry**
 > on the aligned 112 px crop, normalised by the crop's own luminance spread so it is not just
 > re-measuring contrast. Neither `det_score` nor `center_proximity` is an input any more.
+>
+> The template is still `ARCFACE_DST` and the crop is still 112 px even though recognition
+> moved from ArcFace to FaceNet: both are kept byte-for-byte (`umeyama.rs`) precisely so the
+> detector/recognizer swap left every culling score untouched. FaceNet gets its own wider
+> framing instead (`FACENET_ZOOM_OUT`), which is not what this measure runs on.
 >
 > Two honest caveats. Strong out-of-plane rotation raises the geometry term, and hard side
 > lighting raises the symmetry term; the field measures "obstructed *or* turned away", which is
@@ -209,7 +215,7 @@ differ only in ranking weights, and the user picks one by hand.
 | **Wedding / event** | 2–5k/day | Every face eyes-open; key-person priority; the moment (kiss, ring, first dance); mixed dim light | `max`-aggregation hides nine blinkers behind one open-eyed face; blink proxy weak; absolute noise penalty misfires at high ISO |
 | **Portrait / headshot** | low, high precision | Sharpness **on the eye plane**; catchlight; micro-expression; hair across face; half-blink | 512 px global sharpness cannot resolve eye vs. nose focus; 17 px eye window |
 | **Sports / action** | 1–5k bursts | Subject sharp — background *should* be soft; peak action; subject not clipped by frame edge | Global sharpness penalises correct shallow DOF and panning |
-| **Wildlife / birds** | large bursts | Animal **eye** sharp + catchlight; wing/limb position; background separation | SCRFD is human-only; no animal-eye detection at all |
+| **Wildlife / birds** | large bursts | Animal **eye** sharp + catchlight; wing/limb position; background separation | YuNet is human-only; no animal-eye detection at all |
 | **Landscape / architecture** | low | Corner-to-corner sharpness; horizon level; **brackets/stacks/panos must survive intact** | Intentional sets are culled |
 | **Street / documentary** | low burst rate | Moment and gesture over technical; grain and motion blur are legitimate | Technical weights over-penalise the aesthetic |
 | **Real estate / product** | tripod-locked repeats | Sharpest of identical frames; verticals; bracket sets | Bracket sets again |

--- a/docs/wiki/Help-Performance-Tips.md
+++ b/docs/wiki/Help-Performance-Tips.md
@@ -199,7 +199,7 @@ These are secondary compared to §2–4, but worth knowing:
 - **Extra context toggles** (folder names, capture date, existing keywords,
   GPS) add a small amount to every prompt. Harmless individually; skip the
   ones you don't need if you're optimizing a very large bulk run.
-- **Face detection during indexing** is local compute (SCRFD + ArcFace), not
+- **Face detection during indexing** is local compute (YuNet + FaceNet), not
   an LLM call, so it doesn't affect cloud cost — but it does add per-photo
   processing time on the backend machine. Worth it if you'll use
   People/Faces or want face-aware Cull scoring; skip it for a pure

--- a/server-rs/crates/lrg-ml/src/face_quality.rs
+++ b/server-rs/crates/lrg-ml/src/face_quality.rs
@@ -105,7 +105,7 @@ pub fn eye_openness_proxy(
 /// How far the detected landmarks are from a plausible face geometry, as a
 /// fraction of the aligned crop's width.
 ///
-/// The five SCRFD keypoints are fitted to ArcFace's canonical template with the
+/// The five detector keypoints are fitted to the canonical `ARCFACE_DST` template with the
 /// same similarity transform the recognition pipeline already uses. A similarity
 /// transform has four degrees of freedom and can absorb any translation,
 /// rotation, uniform scale — so on an unobstructed frontal face the residual is


### PR DESCRIPTION
The model swap in #287 updated the six pages named in its `Docs-Reviewed:` trailers, but pages outside that set still described the **current** face pipeline as SCRFD/ArcFace.

## What was stale

- **`Dev-Backend-API.md`** — `/health`'s `face_model`/`face_error` was documented as `(SCRFD/ArcFace)`.
- **`Help-Performance-Tips.md`** — the face-detection cost bullet named the retired pair.
- **`Dev-Image-Culling-Signal-Analysis.md`** — this page is living reference material, so every present-tense claim in it was wrong: the eye keypoints, the letterbox bullet (which also pointed at `scrfd.rs:15`, a file that no longer exists → now `yunet.rs:31`), the eye-classifier rationale, and "SCRFD is human-only" in the genre table.
- **`Dev-Image-Culling-Implementation-Plan.md`** — only the four hits inside the "Current state" section, which describe shipped behaviour. The original plan and checklist above it are a historical record and are left alone.
- **`face_quality.rs`** — a doc comment claiming the fit takes "the five SCRFD keypoints".

## What was deliberately left alone

Every other mention of InsightFace is historical framing — "used to run", "the retired ArcFace", "these replaced" — in `assets.rs`, `index.rs`, `index_upload.rs`, `model_paths.rs`, `yunet.rs`, `facenet.rs`, `umeyama.rs`, the export/golden scripts, `model-assets-face.yml`, and the upgrade sections of Troubleshooting / Help-People-Faces. The old model-ID strings in `contract.rs` are fixtures for the mixed-embedding guard.

## One thing that reads stale but is not

`ARCFACE_DST` and the 112 px crop are still in use. `umeyama.rs` keeps them byte-for-byte precisely so the detector/recognizer swap left every culling score untouched, while FaceNet gets its own wider framing via `FACENET_ZOOM_OUT`. Rather than rename something accurate, the Signal-Analysis status block now explains why the name outlived the model.

## Verification

`cargo fmt`, `cargo clippy -p lrg-ml --all-targets` and `scripts/check-docs.py` all clean (the pre-commit hooks ran on commit). Docs-only apart from the one Rust doc comment; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gY9osZuR2Eo5msotWpjsM
