### PR TITLE
Sanitize request-supplied strings in logs; move Gemini API key to header

### DIFF
--- a/.github/workflows/golden-tests-full.yml
+++ b/.github/workflows/golden-tests-full.yml
@@ -18,6 +18,10 @@ on:
     - cron: '30 4 * * *'
   workflow_dispatch: {}
 
+# Only ever reads the checkout; the model assets come from public releases.
+permissions:
+  contents: read
+
 jobs:
   golden-tests:
     name: Goldens with real model assets

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,5 +1,10 @@
 name: "Lint/format check"
 on: [push, pull_request]
+
+# Only ever reads the checkout; nothing here writes back to the repository.
+permissions:
+  contents: read
+
 jobs:
   format-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lua-tests.yml
+++ b/.github/workflows/lua-tests.yml
@@ -11,6 +11,10 @@ on:
       - "plugin/**"
       - ".busted"
       - ".github/workflows/lua-tests.yml"
+# Only ever reads the checkout; nothing here writes back to the repository.
+permissions:
+  contents: read
+
 jobs:
   busted:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
         type: boolean
         default: false
 
+# Default for every job below; the jobs that need more (contents: write to
+# publish the release, packages: write to push images) raise it themselves.
+permissions:
+  contents: read
+
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
@@ -37,6 +42,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: [validate-tag]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      # The SignPath action downloads the just-uploaded artifact through the
+      # Actions API, which the contents scope alone does not cover.
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/server-rs-tests.yml
+++ b/.github/workflows/server-rs-tests.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - 'server-rs/**'
       - '.github/workflows/server-rs-tests.yml'
+# Only ever reads the checkout; nothing here writes back to the repository.
+permissions:
+  contents: read
+
 jobs:
   cargo-test:
     runs-on: ubuntu-latest

--- a/scripts/repowise_pr_report.py
+++ b/scripts/repowise_pr_report.py
@@ -281,8 +281,12 @@ def render(base: str, head: str, repo: Path) -> str:
     out += findings_section(files, head_health, base_health)
     out += [
         "",
-        "<sub>Advisory only — this check never fails a build. "
-        "Health is 1–10, higher is better.</sub>",
+        # Parenthesised so the wrap reads as one string, not as two list items
+        # with a missing comma.
+        (
+            "<sub>Advisory only — this check never fails a build. "
+            "Health is 1–10, higher is better.</sub>"
+        ),
     ]
     return "\n".join(out)
 

--- a/server-rs/crates/lrg-api/src/routes/faces.rs
+++ b/server-rs/crates/lrg-api/src/routes/faces.rs
@@ -34,6 +34,7 @@ use lrg_analysis::face_cluster::{self, ClusterParams, FaceInput, QualityGate};
 use lrg_analysis::{clustering, persons};
 use lrg_store::{StoreRecord, FACE_TABLE};
 
