### PR TITLE
Group the HTTP API into domains under /v1

### DIFF
--- a/.github/workflows/model-assets-bioclip.yml
+++ b/.github/workflows/model-assets-bioclip.yml
@@ -70,7 +70,7 @@ jobs:
           body: |
             Pinned BioCLIP 2 export (`imageomics/bioclip-2`, MIT) plus a pruned
             TreeOfLife-200M zero-shot head, downloaded at runtime by the backend's
-            `/bioclip/download/start` — **not an app release**, see the tagged `v*`
+            `/v1/models/bioclip/downloads` — **not an app release**, see the tagged `v*`
             releases for those. Regenerated only when
             `server-rs/scripts/export_bioclip2_fp16.py`, the taxa filter, or their
             pinned deps change.

--- a/.github/workflows/model-assets-face.yml
+++ b/.github/workflows/model-assets-face.yml
@@ -65,7 +65,7 @@ jobs:
           name: Face model assets (YuNet + FaceNet)
           body: |
             ONNX assets for the backend's face pipeline, fetched by
-            `POST /assets/download/start`.
+            `POST /v1/models/assets/downloads`.
 
             - `yunet_face_detection.onnx` — OpenCV Zoo YuNet 2023mar, Apache-2.0
             - `facenet_vggface2.onnx` — facenet-pytorch Inception-ResNet-v1

--- a/.github/workflows/model-assets.yml
+++ b/.github/workflows/model-assets.yml
@@ -62,7 +62,7 @@ jobs:
           name: "SigLIP2 model assets (fp16 ONNX)"
           body: |
             Pinned SigLIP2 fp16 ONNX export (`timm/ViT-SO400M-16-SigLIP2-384`), downloaded
