### PR TITLE
Survive a disk cleaner deleting the macOS log directory

### DIFF
--- a/installers/macos/build_pkg.sh
+++ b/installers/macos/build_pkg.sh
@@ -97,7 +97,7 @@ display dialog "Are you sure you want to uninstall LrGeniusAI? This will remove 
 if button returned of result is "Uninstall" then
     try
         set userHome to (do shell script "dscl . -read /Users/$(id -un " & currentUser & ") NFSHomeDirectory | awk '{print $2}'")
-        do shell script "launchctl asuser " & currentUser & " launchctl unload /Library/LaunchAgents/com.lrgenius.server.plist 2>/dev/null || true; rm -f /Library/LaunchAgents/com.lrgenius.server.plist; rm -rf '" & userHome & "/Library/Application Support/Adobe/Lightroom/Modules/LrGeniusAI.lrplugin'; rm -rf /Library/Logs/LrGeniusAI; rm -rf /Applications/LrGeniusAI" with administrator privileges
+        do shell script "launchctl asuser " & currentUser & " launchctl unload /Library/LaunchAgents/com.lrgenius.server.plist 2>/dev/null || true; rm -f /Library/LaunchAgents/com.lrgenius.server.plist; rm -rf '" & userHome & "/Library/Application Support/Adobe/Lightroom/Modules/LrGeniusAI.lrplugin'; rm -rf /Library/Logs/LrGeniusAI; rm -rf '" & userHome & "/Library/Logs/LrGeniusAI'; rm -rf /Applications/LrGeniusAI" with administrator privileges
         display dialog "LrGeniusAI has been successfully uninstalled." with title "Uninstall LrGeniusAI" buttons {"OK"} default button "OK"
     on error errMsg
         display dialog "Uninstallation failed: " & errMsg with title "Uninstall LrGeniusAI" buttons {"OK"} default button "OK" with icon stop

--- a/installers/macos/com.lrgenius.server.plist
+++ b/installers/macos/com.lrgenius.server.plist
@@ -4,17 +4,32 @@
 <dict>
     <key>Label</key>
     <string>com.lrgenius.server</string>
+
+    <!-- Deliberately not StandardOutPath/StandardErrorPath. launchd opens
+         those before it execs the program: it will create a missing directory
+         when it can, but /Library/Logs is root:wheel and this is a LaunchAgent
+         running as the logged-in user, so once a disk cleaner deletes
+         /Library/Logs/LrGeniusAI nobody but root can put it back. launchd then
+         refuses to spawn the job at all -- EX_CONFIG (78) -- and the server
+         never runs, which is a hard failure to pay for a missing log file.
+
+         Redirecting from a shell instead lets us fall back to
+         ~/Library/Logs/LrGeniusAI, which is always ours to recreate, so every
+         launch attempt heals itself. `exec` keeps the server on the PID
+         launchd is watching, so KeepAlive still works, and ${LOG:-/dev/null}
+         means an unwritable pair of candidates costs us the log, not the
+         server. -->
+
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/LrGeniusAI/Server/lrgenius-server</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>for d in /Library/Logs/LrGeniusAI "$HOME/Library/Logs/LrGeniusAI"; do mkdir -p "$d" 2>/dev/null; if [ -w "$d" ]; then LOG="$d/service.log"; break; fi; done; exec /Applications/LrGeniusAI/Server/lrgenius-server >>"${LOG:-/dev/null}" 2&gt;&amp;1</string>
     </array>
+
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
-    <key>StandardOutPath</key>
-    <string>/Library/Logs/LrGeniusAI/service.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Library/Logs/LrGeniusAI/service.log</string>
 </dict>
 </plist>

--- a/server-rs/crates/lrg-common/src/config.rs
+++ b/server-rs/crates/lrg-common/src/config.rs
@@ -2,6 +2,8 @@
 //! platform-specific log path rules ported from `server/src/config.py`.
 
 use std::env;