+use crate::routes::route_util::log_safe;
 use crate::state::AppState;
 
 pub fn router() -> Router<Arc<AppState>> {
@@ -759,7 +760,10 @@ async fn person_thumbnail(
     State(state): State<Arc<AppState>>,
     UrlPath(person_id): UrlPath<String>,
 ) -> Response {
-    log::info!("Get person thumbnail request received for person_id={person_id}");
+    log::info!(
+        "Get person thumbnail request received for person_id={}",
+        log_safe(&person_id)
+    );
     let Some(store) = state.store() else {
         return Json(json!({"status": "ok", "person_id": person_id, "thumbnail": ""}))
             .into_response();
@@ -796,7 +800,10 @@ async fn set_person_name(
     UrlPath(person_id): UrlPath<String>,
     body: Option<Json<Value>>,
 ) -> Response {
-    log::info!("Set person name request received for person_id={person_id}");
+    log::info!(
+        "Set person name request received for person_id={}",
+        log_safe(&person_id)
+    );
     let name = body
         .as_ref()
         .and_then(|Json(v)| v.get("name"))
@@ -829,7 +836,10 @@ async fn set_person_name(
                 // The name is already saved, so this is a degraded success and
                 // has to be reported as one: the user would otherwise believe
                 // the naming also pinned the cluster.
-                log::warn!("Confirming the faces of {person_id} failed: {e}");
+                log::warn!(
+                    "Confirming the faces of {} failed: {e}",
+                    log_safe(&person_id)
+                );
                 warnings.push(format!(
                     "The name was saved, but these faces could not be confirmed, so the next \
                      “Cluster faces” run may regroup them: {e}"
@@ -889,7 +899,7 @@ async fn confirm_person_faces(state: &AppState, person_id: &str) -> Result<usize
         .upsert(FACE_TABLE, &updated)
         .await
         .map_err(|e| e.to_string())?;
-    log::info!("Naming {person_id} confirmed {count} face(s).");
+    log::info!("Naming {} confirmed {count} face(s).", log_safe(person_id));
     Ok(count)
 }
 
@@ -897,7 +907,10 @@ async fn person_photos(
     State(state): State<Arc<AppState>>,
     UrlPath(person_id): UrlPath<String>,
 ) -> Response {
-    log::info!("Get photos for person request received for person_id={person_id}");
+    log::info!(
+        "Get photos for person request received for person_id={}",
+        log_safe(&person_id)
+    );
     let Some(store) = state.store() else {
         return Json(
             json!({"status": "ok", "person_id": person_id, "photo_ids": [], "photo_uuids": []}),
@@ -960,7 +973,10 @@ async fn person_faces(
     UrlPath(person_id): UrlPath<String>,
     Query(params): Query<PersonFacesQuery>,
 ) -> Response {
-    log::info!("Get faces for person request received for person_id={person_id}");
+    log::info!(
+        "Get faces for person request received for person_id={}",
+        log_safe(&person_id)
+    );
     let limit = params
         .limit
         .unwrap_or(PERSON_FACES_MAX_LIMIT)
@@ -1012,7 +1028,10 @@ async fn person_faces(
         Err(e) => {
             // Distances are a diagnostic, not the content: losing them should
             // not cost the user the face grid they asked for.
-            log::warn!("Could not load embeddings for {person_id}: {e}");
+            log::warn!(
+                "Could not load embeddings for {}: {e}",
+                log_safe(&person_id)
+            );
             HashMap::new()
         }
     };
@@ -1285,7 +1304,10 @@ async fn assign_faces(State(state): State<Arc<AppState>>, body: Option<Json<Valu
             request.face_ids.len()
         ));
     }
-    log::info!("Assigned {count} face(s) to person_id=\"{target}\"");
+    log::info!(
+        "Assigned {count} face(s) to person_id=\"{}\"",
+        log_safe(&target)
+    );
     Json(json!({
         "status": "ok",
         "person_id": target,
@@ -1470,8 +1492,9 @@ async fn merge_persons(State(state): State<Arc<AppState>>, body: Option<Json<Val
 
     let merged_from: Vec<&String> = sources.iter().filter(|p| *p != &target).collect();
     log::info!(
-        "Merged {} person(s) into {target}: {moved} face(s) moved, {touched} pinned.",
-        merged_from.len()
+        "Merged {} person(s) into {}: {moved} face(s) moved, {touched} pinned.",
+        merged_from.len(),
+        log_safe(&target)
     );
     Json(json!({
         "status": "ok",

--- a/server-rs/crates/lrg-api/src/routes/route_util.rs
+++ b/server-rs/crates/lrg-api/src/routes/route_util.rs
@@ -1,8 +1,10 @@
-//! Small helpers shared by `training.rs`, `style_edit.rs`, `group_similar.rs`
-//! and `index_upload.rs`: multipart request parsing, local-hour resolution for
-//! time-of-day bucketing, CLIP zero-shot scene-tag probing, and the CLIP-IQA
-//! prompt-set cache.
+//! Small helpers shared by `training.rs`, `style_edit.rs`, `group_similar.rs`,
+//! `index_upload.rs` and `faces.rs`: multipart request parsing, local-hour
+//! resolution for time-of-day bucketing, CLIP zero-shot scene-tag probing, the
+//! CLIP-IQA prompt-set cache, and sanitising request-supplied text for the
+//! log.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use axum::extract::Multipart;
@@ -13,6 +15,29 @@ use lrg_ml::clip_iqa::{IqaPrompts, PromptSet};
 use lrg_ml::siglip::{l2_normalize, SiglipModel};
 
 use crate::state::AppState;
+
+/// Make a request-supplied string safe to write into the log.
+///
+/// Ids and names arrive from the plugin and from the People page, which means
+/// they arrive over HTTP and can contain anything — including the newlines
+/// that would let a crafted `person_id` write what looks like its own log
+/// line ("log injection"). Control characters are replaced so a value can
+/// only ever be *one* line of the log, whatever it contains.
+///
+/// Borrows in the normal case: a well-formed id costs a scan and no
+/// allocation.
+pub(crate) fn log_safe(value: &str) -> Cow<'_, str> {
+    if value.chars().any(char::is_control) {
+        Cow::Owned(
+            value
+                .chars()
+                .map(|c| if c.is_control() { '\u{fffd}' } else { c })
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(value)
+    }
+}
 
 /// Local-hour equivalent of Python's `datetime.fromtimestamp(unix).hour`.
 pub(crate) fn local_hour(capture_time_unix: Option<f64>) -> Option<u32> {
@@ -228,6 +253,28 @@ pub(crate) async fn parse_multipart(multipart: &mut Multipart) -> Result<Multipa
         }
     }
     Ok(form)
+}
+
+#[cfg(test)]
+mod log_safe_tests {
+    use super::log_safe;
+
+    #[test]
+    fn an_ordinary_id_is_returned_untouched() {
+        assert_eq!(log_safe("person_12"), "person_12");
+    }
+
+    #[test]
+    fn a_newline_cannot_start_a_second_log_line() {
+        let forged = log_safe("person_12\nINFO  Deleted the catalog");
+        assert!(!forged.contains('\n'), "{forged}");
+        assert!(forged.starts_with("person_12"), "{forged}");
+    }
+
+    #[test]
+    fn non_ascii_names_survive() {
+        assert_eq!(log_safe("Renée 中村"), "Renée 中村");
+    }
 }
 
 #[cfg(test)]

--- a/server-rs/crates/lrg-providers/src/gemini.rs
+++ b/server-rs/crates/lrg-providers/src/gemini.rs
@@ -29,6 +29,14 @@ use crate::types::{
 const DEFAULT_MAX_TOKENS: u32 = 2048;
 const API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
 
+/// Gemini accepts the API key either as a `?key=` query parameter or in this
+/// header. The header is the one to use: a URL travels into places a header
+/// does not — `reqwest`'s error messages (which this module hands to the
+/// plugin, and the plugin shows the user), proxy and server access logs, and
+/// anything that later prints the request. Same wire, one fewer place for the
+/// key to end up in clear text.
+const API_KEY_HEADER: &str = "x-goog-api-key";
+
 const ALLOWED_PREFIX: &str = "gemini-";
 const BLOCKED_PREFIXES: [&str; 1] = ["gemini-1.0"];
 const BLOCKED_SUBSTRINGS: [&str; 11] = [
@@ -137,10 +145,7 @@ impl GeminiProvider {
         generation_config: Value,
     ) -> Result<Value, String> {
         let image_b64 = image_to_base64(image_data).map_err(|e| e.to_string())?;
-        let url = format!(
-            "{API_BASE}/models/{model_name}:generateContent?key={}",
-            self.api_key
-        );
+        let url = format!("{API_BASE}/models/{model_name}:generateContent");
         let body = json!({
             "systemInstruction": {"parts": [{"text": system_instruction}]},
             "contents": [{
@@ -156,6 +161,7 @@ impl GeminiProvider {
         let resp = self
             .client
             .post(&url)
+            .header(API_KEY_HEADER, &self.api_key)
             .json(&body)
             .timeout(Duration::from_secs(300))
             .send()
@@ -184,10 +190,7 @@ impl GeminiProvider {
         user_prompt: &str,
     ) -> Option<String> {
         let model = model.unwrap_or("gemini-2.0-flash");
-        let url = format!(
-            "{API_BASE}/models/{model}:generateContent?key={}",
-            self.api_key
-        );
+        let url = format!("{API_BASE}/models/{model}:generateContent");
         let body = json!({
             "systemInstruction": {"parts": [{"text": system_prompt}]},
             "contents": [{"role": "user", "parts": [{"text": user_prompt}]}],
@@ -196,6 +199,7 @@ impl GeminiProvider {
         let resp = self
             .client
             .post(&url)
+            .header(API_KEY_HEADER, &self.api_key)
             .json(&body)
             .timeout(Duration::from_secs(120))
             .send()
@@ -431,11 +435,17 @@ impl GeminiProvider {
         let mut raw_models: Vec<Value> = Vec::new();
         let mut page_token: Option<String> = None;
         for _ in 0..20 {
-            let mut url = format!("{API_BASE}/models?key={}&pageSize=200", self.api_key);
+            let mut url = format!("{API_BASE}/models?pageSize=200");
             if let Some(token) = &page_token {
                 url.push_str(&format!("&pageToken={token}"));
             }
-            let Ok(resp) = self.client.get(&url).send().await else {
+            let Ok(resp) = self
+                .client
+                .get(&url)
+                .header(API_KEY_HEADER, &self.api_key)
+                .send()
+                .await
+            else {
                 return Vec::new();
             };
             let Ok(body) = resp.json::<Value>().await else {


### PR DESCRIPTION
## Summary

This PR addresses two security concerns:

1. **Log injection prevention**: Request-supplied strings (person IDs, names) can now contain control characters including newlines, which could be exploited to forge log lines. A new `log_safe()` utility sanitizes these values by replacing control characters with the Unicode replacement character (U+FFFD).

2. **API key exposure reduction**: The Gemini provider now passes the API key via the `x-goog-api-key` header instead of the `?key=` query parameter, reducing exposure in URLs that appear in error messages, proxy logs, and server access logs.

3. **GitHub Actions security hardening**: Added explicit `permissions: contents: read` declarations to all workflow files, following the principle of least privilege.

## Key Changes

- **`route_util.rs`**: Added `log_safe()` function with comprehensive tests covering ordinary IDs, newline injection attempts, and non-ASCII names
- **`faces.rs`**: Updated all logging statements involving `person_id` and `target` to use `log_safe()` for sanitization
- **`gemini.rs`**: 
  - Moved API key from URL query parameter to `x-goog-api-key` header
  - Added documentation explaining why the header approach is safer
  - Updated three request sites: `generateContent` (image), `generateContent` (text), and `models` list endpoint
- **Workflow files**: Added explicit `permissions: contents: read` to `release.yml`, `lint-format.yml`, `golden-tests-full.yml`, `lua-tests.yml`, and `server-rs-tests.yml`
- **`repowise_pr_report.py`**: Minor formatting fix to clarify multi-line string intent

## Implementation Details

The `log_safe()` function uses `Cow<'_, str>` to avoid allocation in the common case—well-formed IDs are borrowed and only scanned for control characters. Only values containing control characters are allocated and transformed. The function replaces all control characters (including newlines, carriage returns, and other problematic characters) with U+FFFD, ensuring a malicious `person_id` can only ever occupy one log line regardless of its content.

https://claude.ai/code/session_01WSFDmzCDYqJb9Q3FrHyumc