### PR TITLE
deps: take arrow from lancedb's re-export, bump sha2 to 0.11

### DIFF
--- a/server-rs/Cargo.lock
+++ b/server-rs/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -1007,15 +1007,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1558,7 +1549,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.5",
  "regex",
- "sha2 0.11.0",
+ "sha2",
  "uuid",
 ]
 
@@ -4277,7 +4268,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "tempfile",
  "tokio",
  "tower",
@@ -4400,8 +4391,6 @@ dependencies = [
 name = "lrg-store"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
  "chrono",
  "futures",
  "lancedb",
@@ -6197,23 +6186,12 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest 0.11.3",
 ]
 

--- a/server-rs/crates/lrg-api/Cargo.toml
+++ b/server-rs/crates/lrg-api/Cargo.toml
@@ -39,7 +39,7 @@ chrono.workspace = true
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-sha2 = "0.10"
+sha2 = "0.11"
 futures-util = { version = "0.3.33", default-features = false, features = ["std"] }
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 async-trait = "0.1.91"

--- a/server-rs/crates/lrg-api/src/routes/update.rs
+++ b/server-rs/crates/lrg-api/src/routes/update.rs
@@ -50,7 +50,11 @@ fn platform_key() -> &'static str {
 fn sha256_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    format!("{:x}", hasher.finalize())
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 fn err(status: StatusCode, msg: impl Into<String>) -> Response {

--- a/server-rs/crates/lrg-store/Cargo.toml
+++ b/server-rs/crates/lrg-store/Cargo.toml
@@ -6,8 +6,6 @@ license.workspace = true
 
 [dependencies]
 lancedb = "0.37"
-arrow-array = "58"
-arrow-schema = "58"
 futures = "0.3"
 serde_json.workspace = true
 lrg-chroma-reader.workspace = true

--- a/server-rs/crates/lrg-store/src/lib.rs
+++ b/server-rs/crates/lrg-store/src/lib.rs
@@ -12,12 +12,17 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use arrow_array::builder::{FixedSizeListBuilder, Float32Builder, StringBuilder};
-use arrow_array::{
+use futures::TryStreamExt;
+// Arrow comes from lancedb's own re-export rather than a direct dependency, so
+// the version is always the one lancedb was built against. Declaring arrow
+// ourselves lets cargo pick a semver-incompatible major (arrow 59 while lancedb
+// pins ^58), which puts two arrow trees in the build and breaks every type that
+// crosses the lancedb boundary.
+use lancedb::arrow::arrow_array::builder::{FixedSizeListBuilder, Float32Builder, StringBuilder};
+use lancedb::arrow::arrow_array::{
     Array, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, StringArray,
 };
-use arrow_schema::{DataType, Field, Schema};
-use futures::TryStreamExt;
+use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
 use lancedb::index::scalar::BTreeIndexBuilder;
 use lancedb::index::Index;
 use lancedb::query::{ExecutableQuery, QueryBase};
@@ -120,7 +125,7 @@ pub enum StoreError {
     #[error("lancedb error: {0}")]
     Lance(#[from] lancedb::Error),
     #[error("arrow error: {0}")]
-    Arrow(#[from] arrow_schema::ArrowError),
+    Arrow(#[from] lancedb::arrow::arrow_schema::ArrowError),
     #[error("unknown table: {0}")]
     UnknownTable(String),
     #[error("dimension mismatch in {table}: expected {expected}, got {got} for id {id}")]
@@ -443,7 +448,9 @@ impl Store {
             .when_matched_update_all(None)
             .when_not_matched_insert_all();
         builder
-            .execute(Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
+            .execute(
+                Box::new(reader) as Box<dyn lancedb::arrow::arrow_array::RecordBatchReader + Send>
+            )
             .await?;
         self.write_ops.fetch_add(1, Ordering::Relaxed);
         Ok(())


### PR DESCRIPTION
Resolves the three dependabot major-version PRs that CI could not build:
closes #262, closes #264, closes #265.

## arrow-array / arrow-schema 58 → 59 (#262, #264) — not mergeable as proposed

`lancedb 0.37.1`, the latest release, requires `arrow ^58.0.0`. Raising our own
arrow to 59 puts two semver-incompatible arrow trees in the build, so every type
crossing the lancedb boundary stops unifying. That is why CI reported

```
the trait `From<arrow_schema::error::ArrowError>` is not implemented for `StoreError`
```

on a `StoreError` that visibly *does* derive it — the two `arrow_schema` in that
message are different crates. Nothing on our side fixes this; it needs a lancedb
release built against arrow 59.

Rather than pin to 58 and add a dependabot `ignore` rule, this drops the direct
arrow dependencies and uses the crates lancedb already re-exports as
`lancedb::arrow::*`. The arrow version is now structurally whatever lancedb was
built against, so it cannot drift again — and dependabot will not open an arrow
PR in future, because we no longer declare the dependency. All five usage sites
are in `lrg-store/src/lib.rs`.

**Tradeoff worth a second opinion:** this trades an explicit dependency for an
implicit one. The alternative — keep `arrow-* = "58"` declared and add an
`ignore` for `version-update:semver-major` — is more config for the same
outcome, but leaves the constraint visible in `Cargo.toml`. I chose the
re-export because it makes the invariant unbreakable rather than merely stated,
and left a comment at the import site explaining why.

## sha2 0.10 → 0.11 (#265) — worth taking

0.11 returns `hybrid_array::Array` from `finalize()`, which no longer implements
`LowerHex`, so the single `format!("{:x}", …)` call site needed hex formatting
spelled out. The payoff is dropping a duplicate crate: `lrg-api` was the last
holder of sha2 0.10, while datafusion (via lancedb) already pulled 0.11.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets` — zero warnings
- `cargo test --workspace` — 0 failures across all test binaries
- The `sha256_hex_matches_known_vector` test in `routes/update.rs` covers the
  reformatted hex path against the standard empty-string vector.

## Docs

`server-rs/README.md` and `docs/wiki/Dev-Backend-API.md` document the touched
files. Neither mentions arrow or sha2, so both remain accurate — no page changes
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cYPq2MzAQDTxnTE8dk1QA