+#[cfg(target_os = "macos")]
+use std::fs;
 use std::path::{Path, PathBuf};
 
 pub const DEFAULT_HOST: &str = "127.0.0.1";
@@ -45,11 +47,57 @@ pub fn log_path_for_db(db_path: &Path) -> PathBuf {
         .join(LOG_FILE_NAME)
 }
 
+/// True when `dir` exists (or can be created) and accepts a new file.
+///
+/// Writing a probe file is the only answer we can trust: the mode bits alone
+/// miss ACLs, a read-only volume, and the case where the directory belongs to
+/// another user. The probe is a separate file rather than the log itself so
+/// that startup rotation still sees the real history instead of rotating an
+/// empty file we just created.
+#[cfg(target_os = "macos")]
+fn log_dir_is_usable(dir: &Path) -> bool {
+    if fs::create_dir_all(dir).is_err() {
+        return false;
+    }
+    let probe = dir.join(".lrgenius-write-probe");
+    match fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
 /// Fallback log path when no db_path is bound yet.
+///
+/// Touches the filesystem: it creates the directory it settles on, so the
+/// caller can open the file without a second thought. Called once at startup.
+///
+/// The macOS branch has two candidates on purpose. The installer puts logs in
+/// `/Library/Logs/LrGeniusAI`, but that directory is not ours to recreate --
+/// `/Library/Logs` is `root:wheel` and the server runs as a LaunchAgent under
+/// the logged-in user, who can write inside a directory the installer made for
+/// them but cannot make a new one. Disk cleaners do delete it (BuhoCleaner
+/// among them), and logging nowhere at all is a poor answer to that, so fall
+/// back to the per-user location we can always recreate.
 pub fn default_log_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        PathBuf::from("/Library/Logs/LrGeniusAI/service.log")
+        let system = PathBuf::from("/Library/Logs/LrGeniusAI");
+        if log_dir_is_usable(&system) {
+            return system.join("service.log");
+        }
+        if let Some(home) = env::var_os("HOME") {
+            let user = PathBuf::from(home).join("Library/Logs/LrGeniusAI");
+            if log_dir_is_usable(&user) {
+                return user.join("service.log");
+            }
+        }
+        // Nothing is writable. Return the documented path anyway so the
+        // reported location matches what the installer set up; the logger
+        // degrades to stdout-only from here.
+        system.join("service.log")
     }
     #[cfg(target_os = "windows")]
     {
@@ -64,5 +112,41 @@ pub fn default_log_path() -> PathBuf {
         env::current_dir()
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(LOG_FILE_NAME)
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usable_dir_is_created_on_demand_and_leaves_nothing_behind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("Logs/LrGeniusAI");
+        assert!(log_dir_is_usable(&dir));
+        assert!(dir.is_dir());
+        // The probe must not survive, or rotation would inherit it.
+        assert_eq!(fs::read_dir(&dir).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn unusable_when_the_directory_cannot_be_created() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A regular file where a parent directory would have to go: this is
+        // the "cannot create" case without depending on running as non-root,
+        // which a permission-based test would.
+        let blocker = tmp.path().join("Logs");
+        fs::write(&blocker, b"not a directory").unwrap();
+        assert!(!log_dir_is_usable(&blocker.join("LrGeniusAI")));
+    }
+
+    #[test]
+    fn default_log_path_points_somewhere_writable() {
+        let path = default_log_path();
+        let dir = path.parent().unwrap();
+        assert_eq!(path.file_name().unwrap(), "service.log");
+        // Whichever candidate won, the directory exists by the time we return
+        // -- unless the machine has neither, which is not the case in CI.
+        assert!(dir.is_dir(), "{} should exist", dir.display());
     }
 }

--- a/server-rs/crates/lrg-common/src/logging.rs
+++ b/server-rs/crates/lrg-common/src/logging.rs
@@ -118,6 +118,16 @@ pub fn init_with_options(log_path: &Path, debug: bool, stdout_echo: bool) {
         } else {
             LevelFilter::Info
         });
+        // Losing the file is the one failure this module cannot report through
+        // itself, so say it on the channel that is still working. Whoever reads
+        // the log later would otherwise just find nothing and have no idea why.
+        if r.file.lock().map(|g| g.is_none()).unwrap_or(true) {
+            log::warn!(
+                "Could not open the log file at {} - logging to stdout only for this run. \
+                 Check that the directory exists and is writable.",
+                log_path.display()
+            );
+        }
     }
 }
 
@@ -134,6 +144,7 @@ pub fn swap_log_file(new_path: &Path) {
         }
     }
     let new_file = open_log_file(new_path);
+    let opened = new_file.is_some();
     {
         let mut guard = logger.file.lock().unwrap();
         *guard = new_file;
@@ -142,7 +153,17 @@ pub fn swap_log_file(new_path: &Path) {
         let mut current = logger.path.write().unwrap();
         *current = new_path.to_path_buf();
     }
-    log::info!("Log path context updated to: {}", new_path.display());
+    if opened {
+        log::info!("Log path context updated to: {}", new_path.display());
+    } else {
+        // Don't claim a move that didn't happen: from here on the only output
+        // is stdout, and the reason has to travel with that.
+        log::warn!(
+            "Could not open the log file at {} - logging to stdout only from here. \
+             Check that the directory exists and is writable.",
+            new_path.display()
+        );
+    }
 }
 
 /// The currently active log file path (config.LOG_PATH equivalent).


### PR DESCRIPTION
## Symptom

BuhoCleaner deletes `/Library/Logs/LrGeniusAI`, and `lrgenius-server` then will not start. Recreating the directory by hand fixes it until the next sweep.

## What actually happens

launchd opens `StandardOutPath` **before** it execs the program. It will create a missing directory when it can — I checked, with a throwaway agent pointed at a nonexistent path: it created the directory and exited 0. What it cannot do is create one under a parent it has no write access to, and that is this case: `/Library/Logs` is `root:wheel drwxr-xr-x`, and this is a LaunchAgent running as the logged-in user. A second throwaway agent with a read-only log parent reproduced the failure exactly:

```
last exit code = 78: EX_CONFIG
```

which matches the live install. So the installer can hand the user a directory inside `/Library/Logs`, but once it is gone nobody but root can put it back — and the server never runs at all, rather than running without a log. The plugin's `launchctl kickstart` just times out.

## Fix

Give both start paths a fallback the user always owns:

- **`com.lrgenius.server.plist`** — redirect from a shell instead of `StandardOutPath`/`StandardErrorPath`, so the directory check happens after launchd has committed to starting us, with `~/Library/Logs/LrGeniusAI` as the second candidate. `exec` keeps the server on the PID launchd watches, so `KeepAlive` is unaffected; `${LOG:-/dev/null}` means an unwritable pair of candidates costs the log, not the server.
- **`default_log_path()`** — probe the candidates instead of trusting the installer's, so a manually started server (the plugin's dev path, `--db-path` unset) heals the same way.

Verified with the same throwaway-agent setup: where the old shape gave `EX_CONFIG`, the new one exits 0 and writes to the fallback.

## Silent failures on the way out

`open_log_file()` returning `None` left the logger writing nowhere with nothing said about it — you would find an empty log and no reason. Losing the file is the one failure this module cannot report through itself, so it now says so on stdout, and `swap_log_file()` no longer logs "Log path context updated to: …" for a move that did not happen.

The uninstaller learns about the new location too.

## Testing

- Three new unit tests around the probe helper and `default_log_path()` (macOS-gated — CI runs `ubuntu-latest`, so these run locally).
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets` clean; `cargo test -p lrg-common` green.
- The shell snippet exercised standalone across four permission cases (creatable / read-only parent / exists-but-unwritable / neither).

## Note for existing installs

This ships in the next package. An already-installed `/Library/LaunchAgents/com.lrgenius.server.plist` keeps the old shape until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNWGWJivRhKnTmXjsWSRj3
