### PR TITLE
Pin the CodeQL Rust toolchain to 1.94

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,9 +66,20 @@ jobs:
         if: matrix.language == 'rust'
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          # Named explicitly: with the ref pinned to a hash, the branch name no
-          # longer conveys which toolchain this installs.
-          toolchain: stable
+          # Pinned to 1.94, deliberately behind stable. The extractor parses the
+          # sysroot with the rust-analyzer vendored into the CodeQL bundle, and
+          # 2.26.3 vendors ra_ap_* 0.0.301, which chokes on the std that ships
+          # with rustc >= 1.96: `vec!`, `format!`, `assert!` and friends all
+          # fail to expand, which is what drags the database-quality metrics
+          # under their thresholds ("Percentage of calls with call target").
+          # Nothing here is compiled, so the version only decides which std
+          # rust-analyzer reads -- it does not have to match the release build.
+          # https://github.com/github/codeql/issues/19982
+          #
+          # Drop the pin once the runner picks up a bundle that contains
+          # https://github.com/github/codeql/pull/21714 (rust-analyzer 0.0.328,
+          # merged 2026-08-14, so 2.26.4 or later) and go back to `stable`.
+          toolchain: "1.94"
 
       - name: Cache cargo registry
         if: matrix.language == 'rust'


### PR DESCRIPTION
## Why

The CodeQL Rust job passes, but every run reports **Low Rust analysis quality**:

> Percentage of calls with call target: 49 % (threshold 50 %). Percentage of expressions with known type: 58 % (threshold 20 %).

The extraction log for the last run on `main` shows what is behind those numbers:

```
WARN .../lrg-analysis/src/clustering.rs:65:21: macro expansion failed for 'vec'
WARN .../examples/bench_grouping.rs:52:27: macro expansion failed for 'format'
WARN .../lrg-ml/src/face_quality.rs:211:9:  macro expansion failed for 'assert_eq'
WARN .../examples/cull_eval.rs:74:9:        macro expansion failed for '$crate::format_args_nl'
...
| Total number of Rust files that were extracted with errors   |   110 |
| Total number of Rust files that were extracted without error |    12 |
```

`vec!`, `format!`, `assert!` and `panic_2021` are everywhere in this workspace, and everything inside an unexpanded macro loses its call targets and types. So this is real lost coverage for the security queries, not only noisy logs.

## Cause

Not this repository's code, and not the recent dependency changes: the failures track the **std version on the runner**. Bundle 2.26.3 vendors `ra_ap_* 0.0.301`, which copes with std up to 1.94 and fails on exactly these macros from 1.96 onwards. `dtolnay/rust-toolchain@stable` installed **1.97.1**. See github/codeql#19982 — the same thread rules out the obvious other suspect, a missing `rust-src` component ("installing it changed the count by exactly zero").

## Change

Pin that one job's toolchain to `1.94`. Nothing is compiled under `build-mode: none`, so the version only decides which std rust-analyzer parses — it does not need to match the release build, and no other workflow is affected.

## Removing the pin

rust-analyzer 0.0.328 merged upstream (github/codeql#21714) on 2026-08-14, two days after 2.26.3 shipped. Once the runner picks up 2.26.4 or later, this goes back to `stable`. The comment in the workflow says so.

## Verification

The CodeQL run on this PR is the test — it should show the macro-expansion warnings gone and the two percentages back above their thresholds. If cargo 1.94 turns out not to resolve the workspace, the job fails loudly rather than silently degrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNWGWJivRhKnTmXjsWSRj3