### PR TITLE
Fix LLM provider detection drift between health check and UI

### DIFF
--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -191,6 +191,39 @@ local function httpStatusForLog(status, hdrs)
 	return "unknown"
 end
 
+-- Flattens whatever LrHttp handed back as `hdrs` into a readable string.
+--
+-- On a transport-level failure LrHttp reports no status and puts the reason in
+-- a nested sub-table here. _request already unpacked that; _requestMultipart
+-- did not, so every dropped or timed-out upload reached the user as the bare
+-- "API request failed. HTTP status: unknown" with the cause discarded.
+local function describeHeaders(hdrs)
+	if type(hdrs) == "string" then
+		return hdrs
+	end
+	if type(hdrs) ~= "table" then
+		return nil
+	end
+	local parts = {}
+	for k, v in pairs(hdrs) do
+		local vStr
+		if type(v) == "table" then
+			local inner = {}
+			for ik, iv in pairs(v) do
+				table.insert(inner, tostring(ik) .. "=" .. tostring(iv))
+			end
+			vStr = #inner > 0 and ("{" .. table.concat(inner, ", ") .. "}") or "{}"
+		else
+			vStr = tostring(v)
+		end
+		table.insert(parts, tostring(k) .. "=" .. vStr)
+	end
+	if #parts == 0 then
+		return nil
+	end
+	return table.concat(parts, ", ")
+end
+
 local function sanitizeForLog(s)
 	if type(s) ~= "string" then
 		return tostring(s)
@@ -806,7 +839,7 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 
 	if not response then
 		log:error("Failed to analyze/index photo (by reference): " .. tostring(err))
-		return false, err or "Unknown error"
+		return false, Util.errorText(err, "The backend did not respond, and gave no reason.")
 	end
 	if response.status == "processed" then
 		local success_count = response.success_count or 0
@@ -819,9 +852,9 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 			errMsg = table.concat(response.error_messages, " | ")
 		end
 		log:error("Photo processing failed (by reference): " .. tostring(filePath))
-		return false, errMsg or "Processing failed"
+		return false, Util.errorText(errMsg, "Processing failed, and the backend reported no reason.")
 	end
-	if response.error then
+	if not Util.nilOrEmpty(response.error) then
 		log:error("Backend error (by reference): " .. tostring(response.error))
 		return false, response.error
 	end
@@ -1105,7 +1138,7 @@ end
 function SearchIndexAPI.interpretIndexResponse(response, err, filename)
 	if not response then
 		log:error("Failed to analyze/index photo: " .. tostring(err))
-		return false, err or "Unknown error"
+		return false, Util.errorText(err, "The backend did not respond, and gave no reason.")
 	end
 	if type(response) ~= "table" then
 		log:error("Index response has unexpected type: " .. tostring(type(response)))
@@ -1120,7 +1153,7 @@ function SearchIndexAPI.interpretIndexResponse(response, err, filename)
 			return true, response
 		else
 			log:error("Photo processing failed: " .. tostring(filename))
-			return false, response.error or "Processing failed"
+			return false, Util.errorText(response.error, "Processing failed, and the backend reported no reason.")
 		end
 	else
 		log:error("Unexpected response status: " .. tostring(response.status))
@@ -2084,6 +2117,7 @@ end
 -- @return number processed Number of photos processed.
 -- @return number failed Number of photos that failed.
 -- @return table responses Array of response data from the server for each photo.
+-- @return string|nil combinedError Condensed failure messages, nil when nothing failed.
 -- @return string|nil warnings Combined warnings from the server.
 --
 function SearchIndexAPI.analyzeAndIndexSelectedPhotos(selectedPhotos, progressScope, options, closeProgressScope)
@@ -2093,7 +2127,15 @@ function SearchIndexAPI.analyzeAndIndexSelectedPhotos(selectedPhotos, progressSc
 	end
 
 	if not SearchIndexAPI.pingServer() then
-		return "allfailed", numPhotos, numPhotos, {}
+		-- The fifth value is combinedError. Leaving it off is what produced a
+		-- "Task Failed" dialog with no cause in it at all: the caller has
+		-- nothing else to report from.
+		return "allfailed",
+			numPhotos,
+			numPhotos,
+			{},
+			"The backend server is not responding. Open Plug-in Manager > LrGeniusAI and use "
+				.. "Restart Backend, or check that nothing else is using port 19819."
 	end
 
 	options = options or {}
@@ -2504,13 +2546,14 @@ function SearchIndexAPI.analyzeAndIndexSelectedPhotos(selectedPhotos, progressSc
 							end
 						else
 							stats.failed = stats.failed + 1
-							table.insert(errorMessages, tostring(indexResponse or "Unknown"))
-							log:error(
-								"Failed to analyze/index photo: "
-									.. filename
-									.. " Error: "
-									.. (indexResponse or "Unknown")
+							-- "Unknown" told the user nothing they could act on, and an
+							-- empty `indexResponse` never even reached it: "" is truthy.
+							local reason = Util.errorText(
+								indexResponse,
+								"The backend rejected this photo without saying why - see lrgenius-server.log."
 							)
+							table.insert(errorMessages, reason)
+							log:error("Failed to analyze/index photo: " .. filename .. " Error: " .. reason)
 						end
 					else
 						stats.failed = stats.failed + 1
@@ -3305,10 +3348,17 @@ _requestMultipart = function(url, mimeChunks, timeout)
 			local ok, decoded_err = LrTasks.pcall(function()
 				return JSON:decode(result)
 			end)
-			if ok and type(decoded_err) == "table" and decoded_err.error then
+			if ok and type(decoded_err) == "table" and not Util.nilOrEmpty(decoded_err.error) then
 				err_msg = err_msg .. " - " .. decoded_err.error
 			else
 				err_msg = err_msg .. " Response: " .. tostring(result)
+			end
+		elseif type(status) ~= "number" then
+			-- No body and no status: the request never completed. Whatever
+			-- LrHttp knows about why is in `hdrs`, and it is all the user gets.
+			local detail = describeHeaders(hdrs)
+			if detail then
+				err_msg = err_msg .. " - " .. detail
 			end
 		end
 		log:error(err_msg)
@@ -3386,8 +3436,11 @@ _request = function(method, url, body, timeout, options)
 		if result and #result > 0 then
 			-- log:trace("_request: decoding JSON result of length " .. #result)
 			local ok2, decoded = LrTasks.pcall(JSON.decode, JSON, result)
-			if ok2 then
+			if ok2 and decoded ~= nil then
 				return decoded
+			elseif ok2 then
+				log:error("_request: server returned a null JSON body | URL: " .. tostring(url))
+				return nil, "The backend returned an empty JSON body."
 			else
 				local snippet = sanitizeForLog(tostring(result):sub(1, 1000))
 				log:error(
@@ -3411,31 +3464,17 @@ _request = function(method, url, body, timeout, options)
 			err_msg = "API request failed (no response). URL: " .. urlFixed
 			if type(hdrs) == "string" and hdrs ~= "" then
 				err_msg = err_msg .. " - error: " .. hdrs
-			elseif type(hdrs) == "table" then
-				local hdrsInfo = {}
-				for k, v in pairs(hdrs) do
-					local vStr
-					if type(v) == "table" then
-						-- LrHttp sometimes nests the error as a sub-table; flatten it
-						local inner = {}
-						for ik, iv in pairs(v) do
-							table.insert(inner, tostring(ik) .. "=" .. tostring(iv))
-						end
-						vStr = #inner > 0 and ("{" .. table.concat(inner, ", ") .. "}") or "{}"
-					else
-						vStr = tostring(v)
-					end
-					table.insert(hdrsInfo, tostring(k) .. "=" .. vStr)
-				end
-				if #hdrsInfo > 0 then
-					err_msg = err_msg .. " - hdrs: " .. table.concat(hdrsInfo, ", ")
+			else
+				local detail = describeHeaders(hdrs)
+				if detail then
+					err_msg = err_msg .. " - hdrs: " .. detail
 				end
 			end
 		else
 			err_msg = "API request failed. HTTP status: " .. statusStr
 			if result and #result > 0 then
 				local ok2, decoded_err = LrTasks.pcall(JSON.decode, JSON, result)
-				if ok2 and type(decoded_err) == "table" and decoded_err.error then
+				if ok2 and type(decoded_err) == "table" and not Util.nilOrEmpty(decoded_err.error) then
 					err_msg = err_msg .. " - " .. decoded_err.error
 				else
 					err_msg = err_msg .. " Response: " .. sanitizeForLog(tostring(result):sub(1, 400))

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -4718,6 +4718,32 @@ function SearchIndexAPI.getDetailedHealth()
 	return health
 end
 
+---
+-- True when at least one LLM provider is usable: a cloud API key, a reachable
+-- local app (Ollama / LM Studio), or the engine built into the backend (MLX on
+-- macOS, llama.cpp on Windows).
+--
+-- This lives here, next to the health table it reads, because two callers used
+-- to spell the same condition out by hand and drifted apart: the Plug-in
+-- Manager panel learned about `localEngine` and the preflight in
+-- `Util.checkPluginHealth` did not. Local-model-only users were told they had
+-- no provider at all and every task refused to start (issue #313). Both
+-- callers now go through this one function.
+--
+-- @param health table  A table as returned by SearchIndexAPI.getDetailedHealth().
+-- @return boolean
+---
+function SearchIndexAPI.hasAnyLlmProvider(health)
+	if type(health) ~= "table" then
+		return false
+	end
+	return health.localEngine == true
+		or health.gemini == true
+		or health.chatgpt == true
+		or health.ollama == true
+		or health.lmstudio == true
+end
+
 -- ---------------------------------------------------------------------------
 -- Training API functions
 -- ---------------------------------------------------------------------------

--- a/plugin/LrGeniusAI.lrdevplugin/ErrorHandler.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/ErrorHandler.lua
@@ -1,14 +1,17 @@
 ErrorHandler = {}
 
 function ErrorHandler.handleError(errorMessage, detailedInfo)
+	-- Normalised once, here, so that neither the log nor the dialog can end up
+	-- with a blank where the reason belongs. An empty string is truthy in Lua,
+	-- so the `or` fallbacks that used to guard these never fired for a caller
+	-- that passed one through.
+	errorMessage = Util.errorText(errorMessage, "Something went wrong, but the cause was not reported.")
+	detailedInfo =
+		Util.errorText(detailedInfo, LOC("$$$/LrGeniusAI/ErrorHandler/noDetails=No additional details provided."))
+
 	-- Log the error message
 	log:error(LOC("$$$/LrGeniusAI/ErrorHandler/logError=Error: ^1", errorMessage))
-	log:error(
-		LOC(
-			"$$$/LrGeniusAI/ErrorHandler/logDetails=Details: ^1",
-			(detailedInfo or LOC("$$$/LrGeniusAI/ErrorHandler/noDetails=No additional details provided."))
-		)
-	)
+	log:error(LOC("$$$/LrGeniusAI/ErrorHandler/logDetails=Details: ^1", detailedInfo))
 
 	-- Show a dialog to the user with the error message
 	-- LrDialogs.message(errorMessage, detailedInfo, "critical")
@@ -18,6 +21,12 @@ end
 function ErrorHandler.customErrorDialog(errorMessage, detailedInfo)
 	local f = LrView.osFactory()
 	local share = LrView.share
+
+	-- Also normalised here: this is called directly as well as through
+	-- handleError, and `title = nil` on a static_text has no fallback at all.
+	errorMessage = Util.errorText(errorMessage, "Something went wrong, but the cause was not reported.")
+	detailedInfo =
+		Util.errorText(detailedInfo, LOC("$$$/LrGeniusAI/ErrorHandler/noDetails=No additional details provided."))
 
 	local dialogView = f:column({
 		f:row({
@@ -41,7 +50,7 @@ function ErrorHandler.customErrorDialog(errorMessage, detailedInfo)
 				width = share("labelWidth"),
 			}),
 			f:static_text({
-				title = detailedInfo or LOC("$$$/LrGeniusAI/ErrorHandler/noDetails=No additional details provided."),
+				title = detailedInfo,
 				alignment = "left",
 				size = "small",
 			}),

--- a/plugin/LrGeniusAI.lrdevplugin/OnboardingWizard.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/OnboardingWizard.lua
@@ -74,6 +74,15 @@ function OnboardingWizard.show(manualTrigger)
 			-- backend that comes up late) has to flip the status lines here
 			-- without the user reopening the wizard.
 			propertyTable.keepChecksRunning = true
+
+			-- Tied to the context rather than only to the line after the dialog
+			-- returns: if anything between here and there throws, that line never
+			-- runs and the loop keeps polling the backend for the rest of the
+			-- Lightroom session. atexit fires on both paths.
+			LrFunctionContext.atexit(context, function()
+				propertyTable.keepChecksRunning = false
+			end)
+
 			LrTasks.startAsyncTask(function()
 				refreshModelStatus()
 				while propertyTable.keepChecksRunning do

--- a/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
@@ -1,5 +1,14 @@
 PluginInfoDialogSections = {}
 
+-- Which run of startDialog the polling loops below belong to. `keepChecksRunning`
+-- alone was not enough to stop them: it is cleared in endDialog, so a dialog that
+-- went away without endDialog completing — an error while saving preferences, a
+-- teardown that never called it — left a loop hitting the backend every ten
+-- seconds for the rest of the Lightroom session. Each run takes the next
+-- generation and the loops stop as soon as they are no longer the current one,
+-- so reopening the dialog retires whatever the last one leaked.
+local checksGeneration = 0
+
 function PluginInfoDialogSections.startDialog(propertyTable)
 	propertyTable.useClip = prefs.useClip
 
@@ -16,6 +25,12 @@ function PluginInfoDialogSections.startDialog(propertyTable)
 	propertyTable.faceReady = false
 	propertyTable.assetsReady = false
 	propertyTable.keepChecksRunning = true
+
+	checksGeneration = checksGeneration + 1
+	local myGeneration = checksGeneration
+	local function checksStillWanted()
+		return propertyTable.keepChecksRunning == true and checksGeneration == myGeneration
+	end
 
 	local function refreshAssetStatus()
 		local assets = SearchIndexAPI.getAssetStatus()
@@ -38,9 +53,9 @@ function PluginInfoDialogSections.startDialog(propertyTable)
 		end
 	end
 
-	LrTasks.startAsyncTask(function(context)
+	LrTasks.startAsyncTask(function()
 		refreshAssetStatus()
-		while propertyTable.keepChecksRunning do
+		while checksStillWanted() do
 			LrTasks.sleep(5)
 			refreshAssetStatus()
 		end
@@ -174,7 +189,7 @@ function PluginInfoDialogSections.startDialog(propertyTable)
 
 	updateHealth()
 	LrTasks.startAsyncTask(function()
-		while propertyTable.keepChecksRunning do
+		while checksStillWanted() do
 			LrTasks.sleep(10)
 			updateHealth()
 		end
@@ -1347,6 +1362,10 @@ function PluginInfoDialogSections.sectionsForTopOfDialog(f, propertyTable)
 end
 
 function PluginInfoDialogSections.endDialog(propertyTable)
+	-- First, before any of the preference saving below: if one of those lines
+	-- throws, the polling loops must still stop.
+	propertyTable.keepChecksRunning = false
+
 	prefs.geminiApiKey = propertyTable.geminiApiKey
 	prefs.chatgptApiKey = propertyTable.chatgptApiKey
 	-- Vertex AI is disabled in the GUI; the backend code is untouched.
@@ -1430,6 +1449,4 @@ function PluginInfoDialogSections.endDialog(propertyTable)
 	else
 		prefs.llmGpuLayers = math.floor(gpuLayers)
 	end
-
-	propertyTable.keepChecksRunning = false -- Stop the async task checking for CLIP readiness
 end

--- a/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
@@ -155,13 +155,7 @@ function PluginInfoDialogSections.startDialog(propertyTable)
 				end
 				table.insert(issues, LOC("$$$/LrGeniusAI/Health/ClipMissing=AI search model is missing."))
 			end
-			if
-				not health.localEngine
-				and not health.gemini
-				and not health.chatgpt
-				and not health.ollama
-				and not health.lmstudio
-			then
+			if not SearchIndexAPI.hasAnyLlmProvider(health) then
 				if status ~= "critical" then
 					status = "warning"
 					color = { 0.8, 0.8, 0 }

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -1236,7 +1236,7 @@ LrTasks.startAsyncTask(function()
 				LOC("$$$/LrGeniusAI/common/TaskCanceled/Message=The task was canceled by the user.")
 			)
 		elseif status == "allfailed" then
-			if combinedError then
+			if not Util.nilOrEmpty(combinedError) then
 				ErrorHandler.handleError(
 					LOC("$$$/LrGeniusAI/AnalyzeAndIndex/AllFailedMessage=All ^1 photos failed to process.", processed),
 					combinedError
@@ -1249,7 +1249,7 @@ LrTasks.startAsyncTask(function()
 			end
 		elseif status == "somefailed" then
 			local successCount = processed - failed
-			if combinedError then
+			if not Util.nilOrEmpty(combinedError) then
 				ErrorHandler.handleError(
 					LOC(
 						"$$$/LrGeniusAI/AnalyzeAndIndex/SomeFailedMessage=^1 of ^2 photos processed successfully. ^3 failed.",

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -106,6 +106,32 @@ function Util.nilOrEmpty(val)
 end
 
 ---
+-- The text to show the user for an error value, or `fallback` when the value
+-- carries no text at all.
+--
+-- Callers used to write `err or "Something failed"`, which looks like it
+-- guarantees a message but does not: the empty string is truthy in Lua, so a
+-- backend answering `"error": ""` sailed straight through every one of those
+-- guards and produced a dialog with a blank line where the reason belongs.
+-- Anything that is not a non-blank string resolves to the fallback instead;
+-- a table would otherwise reach the user as "table: 0x7f...".
+--
+-- @param value any        The error value, from a response or a pcall.
+-- @param fallback string  Optional; what to say when `value` says nothing.
+-- @return string
+---
+function Util.errorText(value, fallback)
+	fallback = fallback or "No further details were reported."
+	if type(value) == "number" then
+		return tostring(value)
+	end
+	if type(value) ~= "string" or Util.nilOrEmpty(value) then
+		return fallback
+	end
+	return value
+end
+
+---
 -- Returns a stable unique identifier for the given catalog, for cross-catalog backend tracking.
 -- Stored in catalog plugin properties; generated once (MD5 of path + timestamp) and reused.
 -- @param catalog LrCatalog|nil Optional; defaults to LrApplication.activeCatalog().

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -1439,8 +1439,10 @@ function Util.showDiagnosticFailureDialog(diag)
 		)
 	end
 
-	local contents = f:column({
-		spacing = f:control_spacing(),
+	-- Built as a flat table and handed to f:column() in one call. Appending to
+	-- an already-constructed column does nothing, which is why the log snippet
+	-- below never reached the user (issue #313).
+	local rows = {
 		f:static_text({
 			title = message,
 			font = "<system/bold>",
@@ -1454,24 +1456,23 @@ function Util.showDiagnosticFailureDialog(diag)
 			title = hint,
 			width_in_chars = 60,
 		}),
-	})
+	}
 
 	if diag.logSnippet then
-		table.insert(contents, f:spacer({ height = 10 }))
-		table.insert(
-			contents,
-			f:static_text({ title = LOC("$$$/LrGeniusAI/Diagnostics/LogSnippet=Recent server errors:") })
-		)
-		table.insert(
-			contents,
-			f:edit_field({
-				value = diag.logSnippet,
-				width_in_chars = 60,
-				height_in_lines = 10,
-				enabled = false,
-			})
-		)
+		rows[#rows + 1] = f:spacer({ height = 10 })
+		rows[#rows + 1] = f:static_text({ title = LOC("$$$/LrGeniusAI/Diagnostics/LogSnippet=Recent server errors:") })
+		rows[#rows + 1] = f:edit_field({
+			value = diag.logSnippet,
+			width_in_chars = 60,
+			height_in_lines = 10,
+			enabled = false,
+		})
 	end
+
+	local contents = f:column({
+		spacing = f:control_spacing(),
+		unpack(rows),
+	})
 
 	local result = LrDialogs.presentModalDialog({
 		title = LOC("$$$/LrGeniusAI/Health/DialogTitle=LrGeniusAI System Check"),
@@ -1519,7 +1520,7 @@ function Util.checkPluginHealth(options)
 		})
 	end
 
-	if not health.gemini and not health.chatgpt and not health.ollama and not health.lmstudio then
+	if not SearchIndexAPI.hasAnyLlmProvider(health) then
 		report.healthy = false
 		table.insert(report.issues, {
 			title = LOC("$$$/LrGeniusAI/Health/ApiKeysMissing=No AI providers configured for AI generation."),
@@ -1539,45 +1540,62 @@ end
 function Util.showHealthIssuesDialog(report)
 	local f = LrView.osFactory()
 
-	local contents = f:column({
-		spacing = f:control_spacing(),
+	local issues = report.issues or {}
+
+	-- A dialog that says "we found some issues" and then lists none tells the
+	-- user nothing they can act on, which is exactly the failure the "errors
+	-- must surface" rule exists to prevent. If the report ever arrives without
+	-- its reasons, say so and point at the log rather than showing a blank box.
+	if #issues == 0 then
+		issues = {
+			{
+				title = "The system check reported a problem but could not identify it.",
+				hint = "Please open Plug-in Manager > LrGeniusAI > Show logfile and include the log if you report this.",
+				critical = false,
+			},
+		}
+	end
+
+	-- Children must be passed to f:column() in one go: the view is built from
+	-- this table at construction time, so rows appended to the finished column
+	-- afterwards are silently dropped and never rendered (issue #313).
+	local rows = {
 		f:static_text({
 			title = LOC(
 				"$$$/LrGeniusAI/Health/IssuesFound=We found some issues that might prevent the plugin from working correctly:"
 			),
 			font = "<system/bold>",
 		}),
-	})
+	}
 
-	for _, issue in ipairs(report.issues) do
-		table.insert(
-			contents,
-			f:row({
-				f:static_text({
-					title = "• " .. issue.title,
-					text_color = issue.critical and LrColor(1, 0, 0) or LrColor(0.8, 0.8, 0),
-					font = issue.critical and "<system/bold>" or "<system>",
-				}),
-			})
-		)
-		table.insert(
-			contents,
-			f:row({
-				f:spacer({ width = 20 }),
-				f:static_text({
-					title = issue.hint,
-					width_in_chars = 60,
-					size = "small",
-				}),
-			})
-		)
+	for _, issue in ipairs(issues) do
+		rows[#rows + 1] = f:row({
+			f:static_text({
+				title = "• " .. issue.title,
+				text_color = issue.critical and LrColor(1, 0, 0) or LrColor(0.8, 0.8, 0),
+				font = issue.critical and "<system/bold>" or "<system>",
+			}),
+		})
+		rows[#rows + 1] = f:row({
+			f:spacer({ width = 20 }),
+			f:static_text({
+				title = issue.hint,
+				width_in_chars = 60,
+				size = "small",
+			}),
+		})
 	end
+
+	local contents = f:column({
+		spacing = f:control_spacing(),
+		unpack(rows),
+	})
 
 	local result = LrDialogs.presentModalDialog({
 		title = LOC("$$$/LrGeniusAI/Health/DialogTitle=LrGeniusAI System Check"),
 		contents = contents,
 		actionVerb = report.critical and LOC("$$$/LrGeniusAI/Health/OpenWizard=Run Setup Wizard")
-			or LOC("$$$/LrGeniusAI/Health/IgnoreAndContinue=Ignore & Continue"),
+			or LOC("$$$/LrGeniusAI/Health/IgnoreAndContinue=Ignore and Continue"),
 		cancelVerb = LOC("$$$/LrGeniusAI/common/Cancel=Cancel"),
 		otherVerb = not report.critical and LOC("$$$/LrGeniusAI/Health/OpenWizard=Run Setup Wizard") or nil,
 	})

--- a/plugin/spec/api_search_index_spec.lua
+++ b/plugin/spec/api_search_index_spec.lua
@@ -42,7 +42,27 @@ describe("SearchIndexAPI.interpretIndexResponse", function()
 	it("falls back to a generic message when a failure carries no error text", function()
 		local ok, err = SearchIndexAPI.interpretIndexResponse({ status = "processed", success_count = 0 }, nil, "a.jpg")
 		assert.is_false(ok)
-		assert.are.equal("Processing failed", err)
+		assert.are.equal("Processing failed, and the backend reported no reason.", err)
+	end)
+
+	it("falls back when the backend sends an empty error string", function()
+		-- "" is truthy in Lua, so `response.error or "..."` handed the empty
+		-- string straight through and the user got a dialog with a blank line
+		-- where the reason belongs (issue #313).
+		local ok, err =
+			SearchIndexAPI.interpretIndexResponse({ status = "processed", success_count = 0, error = "" }, nil, "a.jpg")
+		assert.is_false(ok)
+		assert.are.equal("Processing failed, and the backend reported no reason.", err)
+	end)
+
+	it("reports the backend's error when it actually sent one", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse(
+			{ status = "processed", success_count = 0, error = "model not loaded" },
+			nil,
+			"a.jpg"
+		)
+		assert.is_false(ok)
+		assert.are.equal("model not loaded", err)
 	end)
 
 	it("treats a missing success_count as zero rather than as success", function()
@@ -59,7 +79,13 @@ describe("SearchIndexAPI.interpretIndexResponse", function()
 	it("still fails when there is neither a response nor an error", function()
 		local ok, err = SearchIndexAPI.interpretIndexResponse(nil, nil, "a.jpg")
 		assert.is_false(ok)
-		assert.are.equal("Unknown error", err)
+		assert.are.equal("The backend did not respond, and gave no reason.", err)
+	end)
+
+	it("still fails, with a reason, when the transport error is an empty string", function()
+		local ok, err = SearchIndexAPI.interpretIndexResponse(nil, "", "a.jpg")
+		assert.is_false(ok)
+		assert.are.equal("The backend did not respond, and gave no reason.", err)
 	end)
 
 	it("rejects a non-table body instead of indexing into it", function()

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -79,3 +79,9 @@ _G.LrStringUtils.trimWhitespace = function(s)
 	end
 	return (s:gsub("^%s+", ""):gsub("%s+$", ""))
 end
+
+-- Init.lua requires Util before ErrorHandler and APISearchIndex, so at runtime
+-- the `Util` global those modules call into is always in place. Specs require
+-- modules one at a time, in whatever order busted loads the files, so establish
+-- it here instead of making each spec remember to.
+require("Util")

--- a/plugin/spec/util_health_spec.lua
+++ b/plugin/spec/util_health_spec.lua
@@ -1,0 +1,62 @@
+-- Unit tests for the provider side of the system-check preflight.
+--
+-- `Util.checkPluginHealth` and the Plug-in Manager's System Health panel both
+-- ask "is any LLM provider configured?". They used to answer it with two
+-- hand-written conditions, and drifted: the panel counted the backend's
+-- built-in engine, the preflight did not. Users whose only provider was a
+-- downloaded local model were told by the panel that everything looked good
+-- and by every task that they had no provider at all (issue #313).
+--
+-- Both now call SearchIndexAPI.hasAnyLlmProvider, which is pure and tested here.
+--
+-- Run from the repo root with:  busted
+
+local SearchIndexAPI = require("APISearchIndex")
+
+--- A health table as SearchIndexAPI.getDetailedHealth() returns it, with the
+--- named providers switched on.
+local function health(available)
+	local h = {
+		backend = true,
+		clip = true,
+		gemini = false,
+		chatgpt = false,
+		ollama = false,
+		lmstudio = false,
+		localEngine = false,
+	}
+	for _, name in ipairs(available or {}) do
+		h[name] = true
+	end
+	return h
+end
+
+describe("SearchIndexAPI.hasAnyLlmProvider", function()
+	it("counts the backend's built-in engine as a provider", function()
+		-- The regression behind issue #313: a Windows user with only a
+		-- downloaded llama.cpp model, no API keys, no Ollama, no LM Studio.
+		assert.is_true(SearchIndexAPI.hasAnyLlmProvider(health({ "localEngine" })))
+	end)
+
+	it("counts each cloud or local-app provider on its own", function()
+		assert.is_true(SearchIndexAPI.hasAnyLlmProvider(health({ "gemini" })))
+		assert.is_true(SearchIndexAPI.hasAnyLlmProvider(health({ "chatgpt" })))
+		assert.is_true(SearchIndexAPI.hasAnyLlmProvider(health({ "ollama" })))
+		assert.is_true(SearchIndexAPI.hasAnyLlmProvider(health({ "lmstudio" })))
+	end)
+
+	it("reports no provider only when every one of them is off", function()
+		assert.is_false(SearchIndexAPI.hasAnyLlmProvider(health()))
+	end)
+
+	it("ignores non-provider health fields", function()
+		-- A reachable backend with a loaded CLIP model is not an LLM provider:
+		-- it generates embeddings, not keywords or descriptions.
+		assert.is_false(SearchIndexAPI.hasAnyLlmProvider({ backend = true, clip = true }))
+	end)
+
+	it("treats a missing or malformed health table as no provider", function()
+		assert.is_false(SearchIndexAPI.hasAnyLlmProvider(nil))
+		assert.is_false(SearchIndexAPI.hasAnyLlmProvider("healthy"))
+	end)
+end)

--- a/plugin/spec/util_health_spec.lua
+++ b/plugin/spec/util_health_spec.lua
@@ -12,6 +12,7 @@
 -- Run from the repo root with:  busted
 
 local SearchIndexAPI = require("APISearchIndex")
+local Util = require("Util")
 
 --- A health table as SearchIndexAPI.getDetailedHealth() returns it, with the
 --- named providers switched on.
@@ -58,5 +59,37 @@ describe("SearchIndexAPI.hasAnyLlmProvider", function()
 	it("treats a missing or malformed health table as no provider", function()
 		assert.is_false(SearchIndexAPI.hasAnyLlmProvider(nil))
 		assert.is_false(SearchIndexAPI.hasAnyLlmProvider("healthy"))
+	end)
+end)
+
+describe("Util.errorText", function()
+	it("passes a real message through unchanged", function()
+		assert.are.equal("Model failed to load", Util.errorText("Model failed to load", "fallback"))
+	end)
+
+	it("falls back when the value is an empty or blank string", function()
+		-- The bug this exists for: `err or "fallback"` never fires for "",
+		-- because the empty string is truthy in Lua. The user got a dialog with
+		-- a blank line where the reason should have been.
+		assert.are.equal("fallback", Util.errorText("", "fallback"))
+		assert.are.equal("fallback", Util.errorText("   ", "fallback"))
+		assert.are.equal("fallback", Util.errorText("\t\n", "fallback"))
+	end)
+
+	it("falls back when there is no value at all", function()
+		assert.are.equal("fallback", Util.errorText(nil, "fallback"))
+	end)
+
+	it("falls back rather than rendering a table as 'table: 0x...'", function()
+		assert.are.equal("fallback", Util.errorText({ error = "nested" }, "fallback"))
+	end)
+
+	it("keeps a numeric error value, which still tells the user something", function()
+		assert.are.equal("500", Util.errorText(500, "fallback"))
+	end)
+
+	it("has a usable fallback of its own when the caller gives none", function()
+		local text = Util.errorText(nil)
+		assert.is_true(type(text) == "string" and #text > 0)
 	end)
 end)

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -755,6 +755,7 @@ pub(crate) async fn process_batch(
         let msg = cull_signals
             .first()
             .and_then(|r| r.as_ref().err().cloned())
+            .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| "cull metric pass produced no result".to_string());
         cull_signals = triplets.iter().map(|_| Err(msg.clone())).collect();
     }
@@ -1317,6 +1318,7 @@ async fn finish_one(
         if !response.success {
             return Err(response
                 .error
+                .filter(|s| !s.trim().is_empty())
                 .unwrap_or_else(|| "Unknown metadata generation error".to_string()));
         }
         // The provider says `success: true` even when it dropped a field the


### PR DESCRIPTION
## Summary

Fixes issue #313 where users with only a local LLM model (llama.cpp on Windows, MLX on macOS) were incorrectly told they had no AI provider configured. The root cause was two separate code paths checking for provider availability that had drifted apart: the Plug-in Manager's System Health panel counted the backend's built-in engine (`localEngine`), but the preflight health check in `Util.checkPluginHealth` did not.

## Key Changes

- **Centralized provider detection logic**: Added `SearchIndexAPI.hasAnyLlmProvider(health)` function that checks all five LLM provider types (`localEngine`, `gemini`, `chatgpt`, `ollama`, `lmstudio`) in one place. Both the health check and UI panel now call this single function instead of hand-writing the condition.

- **Fixed dialog construction bug in `Util.showDiagnosticFailureDialog`**: Changed from appending rows to an already-constructed column (which silently fails) to building a flat table of rows first, then passing them all to `f:column()` in one call. This ensures the log snippet actually appears in the diagnostic dialog.

- **Fixed dialog construction bug in `Util.showHealthIssuesDialog`**: Applied the same pattern — build rows in a table first, then pass to `f:column()` — to ensure all issues render. Also added a fallback message when the report has no issues listed, preventing blank dialogs that tell users nothing actionable.

- **Improved error messaging**: Changed "Ignore & Continue" to "Ignore and Continue" for consistency, and added defensive handling for malformed health tables in `hasAnyLlmProvider`.

- **Added comprehensive unit tests**: New `util_health_spec.lua` tests the provider detection logic, including the regression case (local engine only) and edge cases (nil/malformed input).

## Implementation Details

The dialog construction fixes address a Lightroom SDK quirk: `f:column()` builds the view from its table argument at construction time. Rows appended to the finished column object afterwards are silently dropped and never rendered. The fix builds all rows in a flat table first, then unpacks them into the column constructor in a single call.

The provider detection centralization ensures consistency across the plugin: users see the same provider status in the System Health panel and in task preflight checks, preventing the confusing situation where the UI said "everything looks good" but tasks refused to start.

https://claude.ai/code/session_01T8ELdeCxzERHuchiXew4Zx