-            at runtime by the backend's `/clip/download/start` — **not an app release**,
+            at runtime by the backend's `/v1/models/clip/downloads` — **not an app release**,
             see the tagged `v*` releases for those. Regenerated only when
             `server-rs/scripts/export_siglip2_fp16.py` or its pinned deps change.
           files: model-assets/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,8 @@ jobs:
 
           echo "Copying plugin files..."
           cp plugin/LrGeniusAI.lrdevplugin/*.lua $PLUGIN_DIR/
+          cp plugin/LrGeniusAI.lrdevplugin/*.png $PLUGIN_DIR/
+          cp plugin/LrGeniusAI.lrdevplugin/*.ico $PLUGIN_DIR/
 
       # macOS Developer ID codesigning + notarization. Skipped (with a
       # warning, not a failure) when the secrets aren't configured, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ cd server-rs
 cargo build --release -p lrg-server
 ```
 
-**The in-process local LLM is behind the `llamacpp` cargo feature, off by default.** Without it the `llamacpp` provider reports "this backend build has no local-model support" and `/llm/catalog` returns `supported: false` — which is the answer to "why doesn't the Local AI Model section do anything". It is off by default because it compiles llama.cpp from source, so it needs `cmake` and `libclang` (bindgen) and adds minutes to a cold build; anyone touching an unrelated crate should not pay that.
+**The in-process local LLM is behind the `llamacpp` cargo feature, off by default.** Without it the `llamacpp` provider reports "this backend build has no local-model support" and `/v1/llm/catalog` returns `supported: false` — which is the answer to "why doesn't the Local AI Model section do anything". It is off by default because it compiles llama.cpp from source, so it needs `cmake` and `libclang` (bindgen) and adds minutes to a cold build; anyone touching an unrelated crate should not pay that.
 
 **Which local engine ships is a per-platform decision.** Release builds enable `llamacpp` on **Windows only**; the **macOS build is MLX-only** and does not compile the feature at all (see `cargo_features` in the release matrix, `.github/workflows/release.yml`). The plugin mirrors that: `sectionsForTopOfDialog` and the onboarding wizard build the MLX group box on macOS and the llama.cpp one elsewhere, and the provider dropdown needs no special-casing because `/models` reports `llamacpp: []` when the feature is absent. The feature still *builds* on macOS, so enabling it locally to compare the two engines is fine — just don't re-add it to the macOS release job.
 
@@ -49,7 +49,7 @@ xcodebuild build -scheme lrgenius-mlx -destination 'platform=macOS,arch=arm64' \
 export LRG_MLX_SIDECAR=$PWD/.build/xcode/Build/Products/Release/lrgenius-mlx
 ```
 
-Without it, `/llm/catalog` reports `mlx.supported: false` with a reason naming what is missing. See [native/mlx-sidecar/README.md](native/mlx-sidecar/README.md) for the protocol, the model layout (a directory, not a GGUF file), and why MLX has no pinned prompt prefix.
+Without it, `/v1/llm/catalog` reports `mlx.supported: false` with a reason naming what is missing. See [native/mlx-sidecar/README.md](native/mlx-sidecar/README.md) for the protocol, the model layout (a directory, not a GGUF file), and why MLX has no pinned prompt prefix.
 
 Point llama.cpp at a model with `LRG_LLAMA_MODEL_GGUF` + `LRG_LLAMA_MMPROJ_GGUF` (a GGUF needs both the weights and an `mmproj` vision projector), or download one from the plugin's settings. Discovery also picks up GGUFs already under `~/.lmstudio/models`. The `lrg-llama` tests that exercise a real model are `#[ignore]`d and need `LRG_TEST_MODEL_GGUF`/`LRG_TEST_MMPROJ_GGUF`:
 
@@ -59,7 +59,7 @@ cargo test -p lrg-llama --test engine_smoke -- --ignored
 
 When Lightroom is involved, note the plugin auto-launches the *installed* binary (`/Applications/LrGeniusAI/Server/lrgenius-server`), which is not your dev build. `startServer` pings port 19819 first and short-circuits if something already answers, so start your feature-enabled build by hand and the plugin will use it.
 
-`POST /clip/download/start` fetches the SigLIP2 fp16 ONNX assets from the fixed `model-assets-v1` release tag (not the build's own version tag); that release exists with all three assets, so this works on any build. To export them yourself instead, see [server-rs/README.md](server-rs/README.md) for the commands and the env vars that point the server at the files (also covers the face models — YuNet needs no export step, FaceNet does). The export/verify script has its own standalone `uv` project at `server-rs/scripts/` (torch/open_clip/onnxruntime — a build-time tool, not a runtime dependency of the Rust binary).
+`POST /v1/models/clip/downloads` fetches the SigLIP2 fp16 ONNX assets from the fixed `model-assets-v1` release tag (not the build's own version tag); that release exists with all three assets, so this works on any build. To export them yourself instead, see [server-rs/README.md](server-rs/README.md) for the commands and the env vars that point the server at the files (also covers the face models — YuNet needs no export step, FaceNet does). The export/verify script has its own standalone `uv` project at `server-rs/scripts/` (torch/open_clip/onnxruntime — a build-time tool, not a runtime dependency of the Rust binary).
 
 ### Pre-commit hooks (formatting + linting)
 

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -11,7 +11,7 @@ This reference is intended for developers integrating with or extending the back
 ### `GET /ping`
 Minimal liveness check. Returns `{"status": "ok"}`.
 
-### `GET /health`
+### `GET /v1/server/health`
 Returns local model load state: `clip_model`/`clip_error` (SigLIP2) and
 `face_model`/`face_error` (YuNet/FaceNet), each `"loaded"`, `"not_loaded"`, or
 `"failed"`. It does **not** report cloud/local LLM provider availability —
@@ -27,25 +27,25 @@ Returns the running backend version string.
 ### `POST /version/check`
 Checks whether the backend version is compatible with the plugin version passed in the request body.
 
-### `POST /initialize`
+### `POST /v1/db/bind`
 Called by the Lightroom plugin on first connect. Accepts catalog/configuration parameters and initializes per-catalog state.
 
-### `GET /models` / `POST /models`
+### `POST /v1/llm/providers/models`
 Returns the list of available AI models grouped by provider (`gemini`, `chatgpt`, `ollama`, `lmstudio`, `llamacpp`, `mlx`). Filters out providers that are not configured or not reachable; the two local backends report what is installed on disk, so they are empty when no local model has been downloaded.
 
-### `GET /logs`
+### `GET /v1/server/logs`
 Returns recent log lines from the server log.
 
-### `GET /logs/raw/<log_type>`
+### `GET /v1/server/logs/<log_type>/raw`
 Streams raw log file content. `log_type` can be `server` or `plugin`.
 
 ### `POST /shutdown`
 Gracefully shuts down the backend process.
 
-### `POST /restart`
+### `POST /v1/server/restart`
 Restarts the backend process. Note: this endpoint is known to be unreliable on Windows (see [Troubleshooting](Troubleshooting)).
 
-### `POST /unload`
+### `POST /v1/server/unload`
 Unloads heavy ML models from memory without shutting the server down (useful to reclaim VRAM/RAM between sessions).
 
 ### `POST /update/apply`
@@ -55,7 +55,7 @@ Triggers an in-place backend self-update from the latest GitHub release.
 
 ## Photo Indexing
 
-### `POST /index`
+### `POST /v1/index/photos`
 Indexes a batch of photos sent as multipart file uploads. Generates embeddings and/or AI metadata depending on options.
 
 **Key request fields:**
@@ -78,7 +78,7 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 | `is_raw` | bool | Whether the original is raw. Stored on the photo so later work (style training above all) can keep raw and rendered originals apart. Omit when unknown |
 | `extra_context` | object | Optional context hints (folder, date, GPS, keywords) |
 
-`/index_by_reference` carries `exposure_bias` and `is_raw` per image inside the
+`/v1/index/photos/by-path` carries `exposure_bias` and `is_raw` per image inside the
 `images` array instead, since both are properties of the individual photo.
 
 **Response:** `{status, success_count, failure_count, error_messages, warnings, results}`.
@@ -93,7 +93,7 @@ provider says so in its own `warning` and it arrives as
 user a clean run that silently produced worse data. Each entry also rides on its
 own photo's `results` element as `warnings`, so a grouped caller can attribute it.
 
-### `POST /index_by_reference`
+### `POST /v1/index/photos/by-path`
 Indexes photos using server-side file paths instead of uploading image data (for local-backend
 setups where the server has filesystem access).
 
@@ -110,32 +110,32 @@ the batch.
 the group size for a `llamacpp` run, and omits it otherwise — a group formed for decode
 throughput must not override a provider's own preferred batch size.
 
-### `POST /get`
+### `POST /v1/photos/lookup`
 Returns stored metadata and embedding status for one or more `photo_id` values.
 
-### `GET /get/ids`
+### `GET /v1/photos/ids`
 Returns a list of all indexed `photo_id` values, optionally filtered by catalog.
 
-### `POST /index/check-unprocessed`
+### `POST /v1/index/unprocessed`
 Given a list of `photo_id` values, returns which ones are not yet indexed or are missing specific data.
 
-### `POST /remove`
+### `POST /v1/photos/remove`
 Removes all data (embeddings, metadata, face data) for a given `photo_id`.
 
-### `POST /remove/metadata`
+### `POST /v1/photos/metadata/remove`
 Removes only the AI-generated metadata fields for a given `photo_id`, leaving embeddings intact.
 
-### `POST /sync/cleanup`
+### `POST /v1/photos/catalogs/cleanup`
 Removes backend records for photos that no longer exist in a given catalog.
 
-### `POST /sync/claim`
+### `POST /v1/photos/catalogs/claim`
 Associates an existing backend record with a (potentially new) catalog ID.
 
 ---
 
 ## Semantic Search
 
-### `GET /search` / `POST /search`
+### `GET /v1/search` / `POST /v1/search`
 Runs a semantic search query against indexed photos.
 
 **Key request fields:**
@@ -159,7 +159,7 @@ check whenever `photo_ids` was present, leaking results from other catalogs.)
 come first, ordered by ascending distance; metadata matches follow with
 `distance: null` and fill whatever is left of `max_results`.
 
-### `POST /find_similar`
+### `POST /v1/search/similar`
 Finds photos similar to a reference photo using perceptual hash (phash) or CLIP embeddings.
 
 **Key request fields:**
@@ -172,25 +172,25 @@ Finds photos similar to a reference photo using perceptual hash (phash) or CLIP 
 | `max_results` | int | Maximum results |
 | `strictness` | string | `strict`, `normal`, or `loose` (phash mode) |
 
-### `POST /group_similar`
+### `POST /v1/cull/groups`
 Groups a set of photos into similarity clusters (used internally by the culling workflow).
 
-### `POST /cull`
+### `POST /v1/cull/grade`
 Runs the full culling pipeline on a set of photos: grouping, scoring, and classification into picks/alternates/rejects.
 
 ---
 
 ## AI Develop Edits
 
-### `POST /edit`
+### `POST /v1/edit/recipe`
 Generates a Lightroom develop recipe for a photo sent as a file upload, using an
 LLM.
 
 > No plugin workflow calls this any more. *AI Edit Photos* runs on
-> `POST /style_edit` alone and never asks for the LLM fallback, so this endpoint
-> and `/edit_base64` are currently reachable only by direct HTTP callers. Both
+> `POST /v1/edit/style` alone and never asks for the LLM fallback, so this endpoint
+> and `/v1/edit/recipe/base64` are currently reachable only by direct HTTP callers. Both
 > are fully supported; `SearchIndexAPI.generateEditRecipePhoto` in the plugin
-> still speaks to `/edit` and is simply not called.
+> still speaks to `/v1/edit/recipe` and is simply not called.
 
 **Key request fields:**
 
@@ -238,15 +238,15 @@ derives a budget from it, and caps contrast-raising fields — `contrast`,
 `whites` against it. The cap runs *before* the creative-control filter, so a
 disabled field is never capped and then discarded.
 
-### `POST /edit_base64`
-Same as `/edit` but accepts image data as base64.
+### `POST /v1/edit/recipe/base64`
+Same as `/v1/edit/recipe` but accepts image data as base64.
 
-### `POST /style_edit`
+### `POST /v1/edit/style`
 Produces a recipe from the user's own saved edits with no LLM involved: it
 retrieves training examples similar to the photo, re-scores them on exposure,
 scene and time of day, and interpolates their develop settings. Needs at least
 five stored examples. The result passes through the same guardrail budget as
-`/edit` and carries the same `guardrail_reasons`.
+`/v1/edit/recipe` and carries the same `guardrail_reasons`.
 
 `temperature` is blended only from examples whose `is_raw` matches the photo
 being edited, because Lightroom's temperature is Kelvin for raw and a relative
@@ -257,7 +257,7 @@ before `is_raw` was recorded count as compatible with anything. Every other
 develop setting means the same on both kinds of file and is blended normally;
 `tint` differs only in range, which the clamp handles.
 
-The `/edit` few-shot path applies the same rule: an example whose raw status
+The `/v1/edit/recipe` few-shot path applies the same rule: an example whose raw status
 conflicts with the target has its white balance stripped before it reaches the
 prompt, so the model is never anchored on a number the schema it must answer in
 cannot express.
@@ -266,20 +266,20 @@ cannot express.
 
 ## Face Detection & Persons
 
-### `POST /faces/detect`
+### `POST /v1/faces/detect`
 Detects faces in an uploaded image and stores their embeddings.
 
-### `POST /faces/query`
+### `POST /v1/faces/search`
 Finds photos containing faces similar to those in a reference image.
 
-### `POST /faces/cluster`
+### `POST /v1/faces/cluster`
 Re-clusters all stored face embeddings into person groups. Faces whose row carries no
 usable embedding are reported as unassigned rather than clustered — an empty
 vector compares as distance 0 to everything and would merge unrelated clusters.
 Above `AGGLOMERATIVE_MAX_POINTS` faces the agglomerative algorithm is skipped
 (its n×n distance matrix would be gigabytes) and DBSCAN is used instead.
 
-### `GET /faces/persons`
+### `GET /v1/faces/persons`
 Returns all detected persons with `person_id`, `name`, `face_count`,
 `photo_count` and a representative `thumbnail` (base64 JPEG, empty when the
 person has none).
@@ -287,80 +287,80 @@ person has none).
 Every face without a person — an empty `person_id` from a row that was never
 clustered, or `person_unassigned` written by the clusterer — is reported as a
 single entry with an empty `person_id`. The thumbnail is included here on
-purpose: fetching it per person from `/faces/persons/<id>/thumbnail` meant one
+purpose: fetching it per person from `/v1/faces/persons/<id>/thumbnail` meant one
 full table scan per person.
 
-### `GET /faces/persons/<person_id>/thumbnail`
+### `GET /v1/faces/persons/<person_id>/thumbnail`
 Returns the representative face thumbnail for a person as base64 JPEG. Kept for
-older plugin builds; `GET /faces/persons` already includes it, and this scans
+older plugin builds; `GET /v1/faces/persons` already includes it, and this scans
 the whole face table for one image, so it must not be called in a loop.
 
-### `PUT /faces/persons/<person_id>`
+### `PUT /v1/faces/persons/<person_id>`
 Updates the name assigned to a person cluster.
 
-### `GET /faces/persons/<person_id>/photos`
+### `GET /v1/faces/persons/<person_id>/photos`
 Returns the list of `photo_id` values associated with a specific person.
 
 ---
 
 ## Metadata Import
 
-### `POST /import/metadata`
+### `POST /v1/photos/metadata/import`
 Imports existing Lightroom catalog metadata (keywords, title, caption, rating, etc.) into the backend database for a batch of photos.
 
 ---
 
 ## Keyword Management
 
-### `POST /keywords/cluster`
+### `POST /v1/keywords/clusters`
 Synchronous keyword clustering: groups catalog keywords by semantic similarity.
 
-### `POST /keywords/cluster/start`
+### `POST /v1/keywords/clusters/jobs`
 Async version: starts a background clustering job and returns a `job_id`.
 
-### `GET /keywords/cluster/status/<job_id>`
+### `GET /v1/keywords/clusters/jobs/<job_id>`
 Polls the status and result of an async clustering job.
 
-### `POST /keywords/apply-merges`
+### `POST /v1/keywords/merges`
 Applies a list of approved keyword merge pairs to the backend's metadata records.
 
 ---
 
 ## Style Training
 
-### `POST /training/add`
+### `POST /v1/edit/training`
 Stores one photo's develop settings as a training example. `is_raw` is recorded
 with it and decides, later, whether the example may contribute a temperature —
-see `POST /style_edit`.
+see `POST /v1/edit/style`.
 
 Saves a photo's Lightroom develop settings as a labeled training example.
 
-### `GET /training/list`
+### `GET /v1/edit/training`
 Lists all stored training examples.
 
-### `GET /training/stats`
+### `GET /v1/edit/training/stats`
 Returns aggregated statistics about stored training examples (count per label, coverage).
 
-### `GET /training/count`
+### `GET /v1/edit/training/count`
 Returns the total number of stored training examples.
 
-### `DELETE /training/<photo_id>`
+### `DELETE /v1/edit/training/<photo_id>`
 Removes the training example for a specific photo.
 
-### `DELETE /training`
+### `DELETE /v1/edit/training`
 Clears all training examples.
 
 ---
 
 ## CLIP Model Management
 
-### `GET /clip/status`
+### `GET /v1/models/clip`
 Returns whether the SigLIP2 embedding model is downloaded and ready.
 
-### `POST /clip/download/start`
+### `POST /v1/models/clip/downloads`
 Triggers a background download of the CLIP model.
 
-### `GET /clip/download/status`
+### `GET /v1/models/clip/downloads`
 Returns the current progress of an ongoing CLIP model download.
 
 ---
@@ -372,7 +372,7 @@ the plugin's setup flows drive these instead: three downloads, three progress
 bars and three ready indicators ask a photographer to care about which neural
 network does which job.
 
-### `GET /assets/status`
+### `GET /v1/models/assets`
 Per-family readiness plus one overall `ready` flag and `missing_approx_bytes`
 for the "this will download about N GB" line. All three families — `clip`,
 `bioclip` and `face` — are `downloadable: true` and all three gate `ready`.
@@ -382,13 +382,13 @@ Face detection used to be the exception: its `buffalo_l` weights came from
 could not fix. Replacing them with YuNet + FaceNet removed that carve-out;
 `downloadable` remains in the response because the plugin reads it.
 
-### `POST /assets/download/start`
+### `POST /v1/models/assets/downloads`
 Downloads every downloadable family that is **missing**, under one progress
 entry keyed `assets`. Families already on disk are skipped, so this doubles as
 "finish setting up" after an upgrade. With nothing missing it reports
 `completed` rather than idling.
 
-### `GET /assets/download/status`
+### `GET /v1/models/assets/downloads`
 Same shape as the other download-status routes.
 
 ---
@@ -406,17 +406,17 @@ The head is pruned from upstream's 867,455 taxa; see
 `server-rs/scripts/bioclip_taxa_filter.toml` for the rules and for what
 pruning costs at the species rank.
 
-### `GET /bioclip/status`
+### `GET /v1/models/bioclip`
 Returns whether the BioCLIP assets are on disk (`bioclip: "ready" | "not_ready"`),
 plus `model` — the head identifier, e.g. `bioclip-2/taxa-v2`, read from the
 labels file when the head is not loaded, so it answers without pulling 866 MB
-into memory. Deliberately distinct from `/health`'s `species_model`, which
+into memory. Deliberately distinct from `/v1/server/health`'s `species_model`, which
 reports whether it is currently resident in memory.
 
-### `POST /bioclip/download/start`
+### `POST /v1/models/bioclip/downloads`
 Triggers a background download of the BioCLIP assets.
 
-### `GET /bioclip/download/status`
+### `GET /v1/models/bioclip/downloads`
 Returns the current progress of an ongoing BioCLIP download. Same shape as the
 CLIP and LLM download status; all three share one progress map keyed by asset
 group, so a species download and a GGUF download can be in flight at once.
@@ -441,7 +441,7 @@ repeat so heavily that resolving on demand costs a handful of calls for a whole
 library. Outbound calls are spaced ~1.1 s apart to stay inside iNaturalist's
 published rate limit.
 
-### `GET /species/links`
+### `GET /v1/species/links`
 Query: `name` (scientific name, required), `rank` (`species`, `genus`, … —
 narrows both lookups so a genus query cannot match a same-named species),
 `lang` (two-letter; picks the Wikipedia edition and the iNaturalist
@@ -480,7 +480,7 @@ The plugin calls this from `MetadataManager.applySpecies` and writes
 `speciesWikipediaUrl` catalog fields, which Lightroom renders as clickable
 links in the Metadata panel.
 
-### `POST /species/links/batch`
+### `POST /v1/species/links/batch`
 Same resolution for several taxa in one request. Resolved sequentially — the
 rate gate would serialize concurrent calls anyway.
 
@@ -497,7 +497,7 @@ name, in request order.
 
 The backend hosts two local inference engines: `llamacpp` (in-process llama.cpp, GGUF models, present only in builds compiled with the `llamacpp` cargo feature) and `mlx` (an `lrgenius-mlx` helper process, Apple silicon only, no cargo feature). Both are exposed through the same routes — the MLX half is nested under an `mlx` key so that older plugins reading the top-level fields still see the llama.cpp engine.
 
-### `GET /llm/catalog`
+### `GET /v1/llm/catalog`
 Lists local models that are installed and those offered for download.
 
 ```json
@@ -518,20 +518,20 @@ Lists local models that are installed and those offered for download.
 
 `supported: false` always carries a `reason` for MLX; for llama.cpp it means the binary was built without the `llamacpp` feature.
 
-### `GET /llm/status`
+### `GET /v1/llm/status`
 Engine state (`status`, loaded `model_name`, …) for the llama.cpp engine, with the MLX engine's equivalent nested under `mlx`.
 
-### `POST /llm/download/start`
+### `POST /v1/llm/downloads`
 Starts a background download of a catalog entry. Body: `{ "id": "gemma4-e4b" }`. The id space is shared across both catalogs and the id alone selects the backend, so there is a single download queue: a GGUF pair is fetched as two files, an MLX entry as a repo snapshot staged into a `.part` directory and renamed on success.
 
-### `GET /llm/download/status`
+### `GET /v1/llm/downloads`
 Progress of the current local-model download (same shape as the CLIP download status).
 
 ---
 
 ## Database Operations
 
-### `GET /db/stats`
+### `GET /v1/db/stats`
 Returns aggregate database statistics:
 - total indexed photos
 - photos with SigLIP embeddings
@@ -542,7 +542,7 @@ Returns aggregate database statistics:
 - total detected faces
 - total persons
 
-### `GET /db/backup`
+### `POST /v1/db/backups`
 Creates and streams a ZIP backup of the full persistent LanceDB data directory.
 
 > **Not available:** `POST /db/migrate-photo-ids` existed on the retired Python backend and

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -316,10 +316,23 @@ Imports existing Lightroom catalog metadata (keywords, title, caption, rating, e
 Synchronous keyword clustering: groups catalog keywords by semantic similarity.
 
 ### `POST /v1/keywords/clusters/jobs`
-Async version: starts a background clustering job and returns a `job_id`.
+Async version: starts a background clustering job. Returns `202` with a
+`job_id` and the `poll_url` to read it back from — see `GET /v1/jobs/<job_id>`.
 
-### `GET /v1/keywords/clusters/jobs/<job_id>`
-Polls the status and result of an async clustering job.
+## Async Jobs
+
+Long-running work is enqueued by the domain that knows what to start, and read
+back from one place. Every enqueue response carries a `job_id` and a `poll_url`
+pointing here, so the poll location is never derived from the enqueue path.
+
+### `GET /v1/jobs/<job_id>`
+Returns `{status, result, error, progress}`, where `status` is `running`,
+`done` or `error`.
+
+A finished job is returned **once** and then dropped from the registry, and
+jobs expire after 600s without activity (polling or reporting progress counts
+as activity). A `404` therefore means the job never existed, was already
+collected, or expired — not necessarily that the id was wrong.
 
 ### `POST /v1/keywords/merges`
 Applies a list of approved keyword merge pairs to the backend's metadata records.

--- a/docs/wiki/Dev-Build-Environment-Setup.md
+++ b/docs/wiki/Dev-Build-Environment-Setup.md
@@ -90,7 +90,7 @@ expect a noticeably longer cold build than the baseline.
 ### 3. MLX sidecar
 
 Not applicable — MLX is Apple-silicon only. On Windows, local inference is
-llama.cpp-only; `/llm/catalog` will report `mlx.supported: false`.
+llama.cpp-only; `/v1/llm/catalog` will report `mlx.supported: false`.
 
 ### 4. Pre-commit hooks
 
@@ -157,7 +157,7 @@ xcodebuild build -scheme lrgenius-mlx -destination 'platform=macOS,arch=arm64' \
 export LRG_MLX_SIDECAR=$PWD/.build/xcode/Build/Products/Release/lrgenius-mlx
 ```
 
-Without `LRG_MLX_SIDECAR` set (or the binary built), `/llm/catalog` reports
+Without `LRG_MLX_SIDECAR` set (or the binary built), `/v1/llm/catalog` reports
 `mlx.supported: false` with a reason naming what's missing. The build also
 produces bundles (`mlx-swift_Cmlx.bundle`, tokenizer resource bundles) that
 must ship **next to** the executable — `Bundle.module` resolves them relative

--- a/docs/wiki/Dev-Server-Guide.md
+++ b/docs/wiki/Dev-Server-Guide.md
@@ -26,7 +26,7 @@ If you are experiencing unexpected backend behavior:
 ## Database Backup Workflow
 
 Given the importance of your generated search indexes and AI metadata, the backend exposes a dedicated backup download flow:
-- API endpoint: `GET /db/backup`
+- API endpoint: `GET /v1/db/backups`
 - Output: A comprehensive ZIP archive containing the complete LanceDB data directory.
 
 **To create a backup via Lightroom:**

--- a/docs/wiki/Dev-Server-README.md
+++ b/docs/wiki/Dev-Server-README.md
@@ -40,6 +40,31 @@ cargo build --release -p lrg-server
 `cargo test --workspace` and `cargo clippy --workspace --all-targets` should
 both be clean before sending changes.
 
+### Host and port
+
+The server listens on `127.0.0.1:19819`. Both halves are environment
+variables, which is how the Docker image binds to all interfaces:
+
+| Env var | Default |
+|---|---|
+| `GENIUSAI_HOST` | `127.0.0.1` |
+| `GENIUSAI_PORT` | `19819` |
+
+```bash
+GENIUSAI_PORT=19833 ./target/release/geniusai-server --db-path /path/to/lrgenius.db
+```
+
+An unparseable `GENIUSAI_PORT` falls back to the default rather than refusing
+to start, so a typo costs you the port you asked for, not the server.
+
+Moving the port is mainly useful for running a second instance beside an
+installed one — a dev build cannot share 19819 with the copy the plug-in
+auto-launches. Point the plug-in at it with **Plug-in Manager → Backend server
+URL** (`http://127.0.0.1:19833`); that setting is the only place the plug-in
+learns the address, so nothing else needs changing. Note that
+`SearchIndexAPI.startServer` still launches the *installed* binary on the
+default port, so start a custom-port build yourself.
+
 ### Golden tests and `LRG_REQUIRE_GOLDENS`
 
 The ML golden tests — SigLIP2, BioCLIP 2 and the face pipeline — compare real

--- a/docs/wiki/Dev-Server-README.md
+++ b/docs/wiki/Dev-Server-README.md
@@ -71,7 +71,7 @@ so a machine that has run the plugin's model download needs no extra setup.
 
 The in-process local LLM is behind a cargo feature that is **off by default**.
 Without it the `llamacpp` provider reports that the build has no local-model
-support and `/llm/catalog` returns `supported: false`, so the plugin's "Local AI
+support and `/v1/llm/catalog` returns `supported: false`, so the plugin's "Local AI
 Model" settings have nothing to work with. It is opt-in because it compiles
 llama.cpp from source: that needs `cmake` and `libclang` (for bindgen) and adds
 minutes to a cold build, which nobody working on an unrelated crate should pay.
@@ -123,7 +123,7 @@ xcodebuild build -scheme lrgenius-mlx -destination 'platform=macOS,arch=arm64' \
 export LRG_MLX_SIDECAR=$PWD/.build/xcode/Build/Products/Release/lrgenius-mlx
 ```
 
-Without it, `/llm/catalog` reports `mlx.supported: false` with a reason naming
+Without it, `/v1/llm/catalog` reports `mlx.supported: false` with a reason naming
 what is missing (wrong architecture, or no helper found). The sidecar is
 resolved from `LRG_MLX_SIDECAR`, then from next to the running server, which is
 how the shipped `.pkg` finds it. See
@@ -139,7 +139,7 @@ cargo test -p lrg-mlx --test sidecar_smoke -- --ignored
 
 ### SigLIP2 (semantic embeddings)
 
-`POST /clip/download/start` + `GET /clip/download/status` fetch the fp16
+`POST /v1/models/clip/downloads` + `GET /v1/models/clip/downloads` fetch the fp16
 ONNX assets (`siglip2_image_fp16.onnx`, `siglip2_text_fp16.onnx`,
 `tokenizer.json`) and place them at the `LRG_SIGLIP_*` paths below,
 pulling CI-exported ONNX assets from a release instead of the fp32
@@ -236,7 +236,7 @@ export LRG_BIOCLIP_TAXA_JSON=/path/to/models/bioclip2/bioclip2_taxa.json
 
 Without these, `lrg-ml` falls back to
 `~/.cache/lrgenius/models/bioclip2_{image.onnx,taxa.bin,taxa.json}`, which is
-where `POST /bioclip/download/start` — and `POST /assets/download/start`, which
+where `POST /v1/models/bioclip/downloads` — and `POST /v1/models/assets/downloads`, which
 the plugin actually calls — put them. Note the fallback name for the tower is
 `bioclip2_image.onnx`, without the export script's `_fp16` suffix.
 
@@ -269,7 +269,7 @@ export LRG_FACENET_ONNX=/path/to/face-assets/facenet_vggface2.onnx
 
 Without these, `lrg-ml` falls back to
 `~/.cache/lrgenius/models/{yunet_face_detection.onnx,facenet_vggface2.onnx}`,
-which is where `POST /assets/download/start` puts them. Assets are published
+which is where `POST /v1/models/assets/downloads` puts them. Assets are published
 by `.github/workflows/model-assets-face.yml` to the fixed `face-assets-v1`
 tag, independent of the other two families.
 
@@ -284,11 +284,11 @@ ignored by clustering and re-queued for detection.
 
 Only present in builds compiled with the `llamacpp` cargo feature; without
 it the `llamacpp` provider reports that the build has no local-model
-support and `/llm/catalog` returns `supported: false`.
+support and `/v1/llm/catalog` returns `supported: false`.
 
 Models are GGUF pairs — the weights plus an `mmproj` vision projector,
-which is what lets the model see the photo. `GET /llm/catalog` lists what
-is installed and what can be downloaded; `POST /llm/download/start` fetches
+which is what lets the model see the photo. `GET /v1/llm/catalog` lists what
+is installed and what can be downloaded; `POST /v1/llm/downloads` fetches
 a catalog entry. Discovery looks at, in order: the explicit env overrides,
 `LRG_LLAMA_MODEL_DIR` (default `~/.cache/lrgenius/models/llm/`), and any
 GGUFs already under `~/.lmstudio/models`, so a model you downloaded in LM
@@ -327,8 +327,8 @@ or more safetensors shards, and the tokenizer files. Discovery therefore looks
 for directories that contain a `config.json` *and* at least one `.safetensors`
 (the config alone would match a half-finished download).
 
-`GET /llm/catalog` reports MLX under a nested `mlx` key alongside the GGUF half,
-including `supported`/`reason`, and `POST /llm/download/start` takes an MLX
+`GET /v1/llm/catalog` reports MLX under a nested `mlx` key alongside the GGUF half,
+including `supported`/`reason`, and `POST /v1/llm/downloads` takes an MLX
 catalog id on the same route — the id alone picks the backend, so there is one
 download queue rather than two competing for the network.
 

--- a/docs/wiki/Help-AI-Edit.md
+++ b/docs/wiki/Help-AI-Edit.md
@@ -137,7 +137,7 @@ at, the plugin switches the source to *All Photographs* to reach it.
 Earlier versions offered a second, prompt-driven path: pick a provider and
 model, write a system instruction, choose a look preset, and let a vision LLM
 propose the develop settings. That path is no longer reachable from the plugin.
-The backend still implements it (`POST /edit`), so it can come back, but the AI
+The backend still implements it (`POST /v1/edit/recipe`), so it can come back, but the AI
 Edit dialog no longer configures it and no run reaches an LLM.
 
 Model choice now only affects [Analyze & Index](Help-Analyze-and-Index) —

--- a/docs/wiki/Help-Advanced-Search.md
+++ b/docs/wiki/Help-Advanced-Search.md
@@ -18,7 +18,7 @@ there. The dialog says so before you type: if the search model is not
 downloaded, or some of the catalog has no search index yet, an orange note at
 the top gives the count and what to run to fix it.
 
-The check is two cheap lookups (`/db/stats` plus the catalog's photo count) and
+The check is two cheap lookups (`/v1/db/stats` plus the catalog's photo count) and
 runs every time the dialog opens. It is a note, not a gate — the search still
 runs across whatever *is* indexed.
 

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -23,66 +23,99 @@ function SearchIndexAPI.isLocalBackend()
 	return url:match("^https?://127%.0%.0%.1:") or url:match("^https?://localhost:")
 end
 
+-- Backend paths, grouped by domain. Everything lives under `/v1` except the
+-- five-path bootstrap contract below, which is deliberately unversioned: a
+-- plug-in that updates ahead of its backend still has to reach `/ping`,
+-- `/version`, `/version/check` and `/shutdown` on the *old* binary, and post to
+-- `/update/apply` there, to pull the install forward. Version those and a
+-- half-updated machine could not repair itself.
+--
+-- Build request URLs with `SearchIndexAPI.url(KEY, ...)` rather than
+-- concatenating -- it URL-encodes any id segments you pass.
 local ENDPOINTS = {
-	INDEX = "/index",
-	EDIT = "/edit",
-	INDEX_BY_REFERENCE = "/index_by_reference",
-	EDIT_BASE64 = "/edit_base64",
-	GROUP_SIMILAR = "/group_similar",
-	CULL = "/cull",
-	FIND_SIMILAR = "/find_similar",
-	SEARCH = "/search",
-	STATS = "/db/stats",
-	MODELS = "/models",
-	GET_IDS = "/get/ids",
-	REMOVE = "/remove",
-	REMOVE_METADATA = "/remove/metadata",
+	-- Unversioned bootstrap contract. Do not move these.
 	PING = "/ping",
 	VERSION = "/version",
 	VERSION_CHECK = "/version/check",
 	SHUTDOWN = "/shutdown",
-	UNLOAD = "/unload",
-	IMPORT_METADATA = "/import/metadata",
-	START_CLIP_DOWNLOAD = "/clip/download/start",
-	STATUS_CLIP_DOWNLOAD = "/clip/download/status",
-	CLIP_STATUS = "/clip/status",
-	START_BIOCLIP_DOWNLOAD = "/bioclip/download/start",
-	STATUS_BIOCLIP_DOWNLOAD = "/bioclip/download/status",
-	BIOCLIP_STATUS = "/bioclip/status",
-	SPECIES_LINKS = "/species/links",
-	ASSETS_STATUS = "/assets/status",
-	START_ASSETS_DOWNLOAD = "/assets/download/start",
-	STATUS_ASSETS_DOWNLOAD = "/assets/download/status",
-	LLM_CATALOG = "/llm/catalog",
-	LLM_STATUS = "/llm/status",
-	START_LLM_DOWNLOAD = "/llm/download/start",
-	STATUS_LLM_DOWNLOAD = "/llm/download/status",
-	CHECK_UNPROCESSED = "/index/check-unprocessed",
-	FACES_CLUSTER = "/faces/cluster",
-	FACES_PERSONS = "/faces/persons",
-	FACES_PERSON_PHOTOS = "/faces/persons", -- suffix /<id>/photos
-	FACES_DETECT = "/faces/detect",
-	FACES_QUERY = "/faces/query",
-	DB_BACKUP = "/db/backup",
-	SYNC_CLEANUP = "/sync/cleanup",
-	SYNC_CLAIM = "/sync/claim",
-	TRAINING_ADD = "/training/add",
-	TRAINING_LIST = "/training/list",
-	TRAINING_COUNT = "/training/count",
-	TRAINING_DELETE = "/training", -- DELETE /training/<photo_id>
-	TRAINING_CLEAR = "/training", -- DELETE /training (all)
-	TRAINING_STATS = "/training/stats",
-	STYLE_EDIT = "/style_edit",
-	KEYWORDS_CLUSTER = "/keywords/cluster",
-	KEYWORDS_CLUSTER_START = "/keywords/cluster/start",
-	KEYWORDS_CLUSTER_STATUS = "/keywords/cluster/status",
-	KEYWORDS_APPLY_MERGES = "/keywords/apply-merges",
-	LOGS = "/logs",
-	LOGS_RAW = "/logs/raw",
-	INITIALIZE = "/initialize",
-	RESTART = "/restart",
-	HEALTH = "/health",
 	UPDATE_APPLY = "/update/apply",
+
+	-- Server lifecycle and introspection
+	UNLOAD = "/v1/server/unload",
+	RESTART = "/v1/server/restart",
+	HEALTH = "/v1/server/health",
+	LOGS = "/v1/server/logs",
+	LOGS_RAW = "/v1/server/logs", -- suffix /<log_type>/raw
+	INITIALIZE = "/v1/db/bind",
+
+	-- Database
+	STATS = "/v1/db/stats",
+	DB_BACKUP = "/v1/db/backups",
+
+	-- Stored photo records
+	GET_PHOTO_DATA = "/v1/photos/lookup",
+	GET_IDS = "/v1/photos/ids",
+	REMOVE = "/v1/photos/remove",
+	REMOVE_METADATA = "/v1/photos/metadata/remove",
+	IMPORT_METADATA = "/v1/photos/metadata/import",
+	SYNC_CLAIM = "/v1/photos/catalogs/claim",
+	SYNC_CLEANUP = "/v1/photos/catalogs/cleanup",
+
+	-- Indexing pipeline
+	INDEX = "/v1/index/photos",
+	INDEX_BY_REFERENCE = "/v1/index/photos/by-path",
+	CHECK_UNPROCESSED = "/v1/index/unprocessed",
+
+	-- Search and culling
+	SEARCH = "/v1/search",
+	FIND_SIMILAR = "/v1/search/similar",
+	GROUP_SIMILAR = "/v1/cull/groups",
+	CULL = "/v1/cull/grade",
+
+	-- Faces and persons
+	FACES_DETECT = "/v1/faces/detect",
+	FACES_QUERY = "/v1/faces/search",
+	FACES_CLUSTER = "/v1/faces/cluster",
+	FACES_PERSONS = "/v1/faces/persons",
+	FACES_PERSON_PHOTOS = "/v1/faces/persons", -- suffix /<id>/photos
+
+	-- AI develop edits and the style-training corpus
+	EDIT = "/v1/edit/recipe",
+	EDIT_BASE64 = "/v1/edit/recipe/base64",
+	STYLE_EDIT = "/v1/edit/style",
+	TRAINING_ADD = "/v1/edit/training",
+	TRAINING_LIST = "/v1/edit/training",
+	TRAINING_CLEAR = "/v1/edit/training", -- DELETE /v1/edit/training (all)
+	TRAINING_DELETE = "/v1/edit/training", -- suffix /<photo_id>
+	TRAINING_STATS = "/v1/edit/training/stats",
+	TRAINING_COUNT = "/v1/edit/training/count",
+
+	-- Keyword clustering
+	KEYWORDS_CLUSTER = "/v1/keywords/clusters",
+	KEYWORDS_CLUSTER_START = "/v1/keywords/clusters/jobs",
+	KEYWORDS_CLUSTER_STATUS = "/v1/keywords/clusters/jobs", -- suffix /<job_id>
+	KEYWORDS_APPLY_MERGES = "/v1/keywords/merges",
+
+	-- Local ML model assets
+	CLIP_STATUS = "/v1/models/clip",
+	START_CLIP_DOWNLOAD = "/v1/models/clip/downloads",
+	STATUS_CLIP_DOWNLOAD = "/v1/models/clip/downloads",
+	BIOCLIP_STATUS = "/v1/models/bioclip",
+	START_BIOCLIP_DOWNLOAD = "/v1/models/bioclip/downloads",
+	STATUS_BIOCLIP_DOWNLOAD = "/v1/models/bioclip/downloads",
+	ASSETS_STATUS = "/v1/models/assets",
+	START_ASSETS_DOWNLOAD = "/v1/models/assets/downloads",
+	STATUS_ASSETS_DOWNLOAD = "/v1/models/assets/downloads",
+
+	-- LLM providers and the local engine
+	MODELS = "/v1/llm/providers/models",
+	LLM_CATALOG = "/v1/llm/catalog",
+	LLM_STATUS = "/v1/llm/status",
+	START_LLM_DOWNLOAD = "/v1/llm/downloads",
+	STATUS_LLM_DOWNLOAD = "/v1/llm/downloads",
+
+	-- Species links
+	SPECIES_LINKS = "/v1/species/links",
 }
 
 local EXPORT_SETTINGS = {
@@ -106,6 +139,28 @@ local EXPORT_SETTINGS = {
 local _request
 local _requestMultipart
 local _urlEncode
+
+--- Builds an absolute backend URL for an `ENDPOINTS` key.
+---
+--- Extra arguments are appended as path segments and URL-encoded, so ids that
+--- contain slashes, spaces or `#` survive the trip. `photo_id` in particular is
+--- a file path on the training routes, which is exactly why hand-concatenating
+--- these was wrong.
+---
+--- @param key string a key of `ENDPOINTS`
+--- @param ... string|number path segments to append
+--- @return string
+function SearchIndexAPI.url(key, ...)
+	local path = ENDPOINTS[key]
+	if path == nil then
+		error("SearchIndexAPI.url: unknown endpoint key " .. tostring(key), 2)
+	end
+	local url = getBaseUrl() .. path
+	for _, segment in ipairs({ ... }) do
+		url = url .. "/" .. _urlEncode(tostring(segment))
+	end
+	return url
+end
 
 -- Returns a string safe for logging; never passes a table to tostring (avoids "table: 0x...").
 local function httpStatusForLog(status, hdrs)
@@ -663,7 +718,7 @@ end
 -- Analyzes and indexes a single photo by submitting only its file path; the
 -- backend reads and converts the original file (RAW/JPEG/HEIC) itself.
 -- Only valid when the backend runs on the same machine (see isLocalBackend).
--- Uses the /index_by_reference endpoint; same options as analyzeAndIndexPhoto.
+-- Uses the /v1/index/photos/by-path endpoint; same options as analyzeAndIndexPhoto.
 -- @param photoId string
 -- @param filePath string Absolute path to the original photo file.
 -- @param options table Same as analyzeAndIndexPhoto.
@@ -680,7 +735,7 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 	end
 
 	options = options or {}
-	local url = getBaseUrl() .. ENDPOINTS.INDEX_BY_REFERENCE
+	local url = SearchIndexAPI.url("INDEX_BY_REFERENCE")
 
 	local body = {
 		images = {
@@ -766,7 +821,7 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 end
 
 ---
--- Analyzes and indexes several photos in one /index_by_reference request.
+-- Analyzes and indexes several photos in one /v1/index/photos/by-path request.
 --
 -- Worthwhile in two cases, both decided by Util.groupedBatchSize: a run that
 -- generates no AI metadata (the server reads, decodes and measures the group
@@ -875,7 +930,7 @@ function SearchIndexAPI.analyzeAndIndexPhotosByReference(entries, options)
 	-- had died. The floor keeps a small group from timing out on a cold start.
 	local perPhoto = llmRun and 720 or 60
 	local timeout = math.max(300, perPhoto * #images)
-	local response, err = _request("POST", getBaseUrl() .. ENDPOINTS.INDEX_BY_REFERENCE, body, timeout)
+	local response, err = _request("POST", SearchIndexAPI.url("INDEX_BY_REFERENCE"), body, timeout)
 
 	if not response then
 		log:error("Failed to analyze/index photo group (by reference): " .. tostring(err))
@@ -921,7 +976,7 @@ end
 -- @return boolean success, table|string response - Returns success status and response data or error message
 --
 -- No task calls this any more: AI Edit runs on the style engine
--- (`SearchIndexAPI.styleEdit`) alone. `/edit` and `/edit_base64` are still
+-- (`SearchIndexAPI.styleEdit`) alone. `/v1/edit/recipe` and `/v1/edit/recipe/base64` are still
 -- served by the backend, so this wrapper stays as the way back to the
 -- prompt-driven LLM edit rather than being deleted with it.
 ---
@@ -994,7 +1049,7 @@ function SearchIndexAPI.condenseMessages(messages)
 end
 
 ---
--- Interprets an /edit response into the (ok, valueOrError) pair the callers use.
+-- Interprets an /v1/edit/recipe response into the (ok, valueOrError) pair the callers use.
 --
 -- Extracted from generateEditRecipePhoto so it can be unit tested: the
 -- surrounding function builds a multipart body and does HTTP, but every bug
@@ -1017,7 +1072,7 @@ function SearchIndexAPI.interpretEditResponse(response, err)
 				.. " value="
 				.. tostring(response)
 		)
-		return false, "Invalid response type from /edit endpoint: " .. tostring(type(response))
+		return false, "Invalid response type from /v1/edit/recipe endpoint: " .. tostring(type(response))
 	end
 	if response.status == "success" then
 		return true, response
@@ -1027,7 +1082,7 @@ function SearchIndexAPI.interpretEditResponse(response, err)
 end
 
 ---
--- Interprets an /index response for a single photo.
+-- Interprets an /v1/index/photos response for a single photo.
 --
 -- Extracted from analyzeAndIndexPhoto for the same reason as
 -- interpretEditResponse. Returns the whole response on success so the caller
@@ -1045,7 +1100,7 @@ function SearchIndexAPI.interpretIndexResponse(response, err, filename)
 	end
 	if type(response) ~= "table" then
 		log:error("Index response has unexpected type: " .. tostring(type(response)))
-		return false, "Invalid response type from /index endpoint: " .. tostring(type(response))
+		return false, "Invalid response type from /v1/index/photos endpoint: " .. tostring(type(response))
 	end
 
 	if response.status == "processed" then
@@ -1078,7 +1133,7 @@ function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 
 	local filename = LrPathUtils.leafName(filepath)
 	options = options or {}
-	local url = getBaseUrl() .. ENDPOINTS.EDIT
+	local url = SearchIndexAPI.url("EDIT")
 	local mimeChunks = {}
 
 	table.insert(mimeChunks, { name = "photo_id", value = photoId })
@@ -1197,7 +1252,7 @@ function SearchIndexAPI.analyzeAndIndexPhoto(photoId, filepath, options)
 
 	options = options or {}
 
-	local url = getBaseUrl() .. ENDPOINTS.INDEX
+	local url = SearchIndexAPI.url("INDEX")
 
 	-- Prepare multipart content chunks
 	local mimeChunks = {}
@@ -1358,7 +1413,7 @@ function SearchIndexAPI.searchIndex(searchTerm, photosToSearch, searchOptions)
 		params.catalog_id = cid
 	end
 
-	local url = getBaseUrl() .. ENDPOINTS.SEARCH
+	local url = SearchIndexAPI.url("SEARCH")
 
 	-- Build search_sources for API (snake_case). If searchOptions is nil, backend uses defaults.
 	local search_sources = nil
@@ -1430,7 +1485,7 @@ end
 
 function SearchIndexAPI.getStats()
 	local cid = getCatalogId()
-	local url = getBaseUrl() .. ENDPOINTS.STATS
+	local url = SearchIndexAPI.url("STATS")
 	if cid then
 		url = url .. (url:find("?") and "&" or "?") .. "catalog_id=" .. cid
 	end
@@ -1438,7 +1493,7 @@ function SearchIndexAPI.getStats()
 end
 
 function SearchIndexAPI.getBackendVersion()
-	return _request("GET", getBaseUrl() .. ENDPOINTS.VERSION)
+	return _request("GET", SearchIndexAPI.url("VERSION"))
 end
 
 function SearchIndexAPI.checkVersionCompatibility()
@@ -1449,7 +1504,7 @@ function SearchIndexAPI.checkVersionCompatibility()
 		plugin_release_tag = pluginReleaseTag,
 		plugin_build = tonumber(Info.BUILD) or 0,
 	}
-	return _request("POST", getBaseUrl() .. ENDPOINTS.VERSION_CHECK, body)
+	return _request("POST", SearchIndexAPI.url("VERSION_CHECK"), body)
 end
 
 function SearchIndexAPI.ensureVersionCompatibility()
@@ -1502,7 +1557,7 @@ function SearchIndexAPI.formatStats(stats)
 end
 
 function SearchIndexAPI.getAllIndexedPhotoIds(requireEmbeddings)
-	local url = getBaseUrl() .. ENDPOINTS.GET_IDS
+	local url = SearchIndexAPI.url("GET_IDS")
 	local params = {}
 	if requireEmbeddings then
 		params.has_embedding = "true"
@@ -1542,7 +1597,7 @@ function SearchIndexAPI.getPhotoData(photoId)
 		return nil
 	end
 
-	local url = getBaseUrl() .. "/get"
+	local url = SearchIndexAPI.url("GET_PHOTO_DATA")
 	local body = { photo_id = photoId }
 	local cid = getCatalogId()
 	if cid then
@@ -1584,7 +1639,7 @@ function SearchIndexAPI.groupSimilarPhotos(photoIds, options)
 		culling_preset = options.culling_preset or "default",
 	}
 
-	local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.GROUP_SIMILAR, body, 300)
+	local result, err = _request("POST", SearchIndexAPI.url("GROUP_SIMILAR"), body, 300)
 	if err then
 		log:error("groupSimilarPhotos failed: " .. tostring(err))
 		return nil, err
@@ -1644,7 +1699,7 @@ function SearchIndexAPI.cullPhotos(photoIds, options)
 		body.semantic_weight = options.semantic_weight
 	end
 
-	local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.CULL, body, 300)
+	local result, err = _request("POST", SearchIndexAPI.url("CULL"), body, 300)
 	if err then
 		log:error("cullPhotos failed: " .. tostring(err))
 		return nil, err
@@ -1672,7 +1727,7 @@ function SearchIndexAPI.checkUnprocessedPhotoIds(photoIds, tasks)
 		regenerate_metadata = false,
 	}
 
-	local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.CHECK_UNPROCESSED, body, 120)
+	local result, err = _request("POST", SearchIndexAPI.url("CHECK_UNPROCESSED"), body, 120)
 	if err then
 		log:error("checkUnprocessedPhotoIds failed: " .. tostring(err))
 		return nil, err
@@ -1712,7 +1767,7 @@ function SearchIndexAPI.findSimilarImages(photoId, options)
 		body.phash_max_hamming,
 		body.scope_photo_ids and (#body.scope_photo_ids .. " ids") or "all"
 	)
-	local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.FIND_SIMILAR, body, 120)
+	local result, err = _request("POST", SearchIndexAPI.url("FIND_SIMILAR"), body, 120)
 	if err then
 		log:error("findSimilarImages failed: " .. tostring(err))
 		return nil, err
@@ -1723,7 +1778,7 @@ function SearchIndexAPI.findSimilarImages(photoId, options)
 end
 
 function SearchIndexAPI.removePhotoId(photoId)
-	local url = getBaseUrl() .. ENDPOINTS.REMOVE
+	local url = SearchIndexAPI.url("REMOVE")
 	local body = { photo_id = photoId }
 	log:trace("Removing photo_id: " .. photoId)
 
@@ -1743,7 +1798,7 @@ end
 --- Remove only AI-generated metadata for a photo (keeps embeddings so the photo stays in the index).
 --- Use when the user discards a suggestion in the review dialog so they can regenerate later.
 function SearchIndexAPI.removePhotoMetadata(photoId)
-	local url = getBaseUrl() .. ENDPOINTS.REMOVE_METADATA
+	local url = SearchIndexAPI.url("REMOVE_METADATA")
 	local body = { photo_id = photoId }
 	log:trace("Removing metadata for photo_id: " .. photoId)
 
@@ -1814,7 +1869,7 @@ function SearchIndexAPI.syncCleanup()
 		for j = startIdx, stopIdx do
 			batch[#batch + 1] = photoIds[j]
 		end
-		local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.SYNC_CLEANUP, {
+		local result, err = _request("POST", SearchIndexAPI.url("SYNC_CLEANUP"), {
 			catalog_id = catalogId,
 			photo_ids = batch,
 		}, 120)
@@ -1922,7 +1977,7 @@ function SearchIndexAPI.claimPhotosForCatalog(progressScope)
 		for j = startIdx, stopIdx do
 			batch[#batch + 1] = photoIds[j]
 		end
-		local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.SYNC_CLAIM, {
+		local result, err = _request("POST", SearchIndexAPI.url("SYNC_CLAIM"), {
 			catalog_id = catalogId,
 			photo_ids = batch,
 		}, 120)
@@ -2583,7 +2638,7 @@ function SearchIndexAPI.importMetadataFromCatalog(photosToProcess, progressScope
 				if importCid then
 					importBody.catalog_id = importCid
 				end
-				local response = _request("POST", getBaseUrl() .. ENDPOINTS.IMPORT_METADATA, importBody)
+				local response = _request("POST", SearchIndexAPI.url("IMPORT_METADATA"), importBody)
 				if response ~= nil and response.status == "processed" then
 					stats.success = stats.success + #metadataBatch
 				else
@@ -2631,7 +2686,7 @@ function SearchIndexAPI.importMetadataFromCatalog(photosToProcess, progressScope
 end
 
 function SearchIndexAPI.pingServer()
-	local url = getBaseUrl() .. "/ping"
+	local url = SearchIndexAPI.url("PING")
 	local result, hdrs = LrHttp.get(url)
 	local status = (type(hdrs) == "number") and hdrs or (type(hdrs) == "table" and hdrs.status) or nil
 	if status == 200 and result == "pong" then
@@ -2647,7 +2702,7 @@ function SearchIndexAPI.isBackendOnLocalhost()
 end
 
 function SearchIndexAPI.downloadDatabaseBackup()
-	local url = getBaseUrl() .. ENDPOINTS.DB_BACKUP
+	local url = SearchIndexAPI.url("DB_BACKUP")
 	log:info("downloadDatabaseBackup: start, url=" .. tostring(url))
 	local outputPath = LrDialogs.runSavePanel({
 		title = "Save database backup",
@@ -2902,7 +2957,7 @@ function SearchIndexAPI.shutdownServer(opts)
 		return true
 	end
 
-	local url = getBaseUrl() .. ENDPOINTS.SHUTDOWN
+	local url = SearchIndexAPI.url("SHUTDOWN")
 	log:trace("Requesting graceful backend shutdown")
 
 	-- /shutdown returns JSON, so we can go through _request() decoding.
@@ -2924,7 +2979,7 @@ function SearchIndexAPI.shutdownServer(opts)
 end
 
 function SearchIndexAPI.unloadResources()
-	local url = getBaseUrl() .. ENDPOINTS.UNLOAD
+	local url = SearchIndexAPI.url("UNLOAD")
 	log:trace("Requesting backend model unload")
 	local status, response = LrTasks.pcall(function()
 		return _request("POST", url, {}, 10) -- 10s timeout
@@ -2939,7 +2994,7 @@ function SearchIndexAPI.unloadResources()
 end
 
 function SearchIndexAPI.restartBackend()
-	local url = getBaseUrl() .. ENDPOINTS.RESTART
+	local url = SearchIndexAPI.url("RESTART")
 	log:info("Requesting backend restart via API")
 	local _, err = _request("POST", url, {}, 5)
 	if err then
@@ -2972,7 +3027,7 @@ function SearchIndexAPI.initializeCatalog(dbPath)
 		dbPath = getDbPath()
 	end
 
-	local url = getBaseUrl() .. ENDPOINTS.INITIALIZE
+	local url = SearchIndexAPI.url("INITIALIZE")
 	log:info("Initializing catalog database at backend: " .. tostring(dbPath))
 	local response, err = _request("POST", url, { db_path = dbPath }, 10)
 
@@ -3265,7 +3320,7 @@ _request = function(method, url, body, timeout, options)
 	-- Auto-inject db_path so the backend can transparently re-bind after a
 	-- crash/restart that wiped its in-memory DB_PATH. Only for local backends
 	-- (a remote backend manages its own db_path via argv/env). Skip if the
-	-- caller already supplied db_path (e.g. /initialize itself).
+	-- caller already supplied db_path (e.g. /v1/db/bind itself).
 	if SearchIndexAPI.isLocalBackend() then
 		local dbPath = getDbPath()
 		if dbPath then
@@ -3467,7 +3522,7 @@ function SearchIndexAPI.getMissingPhotosFromIndex(taskOptions, lookupProgressSco
 		if checkCid then
 			body.catalog_id = checkCid
 		end
-		local result, err = _request("POST", getBaseUrl() .. ENDPOINTS.CHECK_UNPROCESSED, body)
+		local result, err = _request("POST", SearchIndexAPI.url("CHECK_UNPROCESSED"), body)
 		if err then
 			ErrorHandler.handleError("Failed to check unprocessed photos", err)
 			return false, {}
@@ -3579,7 +3634,7 @@ function SearchIndexAPI.clusterKeywords(keywordNames, threshold, options, cancel
 	end
 
 	-- Start async job
-	local startUrl = getBaseUrl() .. ENDPOINTS.KEYWORDS_CLUSTER_START
+	local startUrl = SearchIndexAPI.url("KEYWORDS_CLUSTER_START")
 	local startResp, startErr = _request("POST", startUrl, body, 30)
 	if startErr or not startResp or not startResp.job_id then
 		log:error("clusterKeywords: failed to start async job: " .. tostring(startErr))
@@ -3589,7 +3644,7 @@ function SearchIndexAPI.clusterKeywords(keywordNames, threshold, options, cancel
 	-- Poll until done. Every poll reports back to the caller so the UI keeps
 	-- moving even while a single LLM round-trip runs for minutes.
 	local jobId = startResp.job_id
-	local statusUrl = getBaseUrl() .. ENDPOINTS.KEYWORDS_CLUSTER_STATUS .. "/" .. jobId
+	local statusUrl = SearchIndexAPI.url("KEYWORDS_CLUSTER_STATUS", jobId)
 	local startedAt = LrDate.currentTime()
 	local lastStageAt = startedAt
 	local lastStageKey = nil
@@ -3679,7 +3734,7 @@ function SearchIndexAPI.applyKeywordMerges(pairs)
 	for _, pair in ipairs(pairs) do
 		table.insert(merges, { duplicate = pair.duplicateName, canonical = pair.canonicalName })
 	end
-	local url = getBaseUrl() .. ENDPOINTS.KEYWORDS_APPLY_MERGES
+	local url = SearchIndexAPI.url("KEYWORDS_APPLY_MERGES")
 	local result, err = _request("POST", url, { merges = merges }, 60)
 	if err then
 		log:error("applyKeywordMerges failed: " .. tostring(err))
@@ -3692,7 +3747,7 @@ end
 -- @param distanceThreshold number Optional cosine distance; default 0.5. Use 0.45 if over-merge; 0.55-0.65 if same person split.
 -- @return table|nil { status, person_count, face_count, updated } or nil, err
 function SearchIndexAPI.clusterFaces(distanceThreshold)
-	local url = getBaseUrl() .. ENDPOINTS.FACES_CLUSTER
+	local url = SearchIndexAPI.url("FACES_CLUSTER")
 	local body = {}
 	if distanceThreshold and type(distanceThreshold) == "number" then
 		body.distance_threshold = distanceThreshold
@@ -3709,7 +3764,7 @@ end
 -- Get list of all persons (face clusters) with name, face_count, photo_count (no thumbnails).
 -- @return table|nil { status, persons = { { person_id, name, face_count, photo_count }, ... } } or nil, err
 function SearchIndexAPI.getPersons()
-	local url = getBaseUrl() .. ENDPOINTS.FACES_PERSONS
+	local url = SearchIndexAPI.url("FACES_PERSONS")
 	local result, err = _request("GET", url)
 	if err then
 		log:error("getPersons failed: " .. err)
@@ -3725,7 +3780,7 @@ function SearchIndexAPI.getPersonThumbnail(personId)
 	if not personId or personId == "" then
 		return nil, "person_id required"
 	end
-	local url = getBaseUrl() .. ENDPOINTS.FACES_PERSON_PHOTOS .. "/" .. personId .. "/thumbnail"
+	local url = SearchIndexAPI.url("FACES_PERSON_PHOTOS", personId, "thumbnail")
 	local result, err = _request("GET", url)
 	if err then
 		log:error("getPersonThumbnail failed: " .. err)
@@ -3743,7 +3798,7 @@ function SearchIndexAPI.setPersonName(personId, name)
 	if not personId or personId == "" then
 		return false, "person_id required"
 	end
-	local url = getBaseUrl() .. ENDPOINTS.FACES_PERSON_PHOTOS .. "/" .. personId
+	local url = SearchIndexAPI.url("FACES_PERSON_PHOTOS", personId)
 	local _, err = _request("PUT", url, { name = name or "" })
 	if err then
 		log:error("setPersonName failed: " .. err)
@@ -3760,7 +3815,7 @@ function SearchIndexAPI.getPhotosForPerson(personId)
 	if not personId or personId == "" then
 		return nil, "person_id required"
 	end
-	local url = getBaseUrl() .. ENDPOINTS.FACES_PERSON_PHOTOS .. "/" .. personId .. "/photos"
+	local url = SearchIndexAPI.url("FACES_PERSON_PHOTOS", personId, "photos")
 	local result, err = _request("GET", url, {})
 	if err then
 		log:error("getPhotosForPerson failed: " .. err)
@@ -3777,7 +3832,7 @@ function SearchIndexAPI.detectFacesInImage(imageBase64)
 	if not imageBase64 or imageBase64 == "" then
 		return nil, "image (base64) required"
 	end
-	local url = getBaseUrl() .. ENDPOINTS.FACES_DETECT
+	local url = SearchIndexAPI.url("FACES_DETECT")
 	local result, err = _request("POST", url, { image = imageBase64 })
 	if err then
 		log:error("detectFacesInImage failed: " .. err)
@@ -3796,7 +3851,7 @@ function SearchIndexAPI.queryFacesByImage(imageBase64, faceIndex, nResults)
 	if not imageBase64 or imageBase64 == "" then
 		return nil, "image (base64) required"
 	end
-	local url = getBaseUrl() .. ENDPOINTS.FACES_QUERY
+	local url = SearchIndexAPI.url("FACES_QUERY")
 	local body = { image = imageBase64 }
 	if faceIndex ~= nil and type(faceIndex) == "number" then
 		body.face_index = faceIndex
@@ -3833,7 +3888,7 @@ end
 -- @param geminiApiKey string|nil Gemini API key for listing Gemini models
 -- @return table|nil Response from server with format: { models = { qwen = {...}, ollama = {...}, ... } }
 function SearchIndexAPI.getModels(openaiApiKey, geminiApiKey)
-	local url = getBaseUrl() .. ENDPOINTS.MODELS
+	local url = SearchIndexAPI.url("MODELS")
 	local body = {
 		openai_apikey = openaiApiKey,
 		gemini_apikey = geminiApiKey,
@@ -3855,7 +3910,7 @@ function SearchIndexAPI.downloadRawLog(logType, targetPath)
 		return false
 	end
 
-	local url = getBaseUrl() .. ENDPOINTS.LOGS_RAW .. "/" .. tostring(logType)
+	local url = SearchIndexAPI.url("LOGS_RAW", logType, "raw")
 	log:trace("Downloading raw " .. logType .. " log from: " .. url)
 
 	local ok, res, hdrs = LrTasks.pcall(function()
@@ -3898,7 +3953,7 @@ function SearchIndexAPI.startClipDownload()
 		return
 	end
 
-	local status, err = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_CLIP_DOWNLOAD)
+	local status, err = _request("GET", SearchIndexAPI.url("STATUS_CLIP_DOWNLOAD"))
 	if not err and status ~= nil and status.status == "downloading" then
 		log:trace("CLIP model download is already in progress")
 		return
@@ -3909,7 +3964,7 @@ function SearchIndexAPI.startClipDownload()
 		functionContext = nil,
 	})
 
-	local url = getBaseUrl() .. ENDPOINTS.START_CLIP_DOWNLOAD
+	local url = SearchIndexAPI.url("START_CLIP_DOWNLOAD")
 	local body = {}
 
 	local _, postErr = _request("POST", url, body)
@@ -3921,7 +3976,7 @@ function SearchIndexAPI.startClipDownload()
 
 	LrTasks.startAsyncTask(function()
 		while true do
-			local loopStatus, loopErr = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_CLIP_DOWNLOAD)
+			local loopStatus, loopErr = _request("GET", SearchIndexAPI.url("STATUS_CLIP_DOWNLOAD"))
 			if loopErr then
 				ErrorHandler.handleError("Error downloading CLIP model", loopErr)
 				if progressScope ~= nil then
@@ -3986,7 +4041,7 @@ end
 -- @return string|nil error
 --
 function SearchIndexAPI.getAssetStatus()
-	local res, err = _request("GET", getBaseUrl() .. ENDPOINTS.ASSETS_STATUS)
+	local res, err = _request("GET", SearchIndexAPI.url("ASSETS_STATUS"))
 	if err then
 		log:error("getAssetStatus failed: " .. tostring(err))
 		return nil, err
@@ -4008,7 +4063,7 @@ function SearchIndexAPI.startAssetDownload()
 		return
 	end
 
-	local running, runErr = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_ASSETS_DOWNLOAD)
+	local running, runErr = _request("GET", SearchIndexAPI.url("STATUS_ASSETS_DOWNLOAD"))
 	if not runErr and running ~= nil and running.status == "downloading" then
 		log:trace("Combined model download is already in progress")
 		return
@@ -4019,7 +4074,7 @@ function SearchIndexAPI.startAssetDownload()
 		functionContext = nil,
 	})
 
-	local _, postErr = _request("POST", getBaseUrl() .. ENDPOINTS.START_ASSETS_DOWNLOAD, {})
+	local _, postErr = _request("POST", SearchIndexAPI.url("START_ASSETS_DOWNLOAD"), {})
 	if postErr then
 		log:error("startAssetDownload failed: " .. postErr)
 		progressScope:done()
@@ -4028,7 +4083,7 @@ function SearchIndexAPI.startAssetDownload()
 
 	LrTasks.startAsyncTask(function()
 		while true do
-			local loopStatus, loopErr = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_ASSETS_DOWNLOAD)
+			local loopStatus, loopErr = _request("GET", SearchIndexAPI.url("STATUS_ASSETS_DOWNLOAD"))
 			if loopErr then
 				ErrorHandler.handleError("Error downloading AI models", loopErr)
 				progressScope:done()
@@ -4082,7 +4137,7 @@ end
 ---
 -- Preflight gate: stop a run that is about to lose a signal it was asked for.
 --
--- /assets/status already knew the models were missing, but nothing consulted
+-- /v1/models/assets already knew the models were missing, but nothing consulted
 -- it when a run started, so the first sign of trouble was a warning after the
 -- indexing time had already been spent. This asks before, while the answer is
 -- still cheap.
@@ -4103,7 +4158,7 @@ function SearchIndexAPI.confirmModelsReadyForTasks(tasks)
 
 	local status, err = SearchIndexAPI.getAssetStatus()
 	if not status or type(status.families) ~= "table" then
-		log:warn("Model readiness preflight skipped: " .. tostring(err or "no families in /assets/status"))
+		log:warn("Model readiness preflight skipped: " .. tostring(err or "no families in /v1/models/assets"))
 		return true
 	end
 
@@ -4168,7 +4223,7 @@ local lastBioclipReadyStatus = nil
 -- @return string|nil message
 --
 function SearchIndexAPI.isBioclipReady()
-	local url = getBaseUrl() .. ENDPOINTS.BIOCLIP_STATUS
+	local url = SearchIndexAPI.url("BIOCLIP_STATUS")
 	local res, err = _request("GET", url)
 	if err then
 		local errStr = (type(err) == "string") and err or "unknown"
@@ -4215,7 +4270,7 @@ function SearchIndexAPI.getSpeciesLinks(name, rank, lang)
 	if type(lang) == "string" and lang ~= "" then
 		params.lang = _urlEncode(lang)
 	end
-	local url = buildUrlWithParams(getBaseUrl() .. ENDPOINTS.SPECIES_LINKS, params)
+	local url = buildUrlWithParams(SearchIndexAPI.url("SPECIES_LINKS"), params)
 	local res, err = _request("GET", url, nil, 20)
 	if err then
 		local errStr = (type(err) == "string") and err or "unknown"
@@ -4242,7 +4297,7 @@ function SearchIndexAPI.startBioclipDownload()
 		return
 	end
 
-	local status, err = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_BIOCLIP_DOWNLOAD)
+	local status, err = _request("GET", SearchIndexAPI.url("STATUS_BIOCLIP_DOWNLOAD"))
 	if not err and status ~= nil and status.status == "downloading" then
 		log:trace("BioCLIP model download is already in progress")
 		return
@@ -4253,7 +4308,7 @@ function SearchIndexAPI.startBioclipDownload()
 		functionContext = nil,
 	})
 
-	local _, postErr = _request("POST", getBaseUrl() .. ENDPOINTS.START_BIOCLIP_DOWNLOAD, {})
+	local _, postErr = _request("POST", SearchIndexAPI.url("START_BIOCLIP_DOWNLOAD"), {})
 	if postErr then
 		log:error("startBioclipDownload failed: " .. postErr)
 		progressScope:done()
@@ -4262,7 +4317,7 @@ function SearchIndexAPI.startBioclipDownload()
 
 	LrTasks.startAsyncTask(function()
 		while true do
-			local loopStatus, loopErr = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_BIOCLIP_DOWNLOAD)
+			local loopStatus, loopErr = _request("GET", SearchIndexAPI.url("STATUS_BIOCLIP_DOWNLOAD"))
 			if loopErr then
 				ErrorHandler.handleError("Error downloading BioCLIP model", loopErr)
 				progressScope:setCaption(
@@ -4318,7 +4373,7 @@ end
 -- @return string|nil error
 --
 function SearchIndexAPI.getLlmCatalog()
-	local res, err = _request("GET", getBaseUrl() .. ENDPOINTS.LLM_CATALOG)
+	local res, err = _request("GET", SearchIndexAPI.url("LLM_CATALOG"))
 	if err then
 		log:error("getLlmCatalog failed: " .. tostring(err))
 		return nil, err
@@ -4333,7 +4388,7 @@ end
 -- @return string|nil error
 --
 function SearchIndexAPI.getLlmStatus()
-	local res, err = _request("GET", getBaseUrl() .. ENDPOINTS.LLM_STATUS)
+	local res, err = _request("GET", SearchIndexAPI.url("LLM_STATUS"))
 	if err then
 		log:error("getLlmStatus failed: " .. tostring(err))
 		return nil, err
@@ -4357,13 +4412,13 @@ function SearchIndexAPI.startLlmDownload(modelId)
 		return false, "No model id provided"
 	end
 
-	local status = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_LLM_DOWNLOAD)
+	local status = _request("GET", SearchIndexAPI.url("STATUS_LLM_DOWNLOAD"))
 	if status ~= nil and status.status == "downloading" then
 		log:trace("A local model download is already in progress")
 		return true
 	end
 
-	local _, postErr = _request("POST", getBaseUrl() .. ENDPOINTS.START_LLM_DOWNLOAD, { id = modelId })
+	local _, postErr = _request("POST", SearchIndexAPI.url("START_LLM_DOWNLOAD"), { id = modelId })
 	if postErr then
 		log:error("startLlmDownload failed: " .. tostring(postErr))
 		return false, postErr
@@ -4376,7 +4431,7 @@ function SearchIndexAPI.startLlmDownload(modelId)
 
 	LrTasks.startAsyncTask(function()
 		while true do
-			local loopStatus, loopErr = _request("GET", getBaseUrl() .. ENDPOINTS.STATUS_LLM_DOWNLOAD)
+			local loopStatus, loopErr = _request("GET", SearchIndexAPI.url("STATUS_LLM_DOWNLOAD"))
 			if loopErr then
 				ErrorHandler.handleError(
 					LOC("$$$/LrGeniusAI/LlmDownload/ErrorTitle=Error downloading local AI model"),
@@ -4430,7 +4485,7 @@ end
 
 local lastClipReadyStatus = nil
 function SearchIndexAPI.isClipReady()
-	local url = getBaseUrl() .. ENDPOINTS.CLIP_STATUS
+	local url = SearchIndexAPI.url("CLIP_STATUS")
 	local res, err = _request("GET", url)
 	if err then
 		local errStr = (type(err) == "string") and err or "unknown"
@@ -4470,7 +4525,7 @@ end
 -- back the Plugin Manager's "System Health" panel and the Setup Wizard.
 --
 function SearchIndexAPI.checkServerHealth()
-	local url = getBaseUrl() .. ENDPOINTS.HEALTH
+	local url = SearchIndexAPI.url("HEALTH")
 	local res, err = _request("GET", url)
 	if err then
 		log:warn("checkServerHealth failed (could not reach /health): " .. tostring(err))
@@ -4631,7 +4686,7 @@ function SearchIndexAPI.addTrainingExample(photoId, filepath, developSettings, o
 		return false, "No photo ID provided"
 	end
 	options = options or {}
-	local url = getBaseUrl() .. ENDPOINTS.TRAINING_ADD
+	local url = SearchIndexAPI.url("TRAINING_ADD")
 	local mimeChunks = {}
 
 	table.insert(mimeChunks, { name = "photo_id", value = photoId })
@@ -4702,7 +4757,7 @@ end
 -- @return boolean success, table|string examples list or error message
 ---
 function SearchIndexAPI.listTrainingExamples()
-	local url = getBaseUrl() .. ENDPOINTS.TRAINING_LIST
+	local url = SearchIndexAPI.url("TRAINING_LIST")
 	local response, err = _request("GET", url)
 	if not response then
 		log:error("listTrainingExamples failed: " .. tostring(err))
@@ -4716,7 +4771,7 @@ end
 -- @return number|nil count, string|nil error
 ---
 function SearchIndexAPI.getTrainingCount()
-	local url = getBaseUrl() .. ENDPOINTS.TRAINING_COUNT
+	local url = SearchIndexAPI.url("TRAINING_COUNT")
 	local response, err = _request("GET", url)
 	if not response then
 		log:error("getTrainingCount failed: " .. tostring(err))
@@ -4734,7 +4789,7 @@ function SearchIndexAPI.deleteTrainingExample(photoId)
 	if not photoId or photoId == "" then
 		return false, "No photo ID provided"
 	end
-	local url = getBaseUrl() .. ENDPOINTS.TRAINING_DELETE .. "/" .. photoId
+	local url = SearchIndexAPI.url("TRAINING_DELETE", photoId)
 	local response, err = _request("DELETE", url)
 	if not response then
 		log:error("deleteTrainingExample failed: " .. tostring(err))
@@ -4751,7 +4806,7 @@ end
 -- @return boolean success, string|nil error
 ---
 function SearchIndexAPI.clearAllTrainingExamples()
-	local url = getBaseUrl() .. ENDPOINTS.TRAINING_CLEAR
+	local url = SearchIndexAPI.url("TRAINING_CLEAR")
 	local response, err = _request("DELETE", url)
 	if not response then
 		log:error("clearAllTrainingExamples failed: " .. tostring(err))
@@ -4769,7 +4824,7 @@ end
 -- @return string|nil error message
 ---
 function SearchIndexAPI.getTrainingStats()
-	local url = getBaseUrl() .. ENDPOINTS.TRAINING_STATS
+	local url = SearchIndexAPI.url("TRAINING_STATS")
 	local response, err = _request("GET", url)
 	if not response then
 		log:error("getTrainingStats failed: " .. tostring(err))
@@ -4790,7 +4845,7 @@ end
 -- @return boolean success, table|string response or error message
 ---
 function SearchIndexAPI.getRemoteLogs()
-	local url = getBaseUrl() .. ENDPOINTS.LOGS
+	local url = SearchIndexAPI.url("LOGS")
 	log:trace("Fetching remote logs from: " .. url)
 	local response, err = _request("GET", url, nil, 10)
 	log:trace("getRemoteLogs: _request returned type=" .. type(response))
@@ -4807,7 +4862,7 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 		return false, "No photo ID provided"
 	end
 	options = options or {}
-	local url = getBaseUrl() .. ENDPOINTS.STYLE_EDIT
+	local url = SearchIndexAPI.url("STYLE_EDIT")
 	local mimeChunks = {}
 
 	table.insert(mimeChunks, { name = "photo_id", value = photoId })
@@ -4832,7 +4887,7 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	-- `TaskAiEditPhotos` no longer asks for that fallback — it never sends
 	-- `use_llm_fallback`, so the backend's default (off) applies and a photo the
 	-- style engine cannot answer for comes back as an error rather than as an
-	-- LLM edit. The fields stay because `/style_edit` still accepts them and a
+	-- LLM edit. The fields stay because `/v1/edit/style` still accepts them and a
 	-- caller that does want the fallback has to be able to send everything
 	-- `generateEditRecipePhoto` sends; `addEditOpt` skips whatever is absent,
 	-- so the style-engine-only path pays nothing for them.
@@ -4913,7 +4968,7 @@ end
 --- @param manifest table
 --- @return boolean success, string|table responseOrError
 function SearchIndexAPI.applyUpdate(manifest)
-	local url = getBaseUrl() .. ENDPOINTS.UPDATE_APPLY
+	local url = SearchIndexAPI.url("UPDATE_APPLY")
 	local body = {
 		manifest = manifest,
 		plugin_path = _PLUGIN.path,

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -93,8 +93,12 @@ local ENDPOINTS = {
 	-- Keyword clustering
 	KEYWORDS_CLUSTER = "/v1/keywords/clusters",
 	KEYWORDS_CLUSTER_START = "/v1/keywords/clusters/jobs",
-	KEYWORDS_CLUSTER_STATUS = "/v1/keywords/clusters/jobs", -- suffix /<job_id>
 	KEYWORDS_APPLY_MERGES = "/v1/keywords/merges",
+
+	-- Async jobs. Enqueueing belongs to the domain that starts the work; every
+	-- such response carries a `poll_url` alongside its `job_id`, and this is
+	-- where it points.
+	JOB_STATUS = "/v1/jobs", -- suffix /<job_id>
 
 	-- Local ML model assets
 	CLIP_STATUS = "/v1/models/clip",
@@ -3644,7 +3648,7 @@ function SearchIndexAPI.clusterKeywords(keywordNames, threshold, options, cancel
 	-- Poll until done. Every poll reports back to the caller so the UI keeps
 	-- moving even while a single LLM round-trip runs for minutes.
 	local jobId = startResp.job_id
-	local statusUrl = SearchIndexAPI.url("KEYWORDS_CLUSTER_STATUS", jobId)
+	local statusUrl = SearchIndexAPI.url("JOB_STATUS", jobId)
 	local startedAt = LrDate.currentTime()
 	local lastStageAt = startedAt
 	local lastStageKey = nil

--- a/plugin/LrGeniusAI.lrdevplugin/LocalModelCatalog.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/LocalModelCatalog.lua
@@ -3,7 +3,7 @@
 --
 -- Both the plug-in settings dialog and the onboarding wizard need the same
 -- picture of "what can this machine run, what is installed, what can I
--- download", so the mapping from /llm/catalog + /llm/status onto property-table
+-- download", so the mapping from /v1/llm/catalog + /v1/llm/status onto property-table
 -- fields lives here instead of being written twice.
 --
 -- Fields written into the caller's property table:
@@ -65,7 +65,7 @@ local function pickValidChoice(choices, current)
 	return choices[1] and choices[1].value or nil
 end
 
--- The llama.cpp half of /llm/catalog + /llm/status.
+-- The llama.cpp half of /v1/llm/catalog + /v1/llm/status.
 local function updateLlamaCppFields(propertyTable, catalog, status)
 	if catalog.supported == false then
 		propertyTable.llmStatusText = LOC(
@@ -154,7 +154,7 @@ local function updateMlxFields(propertyTable, catalog, status)
 end
 
 ---
--- Refreshes both local-model sections from /llm/catalog and /llm/status.
+-- Refreshes both local-model sections from /v1/llm/catalog and /v1/llm/status.
 --
 -- Everything here is best-effort: the backend may be down, or built without
 -- local-model support, and neither should break the calling dialog. Runs in

--- a/plugin/LrGeniusAI.lrdevplugin/OnboardingWizard.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/OnboardingWizard.lua
@@ -35,7 +35,7 @@ function OnboardingWizard.show(manualTrigger)
 				propertyTable.backendRunning = SearchIndexAPI.pingServer()
 			end
 
-			-- The on-device models answer through /assets/status, which covers
+			-- The on-device models answer through /v1/models/assets, which covers
 			-- every family in one request. Same source as the Plug-in Manager's
 			-- indicator, so the two cannot disagree about what is on disk.
 			local function refreshAssetStatus()

--- a/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
@@ -3,7 +3,7 @@ PluginInfoDialogSections = {}
 function PluginInfoDialogSections.startDialog(propertyTable)
 	propertyTable.useClip = prefs.useClip
 
-	-- One poller for every model, not one per model: /assets/status answers for
+	-- One poller for every model, not one per model: /v1/models/assets answers for
 	-- all of them in a single request, and two loops on separate 5s timers used
 	-- to make the two indicators update at visibly different moments.
 	--
@@ -339,7 +339,7 @@ function PluginInfoDialogSections.sectionsForTopOfDialog(f, propertyTable)
 	-- .github/workflows/release.yml), so a llama.cpp box there could never do
 	-- anything but report "this backend build has no local-model support".
 	-- Windows is the mirror image — MLX is Apple silicon only, and its half of
-	-- /llm/catalog always comes back unsupported.
+	-- /v1/llm/catalog always comes back unsupported.
 	--
 	-- Building only the box that applies, rather than hiding the other one,
 	-- keeps the dialog free of a dead group and means neither set of bindings

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAiEditPhotos.lua
@@ -1,11 +1,11 @@
 require("DevelopEditManager")
 
--- AI Edit runs on the Style Engine only. The LLM edit path (`/edit`, provider
+-- AI Edit runs on the Style Engine only. The LLM edit path (`/v1/edit/recipe`, provider
 -- and model choice, prompts, intent presets, creative controls, per-photo
 -- instructions) is gone from this task: none of it reached the style engine,
 -- which builds a recipe purely by matching the photo against the training
 -- examples the user saved from their own edits. The backend still serves
--- `/edit`, and `SearchIndexAPI.generateEditRecipePhoto` still speaks to it —
+-- `/v1/edit/recipe`, and `SearchIndexAPI.generateEditRecipePhoto` still speaks to it —
 -- nothing here calls either.
 
 -- Mirrors `MIN_TRAINING_EXAMPLES` in

--- a/plugin/LrGeniusAI.lrdevplugin/TaskDeduplicateKeywords.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskDeduplicateKeywords.lua
@@ -83,7 +83,7 @@ local function collectLeafGroups(roots, onProgress, isCanceled)
 	return groups, examined, canceled
 end
 
--- Turn a backend progress report from /keywords/cluster/status into a phrase
+-- Turn a backend progress report from /v1/keywords/clusters/jobs into a phrase
 -- for the progress caption.
 local function describeClusterStage(progress)
 	local stage = progress and progress.stage

--- a/plugin/LrGeniusAI.lrdevplugin/TaskExportCullFixture.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskExportCullFixture.lua
@@ -261,7 +261,7 @@ LrTasks.startAsyncTask(function()
 			return
 		end
 
-		-- The grouping and the stored metrics both come from a real /cull call,
+		-- The grouping and the stored metrics both come from a real /v1/cull/grade call,
 		-- so the fixture describes exactly what the backend saw. The labels
 		-- layered on top are the only human input.
 		local progressScope = LrProgressScope({

--- a/plugin/LrGeniusAI.lrdevplugin/TaskSemanticSearch.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskSemanticSearch.lua
@@ -31,7 +31,7 @@ local function buildCoverageWarning()
 		end
 	end
 
-	-- One /db/stats call, measured at ~95 ms over 14,000 photos, plus the
+	-- One /v1/db/stats call, measured at ~95 ms over 14,000 photos, plus the
 	-- catalog count the search itself already pays for further down. Cheap
 	-- enough to run before every search; if it ever is not, the number it
 	-- produces is the one worth waiting for.

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -1948,8 +1948,8 @@ end
 -- quality (the backend's `compute_faces = has_task("faces") || cull_pass`);
 -- it deliberately skips the embedding, so it does not need `clip`.
 --
--- @param tasks table Array of task names as sent to /index.
--- @return table Array of family ids, in the order /assets/status reports them.
+-- @param tasks table Array of task names as sent to /v1/index/photos.
+-- @return table Array of family ids, in the order /v1/models/assets reports them.
 --
 function Util.requiredModelFamilies(tasks)
 	if type(tasks) ~= "table" then
@@ -1979,12 +1979,12 @@ end
 ---
 -- Which of the families a run needs are not downloaded yet.
 --
--- Takes the `families` array from /assets/status. A family the run does not
+-- Takes the `families` array from /v1/models/assets. A family the run does not
 -- need is ignored however unready it is, and a required family the backend
 -- does not report at all is treated as present: an older backend that has
 -- never heard of it must not block a run it can perform perfectly well.
 --
--- @param families table `families` from /assets/status.
+-- @param families table `families` from /v1/models/assets.
 -- @param requiredIds table Array of family ids from Util.requiredModelFamilies.
 -- @return table Array of { id, name, approx_bytes } per missing family, in required order.
 --
@@ -2025,7 +2025,7 @@ end
 -- reveal the ones that were never indexed at all. Falls back to the backend's
 -- figure when the catalog count is unavailable.
 --
--- @param stats table|nil The /db/stats response.
+-- @param stats table|nil The /v1/db/stats response.
 -- @param catalogPhotoCount number|nil Photos in the Lightroom catalog.
 -- @return table|nil { total, searchable, unsearchable }, or nil when unknown.
 --

--- a/plugin/spec/util_model_readiness_spec.lua
+++ b/plugin/spec/util_model_readiness_spec.lua
@@ -8,7 +8,7 @@
 
 local Util = require("Util")
 
---- The `families` array as /assets/status reports it, with the given ids unready.
+--- The `families` array as /v1/models/assets reports it, with the given ids unready.
 local function families(unready)
 	local notReady = {}
 	for _, id in ipairs(unready) do

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -42,6 +42,16 @@ DOC_MAP = REPO / "docs/doc-sources.toml"
 
 HTTP_METHODS = ("get", "post", "put", "delete", "patch", "head", "options")
 
+# `lrg_api::build_router` nests every route module under this prefix, so the
+# path a module writes is not the path it serves. Keep in step with
+# `API_PREFIX` in `server-rs/crates/lrg-api/src/lib.rs`.
+API_PREFIX = "/v1"
+
+# ...except these two, merged at the root instead. They are the unversioned
+# bootstrap contract a new plug-in uses to talk to an old backend, so they are
+# spelled exactly as served. Keep in step with `build_router`.
+UNVERSIONED_ROUTE_FILES = frozenset({"bootstrap.rs", "update.rs"})
+
 
 # --------------------------------------------------------------------------
 # Extraction
@@ -87,7 +97,10 @@ def backend_routes() -> dict[tuple[str, str], str]:
         for m in re.finditer(r"\.route\(\s*\n?\s*\"([^\"]+)\"", text):
             open_idx = text.index("(", m.start())
             body = text[open_idx : _matching_paren(text, open_idx) + 1]
-            path = normalize_path(m.group(1))
+            path = m.group(1)
+            if src.name not in UNVERSIONED_ROUTE_FILES:
+                path = API_PREFIX + path
+            path = normalize_path(path)
             methods = {
                 v.lower()
                 for v in re.findall(

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -67,7 +67,7 @@ so a machine that has run the plugin's model download needs no extra setup.
 
 The in-process local LLM is behind a cargo feature that is **off by default**.
 Without it the `llamacpp` provider reports that the build has no local-model
-support and `/llm/catalog` returns `supported: false`, so the plugin's "Local AI
+support and `/v1/llm/catalog` returns `supported: false`, so the plugin's "Local AI
 Model" settings have nothing to work with. It is opt-in because it compiles
 llama.cpp from source: that needs `cmake` and `libclang` (for bindgen) and adds
 minutes to a cold build, which nobody working on an unrelated crate should pay.
@@ -119,7 +119,7 @@ xcodebuild build -scheme lrgenius-mlx -destination 'platform=macOS,arch=arm64' \
 export LRG_MLX_SIDECAR=$PWD/.build/xcode/Build/Products/Release/lrgenius-mlx
 ```
 
-Without it, `/llm/catalog` reports `mlx.supported: false` with a reason naming
+Without it, `/v1/llm/catalog` reports `mlx.supported: false` with a reason naming
 what is missing (wrong architecture, or no helper found). The sidecar is
 resolved from `LRG_MLX_SIDECAR`, then from next to the running server, which is
 how the shipped `.pkg` finds it. See
@@ -135,7 +135,7 @@ cargo test -p lrg-mlx --test sidecar_smoke -- --ignored
 
 ### SigLIP2 (semantic embeddings)
 
-`POST /clip/download/start` + `GET /clip/download/status` fetch the fp16
+`POST /v1/models/clip/downloads` + `GET /v1/models/clip/downloads` fetch the fp16
 ONNX assets (`siglip2_image_fp16.onnx`, `siglip2_text_fp16.onnx`,
 `tokenizer.json`) and place them at the `LRG_SIGLIP_*` paths below,
 pulling CI-exported ONNX assets from a release instead of the fp32
@@ -232,7 +232,7 @@ export LRG_BIOCLIP_TAXA_JSON=/path/to/models/bioclip2/bioclip2_taxa.json
 
 Without these, `lrg-ml` falls back to
 `~/.cache/lrgenius/models/bioclip2_{image.onnx,taxa.bin,taxa.json}`, which is
-where `POST /bioclip/download/start` — and `POST /assets/download/start`, which
+where `POST /v1/models/bioclip/downloads` — and `POST /v1/models/assets/downloads`, which
 the plugin actually calls — put them. Note the fallback name for the tower is
 `bioclip2_image.onnx`, without the export script's `_fp16` suffix.
 
@@ -265,7 +265,7 @@ export LRG_FACENET_ONNX=/path/to/face-assets/facenet_vggface2.onnx
 
 Without these, `lrg-ml` falls back to
 `~/.cache/lrgenius/models/{yunet_face_detection.onnx,facenet_vggface2.onnx}`,
-which is where `POST /assets/download/start` puts them. Assets are published
+which is where `POST /v1/models/assets/downloads` puts them. Assets are published
 by `.github/workflows/model-assets-face.yml` to the fixed `face-assets-v1`
 tag, independent of the other two families.
 
@@ -280,11 +280,11 @@ ignored by clustering and re-queued for detection.
 
 Only present in builds compiled with the `llamacpp` cargo feature; without
 it the `llamacpp` provider reports that the build has no local-model
-support and `/llm/catalog` returns `supported: false`.
+support and `/v1/llm/catalog` returns `supported: false`.
 
 Models are GGUF pairs — the weights plus an `mmproj` vision projector,
-which is what lets the model see the photo. `GET /llm/catalog` lists what
-is installed and what can be downloaded; `POST /llm/download/start` fetches
+which is what lets the model see the photo. `GET /v1/llm/catalog` lists what
+is installed and what can be downloaded; `POST /v1/llm/downloads` fetches
 a catalog entry. Discovery looks at, in order: the explicit env overrides,
 `LRG_LLAMA_MODEL_DIR` (default `~/.cache/lrgenius/models/llm/`), and any
 GGUFs already under `~/.lmstudio/models`, so a model you downloaded in LM
@@ -323,8 +323,8 @@ or more safetensors shards, and the tokenizer files. Discovery therefore looks
 for directories that contain a `config.json` *and* at least one `.safetensors`
 (the config alone would match a half-finished download).
 
-`GET /llm/catalog` reports MLX under a nested `mlx` key alongside the GGUF half,
-including `supported`/`reason`, and `POST /llm/download/start` takes an MLX
+`GET /v1/llm/catalog` reports MLX under a nested `mlx` key alongside the GGUF half,
+including `supported`/`reason`, and `POST /v1/llm/downloads` takes an MLX
 catalog id on the same route — the id alone picks the backend, so there is one
 download queue rather than two competing for the network.
 

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -36,6 +36,31 @@ cargo build --release -p lrg-server
 `cargo test --workspace` and `cargo clippy --workspace --all-targets` should
 both be clean before sending changes.
 
+### Host and port
+
+The server listens on `127.0.0.1:19819`. Both halves are environment
+variables, which is how the Docker image binds to all interfaces:
+
+| Env var | Default |
+|---|---|
+| `GENIUSAI_HOST` | `127.0.0.1` |
+| `GENIUSAI_PORT` | `19819` |
+
+```bash
+GENIUSAI_PORT=19833 ./target/release/geniusai-server --db-path /path/to/lrgenius.db
+```
+
+An unparseable `GENIUSAI_PORT` falls back to the default rather than refusing
+to start, so a typo costs you the port you asked for, not the server.
+
+Moving the port is mainly useful for running a second instance beside an
+installed one — a dev build cannot share 19819 with the copy the plug-in
+auto-launches. Point the plug-in at it with **Plug-in Manager → Backend server
+URL** (`http://127.0.0.1:19833`); that setting is the only place the plug-in
+learns the address, so nothing else needs changing. Note that
+`SearchIndexAPI.startServer` still launches the *installed* binary on the
+default port, so start a custom-port build yourself.
+
 ### Golden tests and `LRG_REQUIRE_GOLDENS`
 
 The ML golden tests — SigLIP2, BioCLIP 2 and the face pipeline — compare real

--- a/server-rs/crates/lrg-analysis/examples/bench_grouping.rs
+++ b/server-rs/crates/lrg-analysis/examples/bench_grouping.rs
@@ -2,7 +2,7 @@
 //!
 //! Grouping used to be a full O(n^2) sweep with a 1152-dimensional f64 cosine
 //! per pair, run inline on a tokio worker thread, so a large cull was the
-//! dominant cost of `/cull`. This measures the sweep at several catalog sizes
+//! dominant cost of `/v1/cull/grade`. This measures the sweep at several catalog sizes
 //! so the scaling curve is visible rather than assumed.
 //!
 //! ```text

--- a/server-rs/crates/lrg-analysis/src/training.rs
+++ b/server-rs/crates/lrg-analysis/src/training.rs
@@ -195,7 +195,7 @@ fn downscale_max512(pixels: &[u8], width: usize, height: usize) -> (Vec<u8>, usi
 
 /// Port of `compute_exposure_metrics`, operating on already-decoded RGB8
 /// pixels rather than raw file bytes (decoding happens once at the route
-/// layer and is shared with the rest of the `/training/add` pipeline).
+/// layer and is shared with the rest of the `/v1/edit/training` pipeline).
 pub fn compute_exposure_metrics(pixels: &[u8], width: usize, height: usize) -> ExposureMetrics {
     if width == 0 || height == 0 {
         return ExposureMetrics {

--- a/server-rs/crates/lrg-api/src/lib.rs
+++ b/server-rs/crates/lrg-api/src/lib.rs
@@ -18,10 +18,19 @@ use axum::Router;
 
 use state::AppState;
 
-/// Build the full application router (M1: server blueprint only; the
-/// remaining blueprints are added milestone by milestone).
+/// The API version prefix every route is served under, bar the frozen
+/// bootstrap contract. Declared once here rather than repeated in each
+/// module's path literals, so it cannot drift.
+pub const API_PREFIX: &str = "/v1";
+
+/// Build the full application router.
+///
+/// Two tiers: the version-independent bootstrap contract at the root (see
+/// [`routes::bootstrap`]) and everything else under [`API_PREFIX`]. Route
+/// modules therefore spell only their domain path — `"/faces/detect"`, not
+/// `"/v1/faces/detect"` — and nesting supplies the prefix.
 pub fn build_router(state: Arc<AppState>) -> Router {
-    Router::new()
+    let v1 = Router::new()
         .merge(routes::server::router())
         .merge(routes::index::router())
         .merge(routes::db::router())
@@ -40,15 +49,21 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .merge(routes::llm::router())
         .merge(routes::style_edit::router())
         .merge(routes::import_::router())
+        .merge(routes::species::router());
+
+    Router::new()
+        // Never versioned — a new plug-in must be able to reach these on an
+        // old binary to pull the install forward.
+        .merge(routes::bootstrap::router())
         .merge(routes::update::router())
-        .merge(routes::species::router())
+        .nest(API_PREFIX, v1)
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             middleware::auto_bind_db_path,
         ))
         // Flask never set MAX_CONTENT_LENGTH, so the Python backend had no
         // request-body cap; axum's own default (2 MiB) is far below a real
-        // Lightroom-exported JPEG preview (or a multi-photo /index batch),
+        // Lightroom-exported JPEG preview (or a multi-photo /v1/index/photos batch),
         // which silently failed `Multipart` field reads on the `image`
         // field once exceeded. Disable it to restore parity.
         .layer(DefaultBodyLimit::disable())

--- a/server-rs/crates/lrg-api/src/lib.rs
+++ b/server-rs/crates/lrg-api/src/lib.rs
@@ -40,6 +40,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .merge(routes::faces::router())
         .merge(routes::index_upload::router())
         .merge(routes::index_by_reference::router())
+        .merge(routes::jobs::router())
         .merge(routes::search::router())
         .merge(routes::find_similar::router())
         .merge(routes::group_similar::router())

--- a/server-rs/crates/lrg-api/src/middleware.rs
+++ b/server-rs/crates/lrg-api/src/middleware.rs
@@ -16,8 +16,12 @@ use axum::{
 use crate::state::AppState;
 
 /// Endpoints that don't need (and shouldn't pay the cost of) binding:
-/// liveness checks and the explicit init route, which handles db_path itself.
-const BYPASS_PATHS: &[&str] = &["/ping", "/initialize"];
+/// liveness checks and the explicit bind route, which handles db_path itself.
+///
+/// Matched against the full request path, so these carry the `/v1` prefix that
+/// `build_router` nests them under. `/ping` is part of the unversioned
+/// bootstrap contract and stays at the root.
+const BYPASS_PATHS: &[&str] = &["/ping", "/v1/db/bind"];
 
 /// JSON bodies are buffered up to this limit for the db_path peek. Larger
 /// bodies (and all non-JSON bodies, e.g. multipart uploads) are passed

--- a/server-rs/crates/lrg-api/src/mlx_models.rs
+++ b/server-rs/crates/lrg-api/src/mlx_models.rs
@@ -276,7 +276,7 @@ mod tests {
     }
 
     /// The ids must not collide with the GGUF catalog's: both appear in the
-    /// same plugin dropdown, and `/llm/download/start` picks an entry by id
+    /// same plugin dropdown, and `/v1/llm/downloads` picks an entry by id
     /// alone.
     #[test]
     fn catalog_ids_do_not_collide_with_the_gguf_catalog() {

--- a/server-rs/crates/lrg-api/src/routes/assets.rs
+++ b/server-rs/crates/lrg-api/src/routes/assets.rs
@@ -56,9 +56,11 @@ const FACE_ASSETS_RELEASE_TAG: &str = "face-assets-v1";
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/assets/status", get(assets_status))
-        .route("/assets/download/start", post(download_start))
-        .route("/assets/download/status", get(download_status))
+        .route("/models/assets", get(assets_status))
+        .route(
+            "/models/assets/downloads",
+            post(download_start).get(download_status),
+        )
 }
 
 /// Per-family readiness plus one overall flag.

--- a/server-rs/crates/lrg-api/src/routes/bioclip.rs
+++ b/server-rs/crates/lrg-api/src/routes/bioclip.rs
@@ -1,7 +1,7 @@
 //! BioCLIP 2 asset status and download — the species-recognition counterpart
 //! to [`crate::routes::clip`], sharing that module's download machinery.
 //!
-//! `/bioclip/status` reports whether the files are on disk ("ready to
+//! `/v1/models/bioclip` reports whether the files are on disk ("ready to
 //! lazy-load"), which is deliberately distinct from `/health`'s
 //! `species_model`, which reports whether they are currently in memory. The
 //! plugin gates its "Identify species" checkbox on this one.
@@ -41,9 +41,11 @@ const ASSET_NAMES: [&str; 3] = [
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/bioclip/status", get(bioclip_status))
-        .route("/bioclip/download/start", post(download_start))
-        .route("/bioclip/download/status", get(download_status))
+        .route("/models/bioclip", get(bioclip_status))
+        .route(
+            "/models/bioclip/downloads",
+            post(download_start).get(download_status),
+        )
 }
 
 async fn bioclip_status(State(state): State<Arc<AppState>>) -> Json<Value> {

--- a/server-rs/crates/lrg-api/src/routes/bootstrap.rs
+++ b/server-rs/crates/lrg-api/src/routes/bootstrap.rs
@@ -1,0 +1,37 @@
+//! The version-independent bootstrap contract.
+//!
+//! These four paths, plus `POST /update/apply` in [`super::update`], are the
+//! only ones served off the root instead of under `/v1`, and they must never
+//! move again. The plug-in's ensure-backend loop (`Util.waitForServerDialog`)
+//! drives `ping` -> `ensureVersionCompatibility` (`/version`) -> `/shutdown`
+//! against **whatever backend is already installed**, and
+//! `SearchIndexAPI.applyUpdate` posts to `/update/apply` on that same old
+//! binary to pull the machine forward.
+//!
+//! So these paths are what a *new* plug-in uses to talk to an *old* server. If
+//! they were versioned, a plug-in that updated ahead of its backend would call
+//! paths the running binary does not serve, and the mechanism needed to repair
+//! the install would be the very thing that broke. Everything else is free to
+//! move between API versions precisely because this set does not.
+//!
+//! The handlers themselves live in [`super::server`]; only the registration is
+//! here, so that `scripts/check-docs.py` can tell versioned routes from
+//! unversioned ones by file name alone.
+
+use std::sync::Arc;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+use super::server::{get_version, ping, shutdown, version_check};
+use crate::state::AppState;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/ping", get(ping))
+        .route("/shutdown", post(shutdown))
+        .route("/version", get(get_version))
+        .route("/version/check", post(version_check))
+}

--- a/server-rs/crates/lrg-api/src/routes/clip.rs
+++ b/server-rs/crates/lrg-api/src/routes/clip.rs
@@ -1,9 +1,9 @@
-//! Clip blueprint — port of `routes/clip.py`. `/clip/status` checks the
+//! Clip blueprint — port of `routes/clip.py`. `/v1/models/clip` checks the
 //! ONNX+tokenizer files are on disk (matching Python's `is_model_cached()`
 //! "ready to lazy-load" semantics — distinct from `/health`'s "currently
 //! loaded in memory" status).
 //!
-//! `/clip/download/*` differs in *source* from Python (which pulls the
+//! `/v1/models/clip/downloads` differs in *source* from Python (which pulls the
 //! fp32 PyTorch checkpoint straight from Hugging Face Hub): this binary
 //! has no PyTorch/onnxscript toolchain to run
 //! `scripts/export_siglip2_fp16.py` itself, so it instead downloads the
@@ -42,10 +42,10 @@ const ASSET_NAMES: [&str; 3] = [
 ];
 
 pub fn router() -> Router<Arc<AppState>> {
-    Router::new()
-        .route("/clip/status", get(clip_status))
-        .route("/clip/download/start", post(download_start))
-        .route("/clip/download/status", get(download_status))
+    Router::new().route("/models/clip", get(clip_status)).route(
+        "/models/clip/downloads",
+        post(download_start).get(download_status),
+    )
 }
 
 async fn clip_status(State(state): State<Arc<AppState>>) -> Json<Value> {

--- a/server-rs/crates/lrg-api/src/routes/db.rs
+++ b/server-rs/crates/lrg-api/src/routes/db.rs
@@ -1,4 +1,4 @@
-//! DB blueprint — port of `routes/db.py`: /db/stats, /db/backup.
+//! DB blueprint: binding the backend to a catalog, stats, and backups.
 //! /db/migrate-photo-ids is legacy (uuid -> photo_id one-time migration)
 //! and isn't carried over to the Rust backend.
 
@@ -15,7 +15,7 @@ use axum::{
         StatusCode,
     },
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use chrono::Utc;
@@ -27,8 +27,13 @@ use crate::state::AppState;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
+        // Binding the backend to a catalog is a database operation, so the
+        // route lives here; the handler still sits in `server.rs`.
+        .route("/db/bind", post(super::server::initialize))
         .route("/db/stats", get(database_stats))
-        .route("/db/backup", get(backup_database))
+        // POST, not GET: taking a backup also retains a copy on disk, which
+        // is not something a safe method may do.
+        .route("/db/backups", post(backup_database))
 }
 
 #[derive(serde::Deserialize)]

--- a/server-rs/crates/lrg-api/src/routes/edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/edit.rs
@@ -1,4 +1,4 @@
-//! `/edit` and `/edit_base64` — port of `routes/edit.py`: single-photo
+//! `/v1/edit/recipe` and `/v1/edit/recipe/base64` — port of `routes/edit.py`: single-photo
 //! LLM-backed Lightroom edit-recipe generation across all four providers,
 //! few-shot injection from the user's own training examples (best-effort,
 //! brute-force cosine search over the small `edit_training` table — same
@@ -7,7 +7,7 @@
 //!
 //! Note: mirrors the real Python behavior, not the aspirational one —
 //! `_extract_options` never populates `location_data` for this endpoint
-//! (only the `/index` batch path wires EXIF location through), so the
+//! (only the `/v1/index/photos` batch path wires EXIF location through), so the
 //! edit prompt's "Photo taken in: ..." context is deliberately never
 //! filled here either, matching production.
 
@@ -29,8 +29,8 @@ use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
-        .route("/edit", axum::routing::post(edit_multipart))
-        .route("/edit_base64", axum::routing::post(edit_base64))
+        .route("/edit/recipe", axum::routing::post(edit_multipart))
+        .route("/edit/recipe/base64", axum::routing::post(edit_base64))
 }
 
 pub(crate) struct EditOptions {
@@ -571,7 +571,7 @@ pub(crate) async fn generate_edit_recipe_for_photo(
 ///
 /// `is_raw` prefers what the plugin said, because it reads Lightroom's own
 /// `fileFormat` and is therefore authoritative. The filename is the fallback
-/// for older plugins and for `/edit_base64` callers that send neither — it is a
+/// for older plugins and for `/v1/edit/recipe/base64` callers that send neither — it is a
 /// heuristic, and one whose unknown case reads as *not* raw, so a frame that
 /// cannot be placed gets the conservative budget.
 pub(crate) fn capture_conditions(

--- a/server-rs/crates/lrg-api/src/routes/faces.rs
+++ b/server-rs/crates/lrg-api/src/routes/faces.rs
@@ -23,7 +23,7 @@ use crate::state::AppState;
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/faces/detect", post(detect))
-        .route("/faces/query", post(query))
+        .route("/faces/search", post(query))
         .route("/faces/cluster", post(cluster))
         .route("/faces/persons", get(list_persons))
         .route(
@@ -274,7 +274,7 @@ async fn cluster(State(state): State<Arc<AppState>>, body: Option<Json<Value>>) 
         // embeddings are 512-d unit vectors exactly like FaceNet's, so mixing
         // them produces no error at all, just clusters built from distances
         // between two unrelated spaces. Photos in this state are re-queued for
-        // detection by `/index/check-unprocessed`; until that runs, leaving
+        // detection by `/v1/index/unprocessed`; until that runs, leaving
         // their faces unassigned is the honest answer.
         let current_model = state.face.model_id();
         let expected_dim = records

--- a/server-rs/crates/lrg-api/src/routes/find_similar.rs
+++ b/server-rs/crates/lrg-api/src/routes/find_similar.rs
@@ -1,4 +1,4 @@
-//! `/find_similar` — port of `routes/search.py::find_similar_route` +
+//! `/v1/search/similar` — port of `routes/search.py::find_similar_route` +
 //! `services/chroma.py::find_similar_to_photo`/`find_similar_to_photo_by_clip`.
 
 use std::collections::HashSet;
@@ -13,7 +13,7 @@ use lrg_store::{meta, IMAGE_TABLE};
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
-    axum::Router::new().route("/find_similar", axum::routing::post(find_similar))
+    axum::Router::new().route("/search/similar", axum::routing::post(find_similar))
 }
 
 fn phash_to_int(value: Option<&Value>) -> Option<u64> {

--- a/server-rs/crates/lrg-api/src/routes/group_similar.rs
+++ b/server-rs/crates/lrg-api/src/routes/group_similar.rs
@@ -1,4 +1,4 @@
-//! `/group_similar` and `/cull` — port of `routes/search.py`'s
+//! `/v1/cull/groups` and `/v1/cull/grade` — port of `routes/search.py`'s
 //! `group_similar_route`/`cull_route` + `services/search.py`'s
 //! `group_similar_images`/`cull_images`, backed by
 //! `lrg_analysis::grouping::group_and_sort_images`.
@@ -18,8 +18,8 @@ use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
-        .route("/group_similar", axum::routing::post(group_similar))
-        .route("/cull", axum::routing::post(cull))
+        .route("/cull/groups", axum::routing::post(group_similar))
+        .route("/cull/grade", axum::routing::post(cull))
 }
 
 struct GroupingParams {

--- a/server-rs/crates/lrg-api/src/routes/import_.rs
+++ b/server-rs/crates/lrg-api/src/routes/import_.rs
@@ -1,4 +1,4 @@
-//! `POST /import/metadata` — port of `routes/import_.py` +
+//! `POST /v1/photos/metadata/import` — port of `routes/import_.py` +
 //! `services/import_.py::import_metadata_task`: bulk-import previously
 //! generated title/caption/alt_text/keywords into existing (or newly
 //! created metadata-only) photo records.
@@ -10,7 +10,7 @@
 //! replaces a record's metadata wholesale — the exact reason every other
 //! metadata-writing call site in the Python codebase (`services/index.py`,
 //! `routes/edit.py`) always starts from `dict(existing_meta)` before
-//! layering new fields on top — the real Python `/import/metadata`
+//! layering new fields on top — the real Python `/v1/photos/metadata/import`
 //! silently wipes an already-indexed photo's other metadata (embedding
 //! status, culling metrics, catalog_ids, provider/model, ...) on every
 //! import of an existing photo. That is very likely an unintended data-
@@ -32,7 +32,7 @@ use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new().route(
-        "/import/metadata",
+        "/photos/metadata/import",
         axum::routing::post(import_metadata_batch),
     )
 }

--- a/server-rs/crates/lrg-api/src/routes/index.rs
+++ b/server-rs/crates/lrg-api/src/routes/index.rs
@@ -1,5 +1,5 @@
 //! Index blueprint (M2 subset) — port of `routes/index.py`: /get,
-//! /get/ids, /remove, /remove/metadata. The upload/indexing endpoints
+//! /v1/photos/ids, /v1/photos/remove, /v1/photos/metadata/remove. The upload/indexing endpoints
 //! arrive with the ML pipeline in M4-M6.
 
 use std::sync::Arc;
@@ -19,13 +19,13 @@ use crate::state::AppState;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/get", post(get_photo_data))
-        .route("/get/ids", get(get_ids))
-        .route("/remove", post(remove_image))
-        .route("/remove/metadata", post(remove_metadata))
-        .route("/sync/claim", post(sync_claim))
-        .route("/sync/cleanup", post(sync_cleanup))
-        .route("/index/check-unprocessed", post(check_unprocessed))
+        .route("/photos/lookup", post(get_photo_data))
+        .route("/photos/ids", get(get_ids))
+        .route("/photos/remove", post(remove_image))
+        .route("/photos/metadata/remove", post(remove_metadata))
+        .route("/photos/catalogs/claim", post(sync_claim))
+        .route("/photos/catalogs/cleanup", post(sync_cleanup))
+        .route("/index/unprocessed", post(check_unprocessed))
 }
 
 /// Port of `get_photo_ids_needing_processing` + the option subset that

--- a/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
@@ -1,5 +1,5 @@
-//! `/index_by_reference` — port of `routes/index.py::index_images_batch_by_reference`.
-//! Same processing pipeline as `/index`, but the plugin sends server-side
+//! `/v1/index/photos/by-path` — port of `routes/index.py::index_images_batch_by_reference`.
+//! Same processing pipeline as `/v1/index/photos`, but the plugin sends server-side
 //! file paths in a JSON body instead of uploading image bytes (used when
 //! the backend has filesystem access to the catalog's photos). Shares
 //! `index_upload::process_batch` for everything past reading the files.
@@ -48,7 +48,7 @@ fn image_overrides(item: &Value) -> PhotoOverrides {
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new().route(
-        "/index_by_reference",
+        "/index/photos/by-path",
         axum::routing::post(index_by_reference),
     )
 }
@@ -128,7 +128,7 @@ async fn index_by_reference(
     // Paths, not bytes: `process_batch` reads each file only when it is about
     // to normalise it, so a group of raw originals is never all resident at
     // once. It also runs the same `normalize_image_bytes` step on these that
-    // `/index` runs on its multipart uploads — converting here too would
+    // `/v1/index/photos` runs on its multipart uploads — converting here too would
     // double-convert.
     //
     // Files that cannot be read are reported by `process_batch` against their

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -1,4 +1,4 @@
-//! `/index` — port of `routes/index.py::index_images_batch` +
+//! `/v1/index/photos` — port of `routes/index.py::index_images_batch` +
 //! `services/index.py::process_image_task`'s core loop: embeddings
 //! (SigLIP2), pHash + culling metrics (always computed), faces (when
 //! requested), catalog association, existing-record merge for
@@ -30,7 +30,7 @@ use crate::routes::route_util::parse_multipart;
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
-    axum::Router::new().route("/index", axum::routing::post(index_batch))
+    axum::Router::new().route("/index/photos", axum::routing::post(index_batch))
 }
 
 pub(crate) struct ParsedOptions {
@@ -64,7 +64,7 @@ pub(crate) struct ParsedOptions {
     api_key: Option<String>,
     capture_time: Option<f64>,
     /// Batch-level exposure compensation, from the single-photo multipart
-    /// path. `/index_by_reference` carries it per photo instead — see
+    /// path. `/v1/index/photos/by-path` carries it per photo instead — see
     /// [`PhotoOverrides::exposure_bias`].
     exposure_bias: Option<f64>,
     /// Whether the original is a raw file, from the multipart path. Stored
@@ -88,7 +88,7 @@ pub(crate) struct ParsedOptions {
 
 /// Per-photo values that must not be shared across a grouped request.
 ///
-/// `/index_by_reference` can carry several photos in one call, but the option
+/// `/v1/index/photos/by-path` can carry several photos in one call, but the option
 /// fields arrive flat, one set for the whole request. These are exactly the
 /// ones `prompts.rs` classifies as volatile — reusing one photo's capture
 /// time, keywords or folders for the whole group would feed the model context
@@ -107,7 +107,7 @@ pub(crate) struct PhotoOverrides {
     /// sequence from a burst, and there is no batch-level fallback because a
     /// per-photo EV shared across a group would be actively misleading.
     pub exposure_bias: Option<f64>,
-    /// Per-photo raw flag, for `/index_by_reference`. Falls back to the
+    /// Per-photo raw flag, for `/v1/index/photos/by-path`. Falls back to the
     /// batch-level [`ParsedOptions::is_raw`] when absent.
     pub is_raw: Option<bool>,
 }
@@ -386,7 +386,7 @@ pub(crate) struct UploadedImage {
 
 /// Where [`process_batch`] gets each photo's bytes.
 ///
-/// The distinction is about peak memory, not convenience. `/index_by_reference`
+/// The distinction is about peak memory, not convenience. `/v1/index/photos/by-path`
 /// points at the user's originals — 25–50 MB raw files — and reading the whole
 /// group before normalising any of it kept every one of them resident at once.
 /// The normalised JPEG is a few hundred KB and the raw bytes are dead the
@@ -564,20 +564,20 @@ async fn index_batch(State(state): State<Arc<AppState>>, mut multipart: Multipar
     .await
 }
 
-/// Shared by `/index` (multipart) and `/index_by_reference` (JSON + on-disk
+/// Shared by `/v1/index/photos` (multipart) and `/v1/index/photos/by-path` (JSON + on-disk
 /// paths) once each has gathered its images/photo_ids/option-fields in its
 /// own way — everything past that point (db_path auto-bind, validation,
 /// per-photo processing, response shape) is identical.
 ///
 /// `pre_failures` are errors the caller already knows about before this
-/// point (e.g. `/index_by_reference`'s file-not-found reads) — folded in
+/// point (e.g. `/v1/index/photos/by-path`'s file-not-found reads) — folded in
 /// exactly like an image-normalization failure so failure_count/
 /// error_messages account for them the same way Python's
 /// `read_failures + processing_failures` does.
 ///
 /// `reject_empty_batch` matches Python's per-endpoint difference on a
-/// genuinely empty batch: `/index` 400s ("no images provided"), while
-/// `/index_by_reference` treats an all-paths-invalid batch as a normal
+/// genuinely empty batch: `/v1/index/photos` 400s ("no images provided"), while
+/// `/v1/index/photos/by-path` treats an all-paths-invalid batch as a normal
 /// zero-success response (or a 500 quoting the read errors, if there
 /// were any) rather than a client-error mismatch.
 pub(crate) async fn process_batch(
@@ -1467,7 +1467,7 @@ async fn finish_one(
                 // empty vectors would corrupt person clustering, and clearing
                 // the photo's existing rows would destroy identities a previous
                 // full run had established. It also deliberately leaves
-                // `faces_checked` unset, so `/index/check-unprocessed` still
+                // `faces_checked` unset, so `/v1/index/unprocessed` still
                 // reports the photo as needing a real face pass later.
                 Ok(faces) if options.face_pass == FacePass::QualityOnly => {
                     let inputs: Vec<FaceMetricsInput> = faces

--- a/server-rs/crates/lrg-api/src/routes/jobs.rs
+++ b/server-rs/crates/lrg-api/src/routes/jobs.rs
@@ -1,0 +1,53 @@
+//! `GET /v1/jobs/{job_id}` — polling for any async job.
+//!
+//! The registry in `lrg_common::jobs` was always generic, but the only way to
+//! read it used to be `/keywords/cluster/status/{job_id}`, a
+//! keyword-clustering-shaped path whose handler contained nothing specific to
+//! keyword clustering. The next long-running operation would have had to grow
+//! its own near-identical poll route, and clients would have needed to know
+//! which one to call for which job.
+//!
+//! So enqueueing stays with the domain that knows what work to start (e.g.
+//! `POST /v1/keywords/clusters/jobs`), and every one of those returns a
+//! `job_id` plus the `poll_url` to read it back here.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde_json::json;
+
+use crate::state::AppState;
+
+/// The path a job is polled at. Handlers that create jobs hand this to the
+/// client so the poll location is never guessed from the enqueue path.
+pub fn poll_url(job_id: &str) -> String {
+    format!("/v1/jobs/{job_id}")
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/jobs/{job_id}", get(job_status))
+}
+
+/// A finished job is returned once and then dropped, so a 404 here means
+/// either "never existed", "already collected" or "expired after 600s idle" —
+/// which is why the message says so rather than claiming the job is unknown.
+async fn job_status(State(state): State<Arc<AppState>>, Path(job_id): Path<String>) -> Response {
+    match state.jobs.get_job(&job_id) {
+        Some(snapshot) => Json(snapshot.to_json()).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": "job not found — it may have already been collected or expired",
+                "status": null,
+                "result": null,
+            })),
+        )
+            .into_response(),
+    }
+}

--- a/server-rs/crates/lrg-api/src/routes/keywords.rs
+++ b/server-rs/crates/lrg-api/src/routes/keywords.rs
@@ -27,7 +27,7 @@ use lrg_store::IMAGE_TABLE;
 use crate::state::AppState;
 
 /// Sink for `run_clustering`'s stage updates. Async-job callers point this
-/// at the job registry; the synchronous `/keywords/cluster` route passes
+/// at the job registry; the synchronous `/v1/keywords/clusters` route passes
 /// `None` because nobody can observe a job that hasn't been created.
 type ProgressSink<'a> = Option<&'a (dyn Fn(Value) + Send + Sync)>;
 
@@ -39,17 +39,19 @@ fn report(sink: ProgressSink<'_>, progress: Value) {
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
-        .route("/keywords/cluster", axum::routing::post(cluster_keywords))
+        .route("/keywords/clusters", axum::routing::post(cluster_keywords))
+        // The async variant of the same work: POST enqueues a job, GET polls
+        // one by id.
         .route(
-            "/keywords/cluster/start",
+            "/keywords/clusters/jobs",
             axum::routing::post(cluster_keywords_start),
         )
         .route(
-            "/keywords/cluster/status/{job_id}",
+            "/keywords/clusters/jobs/{job_id}",
             axum::routing::get(cluster_keywords_status),
         )
         .route(
-            "/keywords/apply-merges",
+            "/keywords/merges",
             axum::routing::post(keywords_apply_merges),
         )
 }

--- a/server-rs/crates/lrg-api/src/routes/keywords.rs
+++ b/server-rs/crates/lrg-api/src/routes/keywords.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use serde_json::{json, Value};
@@ -40,15 +40,10 @@ fn report(sink: ProgressSink<'_>, progress: Value) {
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
         .route("/keywords/clusters", axum::routing::post(cluster_keywords))
-        // The async variant of the same work: POST enqueues a job, GET polls
-        // one by id.
+        // Enqueues a job; poll it at `GET /v1/jobs/{job_id}`.
         .route(
             "/keywords/clusters/jobs",
             axum::routing::post(cluster_keywords_start),
-        )
-        .route(
-            "/keywords/clusters/jobs/{job_id}",
-            axum::routing::get(cluster_keywords_status),
         )
         .route(
             "/keywords/merges",
@@ -245,23 +240,14 @@ async fn cluster_keywords_start(
 
     (
         StatusCode::ACCEPTED,
-        Json(json!({"job_id": job_id_for_log, "error": null, "warning": null})),
+        Json(json!({
+            "job_id": job_id_for_log,
+            "poll_url": super::jobs::poll_url(&job_id_for_log),
+            "error": null,
+            "warning": null,
+        })),
     )
         .into_response()
-}
-
-async fn cluster_keywords_status(
-    State(state): State<Arc<AppState>>,
-    Path(job_id): Path<String>,
-) -> Response {
-    match state.jobs.get_job(&job_id) {
-        Some(snapshot) => Json(snapshot.to_json()).into_response(),
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "job not found", "status": null, "result": null})),
-        )
-            .into_response(),
-    }
 }
 
 async fn keywords_apply_merges(

--- a/server-rs/crates/lrg-api/src/routes/llm.rs
+++ b/server-rs/crates/lrg-api/src/routes/llm.rs
@@ -39,8 +39,13 @@ pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/llm/catalog", get(catalog))
         .route("/llm/status", get(status))
-        .route("/llm/download/start", post(download_start))
-        .route("/llm/download/status", get(download_status))
+        // POST starts a download, GET reports its progress — the verb is the
+        // method's job, so both share one path.
+        .route("/llm/downloads", post(download_start).get(download_status))
+        // Probing the cloud providers means sending their API keys. POST only:
+        // the old `GET /models` accepted them as query parameters, which land
+        // in access logs and process listings.
+        .route("/llm/providers/models", post(super::server::list_models))
 }
 
 /// Resolve the engine for a request, loading the model if needed.

--- a/server-rs/crates/lrg-api/src/routes/mod.rs
+++ b/server-rs/crates/lrg-api/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod import_;
 pub mod index;
 pub mod index_by_reference;
 pub mod index_upload;
+pub mod jobs;
 pub mod keywords;
 pub mod llm;
 pub(crate) mod route_util;

--- a/server-rs/crates/lrg-api/src/routes/mod.rs
+++ b/server-rs/crates/lrg-api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod assets;
 pub mod bioclip;
+pub mod bootstrap;
 pub mod clip;
 pub mod db;
 pub mod edit;

--- a/server-rs/crates/lrg-api/src/routes/route_util.rs
+++ b/server-rs/crates/lrg-api/src/routes/route_util.rs
@@ -95,7 +95,7 @@ pub(crate) fn compute_scene_tags(siglip: &SiglipModel, image_embedding: &[f32]) 
 /// One `image` part of an upload.
 ///
 /// `filename` stays optional because the callers disagree about the default —
-/// `/index` substitutes `"photo"`, the edit routes keep `None` and let the
+/// `/v1/index/photos` substitutes `"photo"`, the edit routes keep `None` and let the
 /// image sniffer decide — and baking either one in here would silently change
 /// the other's behaviour.
 #[derive(Debug)]
@@ -106,14 +106,14 @@ pub(crate) struct MultipartImage {
 
 /// Everything a multipart upload in this API can carry.
 ///
-/// The four upload routes (`/edit`, `/style_edit`, `/index`, `/training/add`)
+/// The four upload routes (`/v1/edit/recipe`, `/v1/edit/style`, `/v1/index/photos`, `/v1/edit/training`)
 /// had four copies of the same field loop — 49 duplicated lines, and the
 /// widest co-change surface in the crate: a change to how one route reads a
 /// part had to be remembered in three other files. They differ only in which
 /// parts they care about afterwards, which is what this shape captures.
 ///
 /// The raw fields filter and default nothing: `photo_ids` and `uuids` stay
-/// separate (only `/index` distinguishes them), empty values are kept, and
+/// separate (only `/v1/index/photos` distinguishes them), empty values are kept, and
 /// `filename` stays `None` rather than acquiring someone's default. Callers
 /// that want the tidied view take [`MultipartForm::photo_ids_or_uuids`] or
 /// [`MultipartForm::into_single_photo`], which do drop empties.
@@ -150,7 +150,7 @@ impl MultipartForm {
 
     /// Collapses the form to what a single-photo route actually uses.
     ///
-    /// `/edit`, `/style_edit` and `/training/add` each take one image and one
+    /// `/v1/edit/recipe`, `/v1/edit/style` and `/v1/edit/training` each take one image and one
     /// id; this hands them that directly so the call site is a destructuring
     /// `let` rather than four mutable accumulators.
     pub(crate) fn into_single_photo(self) -> SinglePhotoForm {
@@ -296,7 +296,7 @@ mod multipart_tests {
         assert_eq!(form.images.len(), 2);
         assert_eq!(form.images[0].filename.as_deref(), Some("a.jpg"));
         assert_eq!(form.images[1].bytes, b"BBBB");
-        // photo_id and uuid stay apart: only `/index` distinguishes them, and
+        // photo_id and uuid stay apart: only `/v1/index/photos` distinguishes them, and
         // merging here would take that choice away from it.
         assert_eq!(form.photo_ids, vec!["id-a", "id-b"]);
         assert_eq!(form.uuids, vec!["uuid-a"]);
@@ -308,7 +308,7 @@ mod multipart_tests {
 
     #[tokio::test]
     async fn an_image_part_without_a_filename_keeps_none() {
-        // `/index` substitutes "photo" itself; the parser must not decide for it.
+        // `/v1/index/photos` substitutes "photo" itself; the parser must not decide for it.
         let form = parse(&[("image", Some(""), "AAAA")]).await.expect("parses");
         assert_eq!(form.images.len(), 1);
         assert_eq!(form.images[0].filename.as_deref(), Some(""));
@@ -363,7 +363,7 @@ mod multipart_tests {
 
     #[tokio::test]
     async fn single_photo_view_reports_no_image_rather_than_failing() {
-        // `/edit` turns this into its "mismatch between images and photo IDs"
+        // `/v1/edit/recipe` turns this into its "mismatch between images and photo IDs"
         // reply; the parser's job is only to say the image is absent.
         let form = parse(&[("photo_id", None, "id-a")]).await.expect("parses");
         let single = form.into_single_photo();

--- a/server-rs/crates/lrg-api/src/routes/server.rs
+++ b/server-rs/crates/lrg-api/src/routes/server.rs
@@ -19,23 +19,21 @@ use lrg_providers::provider::{build_provider, ProviderSelection};
 
 use crate::state::AppState;
 
+/// The versioned slice of this module. `/ping`, `/shutdown`, `/version` and
+/// `/version/check` are registered by [`super::bootstrap`] instead, off the
+/// root; `initialize` and `list_models` are registered by [`super::db`] and
+/// [`super::llm`], whose domains they belong to.
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/ping", get(ping))
-        .route("/shutdown", post(shutdown))
-        .route("/unload", post(unload))
-        .route("/restart", post(restart))
-        .route("/initialize", post(initialize))
-        .route("/version", get(get_version))
-        .route("/version/check", post(version_check))
-        .route("/health", get(health))
-        .route("/logs", get(get_logs))
-        .route("/logs/raw/{log_type}", get(get_raw_log))
-        .route("/models", get(list_models).post(list_models))
+        .route("/server/unload", post(unload))
+        .route("/server/restart", post(restart))
+        .route("/server/health", get(health))
+        .route("/server/logs", get(get_logs))
+        .route("/server/logs/{log_type}/raw", get(get_raw_log))
 }
 
 #[derive(serde::Deserialize, Default)]
-struct ModelsQuery {
+pub(super) struct ModelsQuery {
     openai_apikey: Option<String>,
     gemini_apikey: Option<String>,
     ollama_base_url: Option<String>,
@@ -50,7 +48,7 @@ struct ModelsQuery {
 /// (`TaskAnalyzeAndIndex.lua`), so a provider absent here is unreachable from
 /// the UI. The long-dead `"qwen"` key, which was always `[]`, is no longer
 /// emitted: the plugin's inner loop produced no entries for it anyway.
-async fn list_models(
+pub(super) async fn list_models(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(q): axum::extract::Query<ModelsQuery>,
     body: Option<Json<Value>>,
@@ -150,7 +148,7 @@ async fn list_models(
     }))
 }
 
-async fn ping() -> &'static str {
+pub(super) async fn ping() -> &'static str {
     "pong"
 }
 
@@ -163,7 +161,7 @@ fn schedule_shutdown(state: Arc<AppState>) {
     });
 }
 
-async fn shutdown(State(state): State<Arc<AppState>>) -> Json<Value> {
+pub(super) async fn shutdown(State(state): State<Arc<AppState>>) -> Json<Value> {
     log::info!("Shutdown request received");
     schedule_shutdown(state);
     Json(json!({"status": "Server is shutting down..."}))
@@ -185,7 +183,10 @@ async fn unload(State(state): State<Arc<AppState>>) -> Json<Value> {
     Json(json!({"status": "Resources unloaded successfully."}))
 }
 
-async fn initialize(State(state): State<Arc<AppState>>, body: Option<Json<Value>>) -> Response {
+pub(super) async fn initialize(
+    State(state): State<Arc<AppState>>,
+    body: Option<Json<Value>>,
+) -> Response {
     let db_path = body
         .as_ref()
         .and_then(|Json(v)| v.get("db_path"))
@@ -223,11 +224,11 @@ async fn initialize(State(state): State<Arc<AppState>>, body: Option<Json<Value>
     Json(json!({"status": "success", "db_path": db_path})).into_response()
 }
 
-async fn get_version() -> Json<Value> {
+pub(super) async fn get_version() -> Json<Value> {
     Json(serde_json::to_value(version::get_backend_version_info()).unwrap())
 }
 
-async fn version_check(body: Option<Json<Value>>) -> Json<Value> {
+pub(super) async fn version_check(body: Option<Json<Value>>) -> Json<Value> {
     let data = body.map(|Json(v)| v).unwrap_or_else(|| json!({}));
     let plugin_version = data.get("plugin_version").and_then(Value::as_str);
     let plugin_release_tag = data.get("plugin_release_tag").and_then(Value::as_str);

--- a/server-rs/crates/lrg-api/src/routes/style_edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/style_edit.rs
@@ -1,4 +1,4 @@
-//! `POST /style_edit` — port of `routes/style_edit.py`: the LLM-free
+//! `POST /v1/edit/style` — port of `routes/style_edit.py`: the LLM-free
 //! style-matched edit endpoint. Retrieves the photo's own CLIP embedding
 //! (if already indexed), scores training examples on visual + exposure +
 //! scene + time-of-day proximity via `lrg-analysis::style_engine`, and
@@ -28,7 +28,7 @@ use crate::routes::route_util::{compute_scene_tags, local_hour, parse_multipart,
 use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
-    axum::Router::new().route("/style_edit", axum::routing::post(style_edit))
+    axum::Router::new().route("/edit/style", axum::routing::post(style_edit))
 }
 
 fn record_to_candidate(id: &str, meta: &Map<String, Value>, distance: f64) -> TrainingCandidate {

--- a/server-rs/crates/lrg-api/src/routes/training.rs
+++ b/server-rs/crates/lrg-api/src/routes/training.rs
@@ -23,15 +23,24 @@ use crate::state::AppState;
 
 pub fn router() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
-        .route("/training/add", axum::routing::post(add_training_example))
-        .route("/training/list", axum::routing::get(list_training_examples))
-        .route("/training/stats", axum::routing::get(get_training_stats))
-        .route("/training/count", axum::routing::get(get_training_count))
         .route(
-            "/training/{*photo_id}",
+            "/edit/training",
+            axum::routing::post(add_training_example)
+                .get(list_training_examples)
+                .delete(clear_training_examples),
+        )
+        .route(
+            "/edit/training/stats",
+            axum::routing::get(get_training_stats),
+        )
+        .route(
+            "/edit/training/count",
+            axum::routing::get(get_training_count),
+        )
+        .route(
+            "/edit/training/{*photo_id}",
             axum::routing::delete(delete_training_example),
         )
-        .route("/training", axum::routing::delete(clear_training_examples))
 }
 
 fn err(status: StatusCode, msg: impl Into<String>) -> Response {

--- a/server-rs/crates/lrg-api/src/state.rs
+++ b/server-rs/crates/lrg-api/src/state.rs
@@ -36,7 +36,7 @@ pub struct AppState {
     /// hundred MB resident, so leaving it out of `run_maintenance` would keep
     /// that memory pinned for the life of the process.
     pub bioclip: Arc<BioclipModel>,
-    /// Global — port of `services/jobs.py`, backs `/v1/keywords/clusters/jobs`.
+    /// Global — port of `services/jobs.py`, read back through `GET /v1/jobs/{job_id}`.
     pub jobs: Arc<JobRegistry>,
     /// CLIP-IQA prompt embeddings, computed on first use and kept for the
     /// process lifetime.

--- a/server-rs/crates/lrg-api/src/state.rs
+++ b/server-rs/crates/lrg-api/src/state.rs
@@ -36,7 +36,7 @@ pub struct AppState {
     /// hundred MB resident, so leaving it out of `run_maintenance` would keep
     /// that memory pinned for the life of the process.
     pub bioclip: Arc<BioclipModel>,
-    /// Global — port of `services/jobs.py`, backs `/keywords/cluster/start`.
+    /// Global — port of `services/jobs.py`, backs `/v1/keywords/clusters/jobs`.
     pub jobs: Arc<JobRegistry>,
     /// CLIP-IQA prompt embeddings, computed on first use and kept for the
     /// process lifetime.

--- a/server-rs/crates/lrg-api/tests/contract.rs
+++ b/server-rs/crates/lrg-api/tests/contract.rs
@@ -1112,3 +1112,45 @@ async fn training_delete_decodes_a_path_shaped_photo_id() {
         "wildcard capture should decode back to {raw:?}, got {body}"
     );
 }
+
+/// Job polling is generic and lives at one path, rather than each async
+/// operation growing its own status route. The keyword-clustering enqueue must
+/// therefore hand back where to poll, not just an opaque id.
+#[tokio::test]
+async fn unknown_job_is_a_404_with_a_reason() {
+    let (app, _) = fresh_app();
+    let response = app
+        .oneshot(
+            Request::get("/v1/jobs/does-not-exist")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = body_json(response).await;
+    assert!(json["status"].is_null());
+    // A collected-or-expired job is indistinguishable from a bad id here, so
+    // the message has to say that rather than assert the id was wrong.
+    let error = json["error"].as_str().unwrap();
+    assert!(
+        error.contains("collected") || error.contains("expired"),
+        "404 should explain the one-shot/TTL semantics, got {error:?}"
+    );
+}
+
+/// The old keyword-shaped poll route is gone; nothing should still answer on it.
+#[tokio::test]
+async fn keyword_specific_job_poll_route_is_gone() {
+    let (app, _) = fresh_app();
+    let response = app
+        .oneshot(
+            Request::get("/v1/keywords/clusters/jobs/abc")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/server-rs/crates/lrg-api/tests/contract.rs
+++ b/server-rs/crates/lrg-api/tests/contract.rs
@@ -116,7 +116,7 @@ async fn initialize_requires_db_path() {
     let (app, _) = fresh_app();
     let response = app
         .oneshot(
-            Request::post("/initialize")
+            Request::post("/v1/db/bind")
                 .header("content-type", "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -137,7 +137,7 @@ async fn initialize_writes_handshake_files_and_is_idempotent() {
 
     let (app, state) = fresh_app();
     let request = |path: &str| {
-        Request::post("/initialize")
+        Request::post("/v1/db/bind")
             .header("content-type", "application/json")
             .body(Body::from(
                 serde_json::json!({ "db_path": path }).to_string(),
@@ -202,7 +202,7 @@ async fn middleware_auto_binds_db_path_from_query_string() {
 
     let (app, state) = fresh_app();
     let uri = format!(
-        "/health?db_path={}",
+        "/v1/server/health?db_path={}",
         db_path.to_str().unwrap().replace('/', "%2F")
     );
     let response = app
@@ -230,7 +230,11 @@ async fn shutdown_and_restart_respond_before_exiting() {
     );
 
     let response = app
-        .oneshot(Request::post("/restart").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::post("/v1/server/restart")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     let json = body_json(response).await;
@@ -241,7 +245,11 @@ async fn shutdown_and_restart_respond_before_exiting() {
 async fn health_reports_model_states() {
     let (app, _) = fresh_app();
     let response = app
-        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get("/v1/server/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
@@ -255,7 +263,7 @@ async fn unknown_raw_log_type_returns_404() {
     let (app, _) = fresh_app();
     let response = app
         .oneshot(
-            Request::get("/logs/raw/nonsense")
+            Request::get("/v1/server/logs/nonsense/raw")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -301,7 +309,7 @@ async fn check_unprocessed_reports_only_missing_work() {
 
     let response = app
         .oneshot(
-            Request::post("/index/check-unprocessed")
+            Request::post("/v1/index/unprocessed")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::json!({
@@ -325,7 +333,7 @@ async fn check_unprocessed_reports_only_missing_work() {
 }
 
 // ---------------------------------------------------------------------------
-// /cull + /group_similar
+// /v1/cull/grade + /v1/cull/groups
 //
 // These had no contract coverage at all, which is how several of the fields
 // below drifted: `debug` was always serialized even though the plugin never
@@ -369,7 +377,7 @@ async fn seed_burst(state: &Arc<AppState>, count: usize, with_embedding: bool) {
 async fn cull_request(app: axum::Router, body: serde_json::Value) -> serde_json::Value {
     let response = app
         .oneshot(
-            Request::post("/cull")
+            Request::post("/v1/cull/grade")
                 .header("content-type", "application/json")
                 .body(Body::from(body.to_string()))
                 .unwrap(),
@@ -528,7 +536,7 @@ async fn cull_rejects_unknown_preset_with_the_available_list() {
     let (app, _) = fresh_app();
     let response = app
         .oneshot(
-            Request::post("/cull")
+            Request::post("/v1/cull/grade")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::json!({"photo_ids": ["a"], "culling_preset": "nope"}).to_string(),
@@ -549,7 +557,7 @@ async fn group_similar_requires_photo_ids() {
     let (app, _) = fresh_app();
     let response = app
         .oneshot(
-            Request::post("/group_similar")
+            Request::post("/v1/cull/groups")
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::json!({}).to_string()))
                 .unwrap(),
@@ -617,7 +625,7 @@ async fn check_unprocessed_understands_the_cull_task() {
 
     let response = app
         .oneshot(
-            Request::post("/index/check-unprocessed")
+            Request::post("/v1/index/unprocessed")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::json!({
@@ -723,7 +731,7 @@ async fn check_unprocessed_requeues_faces_from_a_superseded_model() {
 
     let response = app
         .oneshot(
-            Request::post("/index/check-unprocessed")
+            Request::post("/v1/index/unprocessed")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::json!({
@@ -790,7 +798,7 @@ async fn cluster_leaves_faces_from_a_superseded_model_unassigned() {
 
     let response = app
         .oneshot(
-            Request::post("/faces/cluster")
+            Request::post("/v1/faces/cluster")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     serde_json::json!({
@@ -826,7 +834,7 @@ async fn cluster_leaves_faces_from_a_superseded_model_unassigned() {
 }
 
 // ---------------------------------------------------------------------------
-// /style_edit
+// /v1/edit/style
 //
 // The plugin's edit workflow routes here whenever "apply my saved edit style" is
 // on, which is the default, so this is the first endpoint a new user's edit run
@@ -834,7 +842,7 @@ async fn cluster_leaves_faces_from_a_superseded_model_unassigned() {
 // shapes below.
 // ---------------------------------------------------------------------------
 
-/// Builds a `multipart/form-data` body. `/style_edit` and `/edit` are the only
+/// Builds a `multipart/form-data` body. `/v1/edit/style` and `/v1/edit/recipe` are the only
 /// multipart endpoints the plugin calls, and both are driven from
 /// `_requestMultipart` in APISearchIndex.lua.
 fn multipart_body(fields: &[(&str, &str)], image: Option<(&str, &[u8])>) -> (String, Vec<u8>) {
@@ -870,7 +878,7 @@ async fn style_edit_request(
     let (content_type, body) = multipart_body(fields, image);
     let response = app
         .oneshot(
-            Request::post("/style_edit")
+            Request::post("/v1/edit/style")
                 .header("content-type", content_type)
                 .body(Body::from(body))
                 .unwrap(),
@@ -942,4 +950,165 @@ async fn style_edit_without_training_data_is_an_error_the_plugin_must_handle() {
     assert_eq!(json["engine"], "none");
     assert_eq!(json["matched_examples"], 0);
     assert!(json["error"].is_string());
+}
+
+// ---------------------------------------------------------------------------
+// Path layout: the `/v1` prefix and the unversioned bootstrap contract
+// ---------------------------------------------------------------------------
+
+/// The five paths a *new* plug-in must be able to reach on an *old* backend to
+/// pull the install forward. `build_router` merges them at the root instead of
+/// nesting them, and versioning any of them would mean a half-updated machine
+/// could not repair itself. `/update/apply` is covered by its own tests; the
+/// four lifecycle paths are asserted here.
+#[tokio::test]
+async fn bootstrap_contract_is_served_unversioned() {
+    for (method, path) in [
+        ("GET", "/ping"),
+        ("GET", "/version"),
+        ("POST", "/version/check"),
+        ("POST", "/update/apply"),
+    ] {
+        let (app, _) = fresh_app();
+        let request = Request::builder()
+            .method(method)
+            .uri(path)
+            .body(Body::empty())
+            .unwrap();
+        let status = app.oneshot(request).await.unwrap().status();
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "{method} {path} must stay at the root — a plug-in that updated \
+             ahead of its backend reaches the old binary through these"
+        );
+    }
+}
+
+/// ...and the corollary: they are *only* at the root. A `/v1` alias would
+/// invite new code to depend on it, quietly re-coupling the two halves.
+#[tokio::test]
+async fn bootstrap_contract_is_not_also_versioned() {
+    for path in [
+        "/v1/ping",
+        "/v1/version",
+        "/v1/shutdown",
+        "/v1/update/apply",
+    ] {
+        let (app, _) = fresh_app();
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "{path} should not exist; the bootstrap contract lives at the root only"
+        );
+    }
+}
+
+/// Everything else moved under `/v1`, with no aliases left behind. This is a
+/// hard cutover, so the old spellings must be gone rather than quietly working
+/// and letting a caller keep using them.
+#[tokio::test]
+async fn pre_v1_paths_are_gone() {
+    for (method, path) in [
+        ("POST", "/index"),
+        ("POST", "/index_by_reference"),
+        ("POST", "/get"),
+        ("GET", "/get/ids"),
+        ("POST", "/remove"),
+        ("POST", "/find_similar"),
+        ("POST", "/group_similar"),
+        ("POST", "/cull"),
+        ("POST", "/edit"),
+        ("POST", "/edit_base64"),
+        ("POST", "/style_edit"),
+        ("POST", "/initialize"),
+        ("GET", "/health"),
+        ("GET", "/logs"),
+        ("GET", "/models"),
+        ("GET", "/clip/status"),
+        ("GET", "/assets/status"),
+        ("GET", "/llm/catalog"),
+        ("GET", "/db/stats"),
+        ("POST", "/training/add"),
+        ("POST", "/keywords/cluster"),
+    ] {
+        let (app, _) = fresh_app();
+        let request = Request::builder()
+            .method(method)
+            .uri(path)
+            .body(Body::empty())
+            .unwrap();
+        let status = app.oneshot(request).await.unwrap().status();
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "{method} {path} is a pre-/v1 path and must no longer be served"
+        );
+    }
+}
+
+/// The db_path auto-bind middleware matches on the *full* request path, so the
+/// bypass list had to learn the `/v1` prefix when `/initialize` became
+/// `/v1/db/bind`. A stale entry there would silently re-enable binding on the
+/// one route that handles db_path itself.
+#[tokio::test]
+async fn db_bind_is_reachable_under_v1() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("lrgenius.db");
+    let (app, state) = fresh_app();
+
+    let body = serde_json::json!({ "db_path": db_path.to_str().unwrap() });
+    let response = app
+        .oneshot(
+            Request::post("/v1/db/bind")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(state.db_path(), Some(db_path));
+}
+
+/// `photo_id` on the training routes is a file path, so it arrives
+/// percent-encoded from `SearchIndexAPI.url` and has to survive the wildcard
+/// capture intact. The plug-in used to concatenate it raw, which broke on any
+/// id containing `?`, `#` or a space; encoding it only helps if axum decodes
+/// the segment back, so assert the round-trip rather than assume it.
+#[tokio::test]
+async fn training_delete_decodes_a_path_shaped_photo_id() {
+    let raw = "/Users/bm/My Photos/a b?c#d.jpg";
+    let encoded = raw
+        .bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'~' | b'-' => {
+                (b as char).to_string()
+            }
+            _ => format!("%{b:02X}"),
+        })
+        .collect::<String>();
+
+    let (app, _) = fresh_app();
+    let response = app
+        .oneshot(
+            Request::delete(format!("/v1/edit/training/{encoded}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Unbound store: the handler 404s and echoes the id it actually received.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = body_string(response).await;
+    assert!(
+        body.contains(raw),
+        "wildcard capture should decode back to {raw:?}, got {body}"
+    );
 }

--- a/server-rs/crates/lrg-common/src/config.rs
+++ b/server-rs/crates/lrg-common/src/config.rs
@@ -17,11 +17,25 @@ pub fn host() -> String {
     env::var("GENIUSAI_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string())
 }
 
+/// The listen port, from `GENIUSAI_PORT`.
+///
+/// A value that will not parse falls back to the default rather than aborting
+/// startup — but it says so. Silently listening on 19819 after being asked for
+/// something else surfaces to the user as "the backend is not responding",
+/// with nothing anywhere connecting that to a typo in an env var.
 pub fn port() -> u16 {
-    env::var("GENIUSAI_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_PORT)
+    let Ok(raw) = env::var("GENIUSAI_PORT") else {
+        return DEFAULT_PORT;
+    };
+    match raw.parse() {
+        Ok(port) => port,
+        Err(_) => {
+            log::warn!(
+                "GENIUSAI_PORT={raw:?} is not a valid port number; falling back to {DEFAULT_PORT}"
+            );
+            DEFAULT_PORT
+        }
+    }
 }
 
 /// Number of rotated log backups kept on startup (GENIUSAI_LOG_ROTATE_BACKUPS,

--- a/server-rs/crates/lrg-common/src/jobs.rs
+++ b/server-rs/crates/lrg-common/src/jobs.rs
@@ -1,5 +1,5 @@
 //! Port of `services/jobs.py`: a generic in-memory async-job registry
-//! (used today by keyword clustering, `/keywords/cluster/start`). Jobs
+//! (used today by keyword clustering, `/v1/keywords/clusters/jobs`). Jobs
 //! expire after 600s of inactivity; `get_job` on a finished job
 //! returns it once and then removes it — matching Python's one-shot
 //! poll-then-gone semantics exactly.

--- a/server-rs/crates/lrg-llama/src/engine.rs
+++ b/server-rs/crates/lrg-llama/src/engine.rs
@@ -45,7 +45,7 @@ impl Default for LlamaEngineConfig {
     }
 }
 
-/// What the engine settled on after inspecting the model, for `/llm/status`
+/// What the engine settled on after inspecting the model, for `/v1/llm/status`
 /// and for the logs.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct EngineInfo {

--- a/server-rs/crates/lrg-ml/src/bioclip.rs
+++ b/server-rs/crates/lrg-ml/src/bioclip.rs
@@ -517,7 +517,7 @@ impl BioclipModel {
     /// missing or unreadable.
     ///
     /// Deliberately reads the file rather than reporting the loaded model's
-    /// version: this is called by `/index/check-unprocessed`, which runs
+    /// version: this is called by `/v1/index/unprocessed`, which runs
     /// *before* any indexing and must not be the thing that pulls a 608 MB
     /// session and a 258 MB head into memory. An earlier version returned
     /// `None` until the model had loaded once and treated that as "no version

--- a/server-rs/crates/lrg-ml/src/model_paths.rs
+++ b/server-rs/crates/lrg-ml/src/model_paths.rs
@@ -118,7 +118,7 @@ pub fn resolve_bioclip() -> BioclipModelPaths {
 /// InsightFace's and the only way to get them was to have run its Python
 /// library. YuNet and FaceNet are redistributable, so they are published with
 /// this project and land here like every other model family — which is what
-/// lets `/assets/download/start` fetch them and lets face detection count
+/// lets `/v1/models/assets/downloads` fetch them and lets face detection count
 /// toward the overall readiness flag.
 pub fn resolve_face() -> FaceModelPaths {
     let dir = default_models_dir();

--- a/server-rs/crates/lrg-mlx/src/engine.rs
+++ b/server-rs/crates/lrg-mlx/src/engine.rs
@@ -26,7 +26,7 @@ pub struct MlxEngineConfig {
     pub sidecar_path: Option<PathBuf>,
 }
 
-/// What the sidecar reported after loading, for `/llm/status` and the logs.
+/// What the sidecar reported after loading, for `/v1/llm/status` and the logs.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct EngineInfo {
     pub model_path: String,

--- a/server-rs/crates/lrg-providers/src/edit_recipe.rs
+++ b/server-rs/crates/lrg-providers/src/edit_recipe.rs
@@ -1,7 +1,7 @@
 //! Port of `utils/edit_recipe.py`: the canonical Lightroom edit-recipe
 //! contract shared by every edit-capable provider — field ranges, the
 //! OpenAI/Gemini JSON schemas built from those ranges, LLM-output
-//! normalization/clamping, and per-control filtering for the `/edit`
+//! normalization/clamping, and per-control filtering for the `/v1/edit/recipe`
 //! endpoint's UI toggles.
 
 use std::sync::OnceLock;

--- a/server-rs/crates/lrg-providers/src/lib.rs
+++ b/server-rs/crates/lrg-providers/src/lib.rs
@@ -1,7 +1,7 @@
 //! LLM provider REST clients for metadata generation, plus the
 //! edit-recipe contract (`edit_recipe`) shared by all edit-capable
 //! providers. Gemini, LM Studio, and Vertex AI providers land in M8
-//! alongside the `/edit` endpoint.
+//! alongside the `/v1/edit/recipe` endpoint.
 
 pub mod edit_recipe;
 pub mod gemini;

--- a/server-rs/crates/lrg-server/src/main.rs
+++ b/server-rs/crates/lrg-server/src/main.rs
@@ -131,7 +131,7 @@ fn main() {
 
 /// Spawns the freshly-swapped-in binary, detached, with no arguments —
 /// matching how the installer/OS would normally launch it (the plugin
-/// re-calls `/initialize` once the new process is up, same as any other
+/// re-calls `/v1/db/bind` once the new process is up, same as any other
 /// restart). On Windows this goes through `run_hidden.vbs` next to the
 /// exe (installer-placed) to avoid a console flash; falls back to a
 /// direct spawn if that wrapper isn't present (dev/manual runs).

--- a/server-rs/crates/lrg-store/src/lib.rs
+++ b/server-rs/crates/lrg-store/src/lib.rs
@@ -428,7 +428,7 @@ impl Store {
     }
 
     /// Bytes currently held by LanceDB's index + file-metadata caches.
-    /// Walks the caches, so it's for diagnostics (`/db/stats`, the
+    /// Walks the caches, so it's for diagnostics (`/v1/db/stats`, the
     /// maintenance log line) — not for a hot path.
     pub fn session_bytes(&self) -> u64 {
         self.session.size_bytes()

--- a/server-rs/crates/lrg-store/src/meta.rs
+++ b/server-rs/crates/lrg-store/src/meta.rs
@@ -70,12 +70,12 @@ pub fn has_embedding(metadata: &Map<String, Value>) -> bool {
         .unwrap_or(true)
 }
 
-/// Keys holding AI-generated metadata, cleared by /remove/metadata while
+/// Keys holding AI-generated metadata, cleared by /v1/photos/metadata/remove while
 /// the photo stays indexed (port of AI_METADATA_KEYS).
 ///
 /// `species_checked` is in here on purpose: clearing AI metadata has to mean
 /// "recompute", and leaving the done-marker behind would make
-/// `/index/check-unprocessed` report the photo as finished forever.
+/// `/v1/index/unprocessed` report the photo as finished forever.
 pub const AI_METADATA_KEYS: [&str; 22] = [
     "title",
     "caption",

--- a/server-rs/scripts/export_face_models.py
+++ b/server-rs/scripts/export_face_models.py
@@ -21,7 +21,7 @@
 Both replace InsightFace's ``buffalo_l`` pack (SCRFD + ArcFace), which is
 licensed for non-commercial research only and so could never be published with
 this project. YuNet is Apache-2.0 and facenet-pytorch is MIT, which is what
-lets ``/assets/download/start`` fetch these like every other model family.
+lets ``/v1/models/assets/downloads`` fetch these like every other model family.
 
 **This script deliberately does not join ``scripts/pyproject.toml``.**
 ``facenet-pytorch`` pins ``torch<2.3`` and ``numpy<2.0``; the shared export


### PR DESCRIPTION
The backend served 63 paths from 20 modules, all merged flat off the root with no version prefix. Every module hard-coded its own full path, so the grouping was a convention nothing enforced — and it had drifted:

- three casing styles at once — `/find_similar`, `/index/check-unprocessed`, `/faces/detect`
- un-namespaced top-level verbs — `/get`, `/remove`, `/cull`, `/unload`
- module names that no longer matched the paths they served (`routes/index.rs` owned `/get`, `/remove`, `/sync/*`)
- payload encoding baked into the path — `/edit` vs `/edit_base64`
- four near-identical `status` + `download/start` + `download/status` triples with no shared root

Paths are now `/v1/<domain>/<resource>`, with the prefix applied once by `Router::nest` in `build_router` rather than repeated in 57 literals. Modules still spell their own domain path, so a path stays greppable across Rust, Lua and the docs.

## The frozen bootstrap contract

Five paths deliberately stay unversioned: `/ping`, `/version`, `/version/check`, `/shutdown`, `/update/apply`.

`Util.waitForServerDialog` drives ping → version-check → shutdown against **whatever backend is already installed**, and `applyUpdate` posts to `/update/apply` on that same old binary. These are what a *new* plug-in uses to reach an *old* server, so versioning them would mean a plug-in that updated ahead of its backend could not repair the install — the mechanism needed to recover would be the thing that broke.

Freezing exactly these is what makes the cutover safe for the other 58. They now live in `routes/bootstrap.rs` with that reasoning recorded, and tests assert they are served at the root **and** are not also aliased under `/v1`.

No aliases anywhere else: the old spellings 404 rather than quietly working.

## Two fixes that fell out

- **API keys out of the query string.** `GET /models` accepted `openai_apikey` and `gemini_apikey` as query parameters, which land in access logs and process listings. Now `POST /v1/llm/providers/models` only. The plug-in already sent a JSON body, so nothing changed there.
- **Unencoded path ids.** Six call sites concatenated ids into URLs raw, including `photo_id`, which is a *file path*. `SearchIndexAPI.url(key, ...)` now encodes each segment; a test covers a `photo_id` containing `/`, spaces, `?` and `#` surviving the wildcard capture, none of which worked before.

## Also here

- **`GET /v1/jobs/{job_id}`** — the job registry was always generic but could only be read through a keyword-clustering-shaped path. Enqueueing stays with the domain that starts the work; its 202 now carries a `poll_url` beside the `job_id`.
- **`GENIUSAI_HOST` / `GENIUSAI_PORT` documented.** They always worked and are how the Docker image binds `0.0.0.0`, but appeared nowhere outside docker-compose. An unparseable port still falls back to 19819, but now warns — the old failure mode was a silent fallback surfacing to the user as "the backend is not responding".
- **Plug-in image assets ship in the installer.** The packaging step copied only `*.lua`, so `icon.ico`, `ok.png` and `nok.png` never reached the installed bundle.

## Verification

`cargo clippy --workspace --all-targets` clean · **496 tests, 0 failures** · `check-docs.py` clean · `luacheck` 0/47 files · `stylua` clean · `busted` 241 passing.

Live-tested against a running binary on a non-default port: all 57 routes, the frozen set at the root, the frozen set absent under `/v1`, 15 pre-`/v1` paths returning 404, and a full enqueue → `poll_url` → progress round-trip.

`release.yml`'s smoke test needed no path changes — it only calls `/ping` and `/shutdown`, both frozen.

## Deliberately not done

`/v1/edit/recipe` and `/v1/edit/recipe/base64` remain two paths, as do `/v1/index/photos` and `/v1/index/photos/by-path` — merging them by `Content-Type` was out of scope. `GET /v1/search` keeps its `POST` twin, which the plug-in uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kKm8pXMnhjdrMvz7csZCj
