### PR TITLE
Separate face tags from keywords to prevent misreading as scenery

### DIFF
--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -77,9 +77,15 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 | `exposure_bias` | float | Exposure compensation in EV. Stored, and the decisive signal for culling's bracket detection. Omit when the camera did not record it; never default it to 0 |
 | `is_raw` | bool | Whether the original is raw. Stored on the photo so later work (style training above all) can keep raw and rendered originals apart. Omit when unknown |
 | `extra_context` | object | Optional context hints (folder, date, GPS, keywords) |
+| `existing_keywords` | string[] | The photo's keywords, *without* face tags. Only reaches the prompt when `submit_keywords` is set |
+| `existing_face_tags` | string[] | Names Lightroom's face recognition put on the photo. Sent apart from `existing_keywords` and labelled as people in the prompt, so a person's name is not read as a place (issue #315). Same `submit_keywords` switch; omit it and the request behaves exactly as before the field existed |
 
-`/v1/index/photos/by-path` carries `exposure_bias` and `is_raw` per image inside the
-`images` array instead, since both are properties of the individual photo.
+`/v1/index/photos/by-path` carries `exposure_bias`, `is_raw`, `existing_keywords` and
+`existing_face_tags` per image inside the `images` array instead, since all four are
+properties of the individual photo.
+
+`/v1/edit/recipe` and `/v1/edit/recipe/base64` accept the same
+`existing_keywords`/`existing_face_tags` pair, under the same switch.
 
 **Response:** `{status, success_count, failure_count, error_messages, warnings, results}`.
 

--- a/docs/wiki/Help-Analyze-and-Index.md
+++ b/docs/wiki/Help-Analyze-and-Index.md
@@ -220,7 +220,10 @@ Prompt templates, plus a free-text custom prompt appended to the built-in one.
 
 Extra information sent alongside the photo to improve accuracy:
 
-- **Existing Keywords**
+- **Existing Keywords** — the photo's keywords go into the prompt. Names that
+  Lightroom's face recognition put on the photo are sent separately from the
+  rest, and labelled as the people in the picture, so a person called *Ivo* is
+  no longer read as scenery and turned into "Ivo Beach".
 - **Folder Names**
 - **Location (looked up from the photo's GPS coordinates)** — on by default.
   The backend turns the photo's own EXIF position into a place name and puts

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -809,6 +809,7 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 		submit_folder_names = tostring(options.submit_folder_names or false),
 		user_context = options.user_context,
 		existing_keywords = options.existing_keywords and JSON:encode(options.existing_keywords) or nil,
+		existing_face_tags = options.existing_face_tags and JSON:encode(options.existing_face_tags) or nil,
 		folder_names = options.folder_names,
 		prompt = options.prompt,
 		keyword_categories = options.keyword_categories and JSON:encode(options.keyword_categories) or "[]",
@@ -905,6 +906,7 @@ function SearchIndexAPI.analyzeAndIndexPhotosByReference(entries, options)
 			date_time = po.date_time,
 			date_time_unix = po.date_time_unix,
 			existing_keywords = po.existing_keywords,
+			existing_face_tags = po.existing_face_tags,
 			folder_names = po.folder_names,
 			exposure_bias = po.exposure_bias,
 			is_raw = po.is_raw,
@@ -1011,7 +1013,8 @@ end
 --   - generate_alt_text boolean: Generate alt text (default: false)
 --   - submit_gps boolean: Include the photo's location in the AI context (default: true)
 --   - submit_keywords boolean: Submit existing keywords (default: false)
---   - existing_keywords table: Array of existing keywords
+--   - existing_keywords table: Array of existing keywords (no face tags)
+--   - existing_face_tags table: Array of names Lightroom face recognition tagged
 --   - submit_folder_names boolean: Submit folder names (default: false)
 --   - folder_names string: Folder path
 --   - user_context string: Additional context for the photo
@@ -1249,6 +1252,9 @@ function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 	if options.existing_keywords then
 		table.insert(mimeChunks, { name = "existing_keywords", value = JSON:encode(options.existing_keywords) })
 	end
+	if options.existing_face_tags then
+		table.insert(mimeChunks, { name = "existing_face_tags", value = JSON:encode(options.existing_face_tags) })
+	end
 	if options.folder_names then
 		table.insert(mimeChunks, { name = "folder_names", value = options.folder_names })
 	end
@@ -1342,6 +1348,9 @@ function SearchIndexAPI.analyzeAndIndexPhoto(photoId, filepath, options)
 	end
 	if options.existing_keywords then
 		table.insert(mimeChunks, { name = "existing_keywords", value = JSON:encode(options.existing_keywords) })
+	end
+	if options.existing_face_tags then
+		table.insert(mimeChunks, { name = "existing_face_tags", value = JSON:encode(options.existing_face_tags) })
 	end
 	if options.folder_names then
 		table.insert(mimeChunks, { name = "folder_names", value = options.folder_names })
@@ -2062,10 +2071,21 @@ local function buildPhotoOptions(photo, photoId, options)
 	if options.submit_keywords then
 		local keywords = photo:getFormattedMetadata("keywordTagsForExport")
 		if keywords then
+			local keywordList
 			if type(keywords) == "string" then
-				photoOptions.existing_keywords = Util.string_split(keywords, ",")
+				keywordList = Util.string_split(keywords, ",")
 			else
-				photoOptions.existing_keywords = keywords
+				keywordList = keywords
+			end
+			-- Face tags travel in their own field. Lightroom flattens a named
+			-- face into the same comma-separated list as every other keyword,
+			-- and a model handed "Ivo" between "beach" and "sunset" reads it as
+			-- scenery: "the rocky shore of Ivo Beach" (issue #315). Splitting
+			-- them here lets the prompt say which names are people.
+			local plainKeywords, faceTags = Util.partitionPersonKeywords(keywordList, Util.getPersonKeywordNames(photo))
+			photoOptions.existing_keywords = plainKeywords
+			if #faceTags > 0 then
+				photoOptions.existing_face_tags = faceTags
 			end
 		end
 	end
@@ -5052,6 +5072,9 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	end
 	if options.existing_keywords then
 		table.insert(mimeChunks, { name = "existing_keywords", value = JSON:encode(options.existing_keywords) })
+	end
+	if options.existing_face_tags then
+		table.insert(mimeChunks, { name = "existing_face_tags", value = JSON:encode(options.existing_face_tags) })
 	end
 
 	if filepath and LrFileUtils.exists(filepath) then

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -244,6 +244,142 @@ function Util.isRawPhoto(photo)
 end
 
 ---
+-- Names of the people Lightroom's face recognition has tagged on a photo.
+--
+-- Lightroom stores a named face as an ordinary keyword whose `keywordType`
+-- attribute is "person", so once keywords have been flattened to plain strings
+-- a person's name is indistinguishable from a place or an object. That is the
+-- bug this exists to fix: handed "Ivo" in the same breath as "beach" and
+-- "sunset", a model happily writes "the rocky shore of Ivo Beach" (issue
+-- #315). Reading the keyword objects is the only way to tell the two apart.
+--
+-- Defensive throughout: `getAttributes` is not implemented by every keyword
+-- object we may be handed, and a photo whose keywords cannot be read has to
+-- degrade to "no face tags known" -- which is exactly the behaviour the
+-- plug-in had before this existed -- rather than fail the indexing run.
+--
+-- @param photo LrPhoto The photo object.
+-- @return table Array of person names (and their synonyms), in catalog order,
+--         deduplicated.
+--
+function Util.getPersonKeywordNames(photo)
+	if photo == nil then
+		return {}
+	end
+	local keywords = safeGetRawMetadata(photo, "keywords")
+	if type(keywords) ~= "table" then
+		return {}
+	end
+
+	local names = {}
+	local seen = {}
+	local function remember(value)
+		if type(value) ~= "string" then
+			return
+		end
+		local cleaned = trim(value)
+		if cleaned ~= "" and not seen[cleaned:lower()] then
+			seen[cleaned:lower()] = true
+			table.insert(names, cleaned)
+		end
+	end
+
+	for _, keyword in ipairs(keywords) do
+		local ok, attributes = LrTasks.pcall(function()
+			return keyword:getAttributes()
+		end)
+		-- Compared case-insensitively: the SDK documents the value as
+		-- "person", and a keyword written by another tool is not worth losing
+		-- over its capitalisation.
+		local keywordType = ok and type(attributes) == "table" and attributes.keywordType or nil
+		if type(keywordType) == "string" and keywordType:lower() == "person" then
+			local okName, name = LrTasks.pcall(function()
+				return keyword:getName()
+			end)
+			if okName then
+				remember(name)
+			end
+			-- A person keyword's synonyms are more names for the same person,
+			-- and Lightroom writes them into the exported keyword list beside
+			-- the name itself. Left out of this list they would stay in the
+			-- plain keywords and read as scenery again.
+			if type(attributes.synonyms) == "table" then
+				for _, synonym in ipairs(attributes.synonyms) do
+					remember(synonym)
+				end
+			end
+		end
+	end
+	return names
+end
+
+---
+-- Splits a flattened keyword list into ordinary keywords and face tags.
+--
+-- `keywordTagsForExport` flattens person keywords and the rest of the
+-- catalog's keywords into one comma-separated list, which is precisely what
+-- makes a person's name readable as scenery. Matching is case-insensitive and
+-- on the whole name, so a person called "Ivo" pulls "Ivo" out of the keywords
+-- and leaves "Ivory Coast" alone.
+--
+-- Only names that actually occur in `keywords` are reported as face tags: a
+-- person keyword excluded from export was never sent to the model before, and
+-- this change is about labelling the context correctly, not about widening it.
+--
+-- @param keywords table Array of keyword strings (may be nil).
+-- @param personNames table Array of person names from Util.getPersonKeywordNames (may be nil).
+-- @return table Keywords with every person name removed.
+-- @return table The person names found among those keywords, in catalog order.
+--
+function Util.partitionPersonKeywords(keywords, personNames)
+	local plain = {}
+	local faces = {}
+
+	local personByLower = {}
+	if type(personNames) == "table" then
+		for _, name in ipairs(personNames) do
+			if type(name) == "string" then
+				local cleaned = trim(name)
+				if cleaned ~= "" then
+					personByLower[cleaned:lower()] = cleaned
+				end
+			end
+		end
+	end
+
+	local matched = {}
+	if type(keywords) == "table" then
+		for _, keyword in ipairs(keywords) do
+			if type(keyword) == "string" then
+				local cleaned = trim(keyword)
+				if cleaned ~= "" then
+					local person = personByLower[cleaned:lower()]
+					if person then
+						matched[person] = true
+					else
+						table.insert(plain, cleaned)
+					end
+				end
+			end
+		end
+	end
+
+	if type(personNames) == "table" then
+		for _, name in ipairs(personNames) do
+			if type(name) == "string" then
+				local cleaned = trim(name)
+				if matched[cleaned] then
+					matched[cleaned] = nil
+					table.insert(faces, cleaned)
+				end
+			end
+		end
+	end
+
+	return plain, faces
+end
+
+---
 -- Extracts standardized EXIF metadata from a photo for use by the backend.
 -- Handles robustness for newer RAW formats (like .CR3) where raw metadata might be elusive.
 -- @param photo LrPhoto The photo object.

--- a/plugin/spec/spec_helper.lua
+++ b/plugin/spec/spec_helper.lua
@@ -80,6 +80,14 @@ _G.LrStringUtils.trimWhitespace = function(s)
 	return (s:gsub("^%s+", ""):gsub("%s+$", ""))
 end
 
+-- LrTasks.pcall is the SDK's yield-safe pcall, and the plugin uses it wherever
+-- a catalog call might fail. The no-op stub made every such call look like a
+-- failure, so give it the real semantics: outside a Lightroom task the only
+-- difference from Lua's pcall is that yielding is impossible anyway.
+_G.LrTasks.pcall = function(fn, ...)
+	return pcall(fn, ...)
+end
+
 -- Init.lua requires Util before ErrorHandler and APISearchIndex, so at runtime
 -- the `Util` global those modules call into is always in place. Specs require
 -- modules one at a time, in whatever order busted loads the files, so establish

--- a/plugin/spec/util_face_tags_spec.lua
+++ b/plugin/spec/util_face_tags_spec.lua
@@ -1,0 +1,140 @@
+-- Unit tests for the face-tag helpers in Util.lua.
+--
+-- Lightroom hands a named face over as an ordinary keyword, so once the
+-- keywords have been flattened to strings there is nothing left to say that
+-- "Ivo" is a person. That is how a caption ended up describing "the rocky
+-- shore of Ivo Beach" (issue #315). These cover the two halves of the fix:
+-- recognising person keywords, and keeping them out of the plain keyword list.
+
+local Util = require("Util")
+
+--- A keyword double: `keywordType` "person" is what Lightroom sets on a face.
+local function keyword(name, keywordType, synonyms)
+	return {
+		getName = function()
+			return name
+		end,
+		getAttributes = function()
+			return { keywordType = keywordType, synonyms = synonyms }
+		end,
+	}
+end
+
+--- A photo double whose `keywords` raw metadata is the given keyword list.
+local function photoWithKeywords(keywords)
+	return {
+		getRawMetadata = function(_, key)
+			if key == "keywords" then
+				return keywords
+			end
+			return nil
+		end,
+	}
+end
+
+describe("Util.getPersonKeywordNames", function()
+	it("returns only the keywords Lightroom marked as people", function()
+		local photo = photoWithKeywords({
+			keyword("Ivo", "person"),
+			keyword("Beach", nil),
+			keyword("Anna", "person"),
+		})
+		assert.are.same({ "Ivo", "Anna" }, Util.getPersonKeywordNames(photo))
+	end)
+
+	it("returns an empty list when no face was tagged", function()
+		local photo = photoWithKeywords({ keyword("Beach", nil) })
+		assert.are.same({}, Util.getPersonKeywordNames(photo))
+	end)
+
+	it("deduplicates names that differ only in case", function()
+		local photo = photoWithKeywords({ keyword("Ivo", "person"), keyword("ivo", "person") })
+		assert.are.same({ "Ivo" }, Util.getPersonKeywordNames(photo))
+	end)
+
+	it("counts a person keyword's synonyms as names too", function()
+		-- Lightroom writes synonyms into the exported keyword list beside the
+		-- name, so a nickname left out here would read as scenery again.
+		local photo = photoWithKeywords({ keyword("Ivo Martins", "person", { "Ivo" }), keyword("Beach", nil) })
+		assert.are.same({ "Ivo Martins", "Ivo" }, Util.getPersonKeywordNames(photo))
+	end)
+
+	it("ignores the synonyms of keywords that are not people", function()
+		local photo = photoWithKeywords({ keyword("Beach", nil, { "Shore" }) })
+		assert.are.same({}, Util.getPersonKeywordNames(photo))
+	end)
+
+	it("survives a keyword object without getAttributes", function()
+		-- Not every keyword-like object implements it, and a missing method
+		-- must degrade to "no face tags" rather than abort the indexing run.
+		local photo = photoWithKeywords({ {
+			getName = function()
+				return "Beach"
+			end,
+		} })
+		assert.are.same({}, Util.getPersonKeywordNames(photo))
+	end)
+
+	it("returns an empty list for a photo whose keywords cannot be read", function()
+		assert.are.same({}, Util.getPersonKeywordNames(photoWithKeywords(nil)))
+		assert.are.same({}, Util.getPersonKeywordNames(nil))
+	end)
+end)
+
+describe("Util.partitionPersonKeywords", function()
+	it("moves person names out of the keyword list", function()
+		local plain, faces = Util.partitionPersonKeywords({ "beach", "Ivo", "sunset" }, { "Ivo" })
+		assert.are.same({ "beach", "sunset" }, plain)
+		assert.are.same({ "Ivo" }, faces)
+	end)
+
+	it("matches a person name regardless of case", function()
+		local plain, faces = Util.partitionPersonKeywords({ "IVO", "beach" }, { "Ivo" })
+		assert.are.same({ "beach" }, plain)
+		-- Reported with the catalog's spelling, not the keyword list's.
+		assert.are.same({ "Ivo" }, faces)
+	end)
+
+	it("only matches whole names", function()
+		-- "Ivory Coast" is a place that merely starts with a person's name.
+		local plain, faces = Util.partitionPersonKeywords({ "Ivory Coast", "Ivo" }, { "Ivo" })
+		assert.are.same({ "Ivory Coast" }, plain)
+		assert.are.same({ "Ivo" }, faces)
+	end)
+
+	it("trims the whitespace a split keyword string leaves behind", function()
+		local plain, faces = Util.partitionPersonKeywords({ " beach", " Ivo " }, { "Ivo" })
+		assert.are.same({ "beach" }, plain)
+		assert.are.same({ "Ivo" }, faces)
+	end)
+
+	it("drops empty entries", function()
+		local plain = Util.partitionPersonKeywords({ "beach", "", "   " }, {})
+		assert.are.same({ "beach" }, plain)
+	end)
+
+	it("reports no face tags when none of the names is on this photo", function()
+		-- A person keyword excluded from export never reaches the keyword
+		-- list, and claiming they are in the frame would invent context.
+		local plain, faces = Util.partitionPersonKeywords({ "beach" }, { "Ivo" })
+		assert.are.same({ "beach" }, plain)
+		assert.are.same({}, faces)
+	end)
+
+	it("returns the keywords untouched when there are no person names", function()
+		local plain, faces = Util.partitionPersonKeywords({ "beach", "sunset" }, nil)
+		assert.are.same({ "beach", "sunset" }, plain)
+		assert.are.same({}, faces)
+	end)
+
+	it("handles a photo with no keywords at all", function()
+		local plain, faces = Util.partitionPersonKeywords(nil, { "Ivo" })
+		assert.are.same({}, plain)
+		assert.are.same({}, faces)
+	end)
+
+	it("lists each person once even when a name is tagged twice", function()
+		local _, faces = Util.partitionPersonKeywords({ "Ivo", "ivo" }, { "Ivo" })
+		assert.are.same({ "Ivo" }, faces)
+	end)
+end)

--- a/server-rs/crates/lrg-api/src/routes/edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/edit.rs
@@ -44,6 +44,9 @@ pub(crate) struct EditOptions {
     submit_keywords: bool,
     submit_folder_names: bool,
     existing_keywords: Option<Vec<String>>,
+    /// Face tags, kept apart from `existing_keywords` — see
+    /// [`lrg_providers::types::MetadataGenerationRequest::existing_face_tags`].
+    existing_face_tags: Option<Vec<String>>,
     folder_names: Option<String>,
     user_context: Option<String>,
     date_time: Option<String>,
@@ -92,6 +95,7 @@ impl Default for EditOptions {
             submit_keywords: false,
             submit_folder_names: false,
             existing_keywords: None,
+            existing_face_tags: None,
             folder_names: None,
             user_context: None,
             date_time: None,
@@ -129,14 +133,18 @@ fn bool_field(fields: &HashMap<String, String>, key: &str, default: bool) -> boo
 
 pub(crate) fn parse_edit_options_form(fields: &HashMap<String, String>) -> EditOptions {
     let defaults = EditOptions::default();
-    let existing_keywords = fields.get("existing_keywords").map(|raw| {
-        serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| {
-            raw.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect()
+    let parse_terms = |key: &str| {
+        fields.get(key).map(|raw| {
+            serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| {
+                raw.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
         })
-    });
+    };
+    let existing_keywords = parse_terms("existing_keywords");
+    let existing_face_tags = parse_terms("existing_face_tags");
     let composition_mode = fields
         .get("composition_mode")
         .map(|s| s.to_lowercase())
@@ -162,6 +170,7 @@ pub(crate) fn parse_edit_options_form(fields: &HashMap<String, String>) -> EditO
         submit_keywords: bool_field(fields, "submit_keywords", false),
         submit_folder_names: bool_field(fields, "submit_folder_names", false),
         existing_keywords,
+        existing_face_tags,
         folder_names: fields.get("folder_names").cloned(),
         user_context: fields.get("user_context").cloned(),
         date_time: fields.get("date_time").cloned(),
@@ -201,20 +210,24 @@ fn parse_edit_options_json(data: &Value) -> EditOptions {
     let get_bool =
         |key: &str, default: bool| data.get(key).and_then(Value::as_bool).unwrap_or(default);
 
-    let existing_keywords = data.get("existing_keywords").and_then(|v| match v {
-        Value::Array(arr) => Some(
-            arr.iter()
-                .filter_map(|x| x.as_str().map(str::to_string))
-                .collect(),
-        ),
-        Value::String(s) => Some(
-            s.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect(),
-        ),
-        _ => None,
-    });
+    let json_terms = |key: &str| {
+        data.get(key).and_then(|v| match v {
+            Value::Array(arr) => Some(
+                arr.iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect(),
+            ),
+            Value::String(s) => Some(
+                s.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            ),
+            _ => None,
+        })
+    };
+    let existing_keywords = json_terms("existing_keywords");
+    let existing_face_tags = json_terms("existing_face_tags");
     let composition_mode = get_str("composition_mode")
         .map(|s| s.to_lowercase())
         .filter(|s| matches!(s.as_str(), "none" | "subtle" | "aggressive"))
@@ -243,6 +256,7 @@ fn parse_edit_options_json(data: &Value) -> EditOptions {
         submit_keywords: get_bool("submit_keywords", false),
         submit_folder_names: get_bool("submit_folder_names", false),
         existing_keywords,
+        existing_face_tags,
         folder_names: get_str("folder_names"),
         user_context: get_str("user_context"),
         date_time: get_str("date_time"),
@@ -473,6 +487,7 @@ pub(crate) async fn generate_edit_recipe_for_photo(
     request.submit_keywords = options.submit_keywords;
     request.submit_folder_names = options.submit_folder_names;
     request.existing_keywords = options.existing_keywords.clone();
+    request.existing_face_tags = options.existing_face_tags.clone();
     request.folder_names = options.folder_names.clone();
     request.user_context = options.user_context.clone();
     request.date_time = options.date_time.clone();

--- a/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
@@ -14,6 +14,17 @@ use serde_json::{json, Map, Value};
 use crate::routes::index_upload::{process_batch, ImageSource, PhotoOverrides};
 use crate::state::AppState;
 
+/// Reads one `images[]` key as an array of strings; `None` when it is absent
+/// or not an array.
+fn string_array(item: &Value, key: &str) -> Option<Vec<String>> {
+    item.get(key).and_then(Value::as_array).map(|a| {
+        a.iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect()
+    })
+}
+
 /// Pulls the per-photo context out of one `images[]` entry.
 ///
 /// A grouped request carries several photos whose capture time, keywords and
@@ -28,15 +39,8 @@ fn image_overrides(item: &Value) -> PhotoOverrides {
             .get("date_time")
             .and_then(Value::as_str)
             .map(str::to_string),
-        existing_keywords: item
-            .get("existing_keywords")
-            .and_then(Value::as_array)
-            .map(|a| {
-                a.iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_string)
-                    .collect()
-            }),
+        existing_keywords: string_array(item, "existing_keywords"),
+        existing_face_tags: string_array(item, "existing_face_tags"),
         folder_names: item
             .get("folder_names")
             .and_then(Value::as_str)
@@ -160,4 +164,34 @@ async fn index_by_reference(
         false,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Face tags travel per photo in their own key. Folding them back into
+    /// `existing_keywords` would put a person's name back among the scenery,
+    /// which is what made a model write "the rocky shore of Ivo Beach"
+    /// (issue #315).
+    #[test]
+    fn per_image_face_tags_are_read_separately_from_keywords() {
+        let overrides = image_overrides(&json!({
+            "existing_keywords": ["beach", "sunset"],
+            "existing_face_tags": ["Ivo"],
+        }));
+        assert_eq!(
+            overrides.existing_keywords,
+            Some(vec!["beach".to_string(), "sunset".to_string()])
+        );
+        assert_eq!(overrides.existing_face_tags, Some(vec!["Ivo".to_string()]));
+    }
+
+    /// An older plugin sends no face-tag key at all; that must stay a
+    /// keywords-only request rather than becoming an empty people list.
+    #[test]
+    fn absent_face_tags_stay_none() {
+        let overrides = image_overrides(&json!({ "existing_keywords": ["beach"] }));
+        assert_eq!(overrides.existing_face_tags, None);
+    }
 }

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -99,6 +99,9 @@ pub(crate) struct PhotoOverrides {
     pub capture_time: Option<f64>,
     pub date_time: Option<String>,
     pub existing_keywords: Option<Vec<String>>,
+    /// Face tags for this photo, separate from `existing_keywords` — see
+    /// [`lrg_providers::types::MetadataGenerationRequest::existing_face_tags`].
+    pub existing_face_tags: Option<Vec<String>>,
     pub folder_names: Option<String>,
     /// Exposure compensation in EV (`exposureBias` in the Lightroom SDK).
     ///
@@ -133,6 +136,7 @@ struct MetadataOptions {
     /// installs keep the context they have been getting.
     submit_gps: bool,
     existing_keywords: Option<Vec<String>>,
+    existing_face_tags: Option<Vec<String>>,
     folder_names: Option<String>,
     user_context: Option<String>,
     /// Custom system prompt from the plugin's "Instructions / Prompt" field
@@ -272,14 +276,18 @@ pub(crate) fn parse_options(fields: &HashMap<String, String>) -> ParsedOptions {
             })
         });
 
-    let existing_keywords = fields.get("existing_keywords").map(|raw| {
-        serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| {
-            raw.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect()
+    let parse_terms = |key: &str| {
+        fields.get(key).map(|raw| {
+            serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| {
+                raw.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
         })
-    });
+    };
+    let existing_keywords = parse_terms("existing_keywords");
+    let existing_face_tags = parse_terms("existing_face_tags");
 
     ParsedOptions {
         compute_embeddings: has_task("embeddings"),
@@ -351,6 +359,7 @@ pub(crate) fn parse_options(fields: &HashMap<String, String>) -> ParsedOptions {
             submit_folder_names: bool_field(fields, "submit_folder_names", false),
             submit_gps: bool_field(fields, "submit_gps", true),
             existing_keywords,
+            existing_face_tags,
             folder_names: fields.get("folder_names").cloned(),
             user_context: fields.get("user_context").cloned(),
             system_prompt: fields
@@ -2042,6 +2051,10 @@ fn build_metadata_request(
             .existing_keywords
             .clone()
             .or_else(|| mo.existing_keywords.clone()),
+        existing_face_tags: overrides
+            .existing_face_tags
+            .clone()
+            .or_else(|| mo.existing_face_tags.clone()),
         location_data,
         folder_names: overrides
             .folder_names
@@ -2203,6 +2216,7 @@ mod keyword_option_tests {
             capture_time: Some(1234.0),
             date_time: Some("2026-08-07 12:00:00".to_string()),
             existing_keywords: Some(vec!["mine".to_string()]),
+            existing_face_tags: Some(vec!["Ivo".to_string()]),
             folder_names: Some("MyFolder".to_string()),
             exposure_bias: None,
             is_raw: None,
@@ -2210,6 +2224,7 @@ mod keyword_option_tests {
         let req = build_metadata_request(&opts, &overrides, &[], "p1");
         assert_eq!(req.date_time.as_deref(), Some("2026-08-07 12:00:00"));
         assert_eq!(req.existing_keywords, Some(vec!["mine".to_string()]));
+        assert_eq!(req.existing_face_tags, Some(vec!["Ivo".to_string()]));
         assert_eq!(req.folder_names.as_deref(), Some("MyFolder"));
     }
 
@@ -2226,6 +2241,32 @@ mod keyword_option_tests {
         assert_eq!(req.date_time.as_deref(), Some("2026-01-01 00:00:00"));
         assert_eq!(req.existing_keywords, Some(vec!["batch".to_string()]));
         assert_eq!(req.folder_names.as_deref(), Some("BatchFolder"));
+    }
+
+    /// Face tags arrive in their own field and stay out of the keyword list:
+    /// merged back together they would read as scenery again (issue #315).
+    #[test]
+    fn face_tags_parse_separately_from_keywords() {
+        let opts = parse_options(&fields(&[
+            ("existing_keywords", r#"["beach","sunset"]"#),
+            ("existing_face_tags", r#"["Ivo"]"#),
+        ]));
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1");
+        assert_eq!(
+            req.existing_keywords,
+            Some(vec!["beach".to_string(), "sunset".to_string()])
+        );
+        assert_eq!(req.existing_face_tags, Some(vec!["Ivo".to_string()]));
+    }
+
+    /// A plugin build that predates the split sends only `existing_keywords`;
+    /// it must keep working, with no face-tag line in the prompt.
+    #[test]
+    fn absent_face_tags_leave_the_request_unchanged() {
+        let opts = parse_options(&fields(&[("existing_keywords", r#"["beach"]"#)]));
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1");
+        assert_eq!(req.existing_keywords, Some(vec!["beach".to_string()]));
+        assert_eq!(req.existing_face_tags, None);
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/prompts.rs
+++ b/server-rs/crates/lrg-providers/src/prompts.rs
@@ -67,6 +67,40 @@ fn split_from_parts(base: String, stable: Vec<String>, per_photo: Vec<String>) -
     }
 }
 
+/// Trims, drops empties and joins a list of terms for a prompt line.
+/// Returns `None` when nothing is left, so callers can skip the line entirely.
+fn join_terms(terms: &[String]) -> Option<String> {
+    let joined = terms
+        .iter()
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if joined.is_empty() {
+        None
+    } else {
+        Some(joined)
+    }
+}
+
+/// The prompt line that tells the model a name belongs to a person.
+///
+/// Lightroom hands face tags over as plain keywords, so without this the model
+/// sees "Ivo" next to "beach" and writes "the rocky shore of Ivo Beach"
+/// (issue #315). Naming what the terms are is the whole fix; the explicit
+/// prohibition is there because a bare list still leaves the model free to
+/// read a name as a place.
+fn face_tag_line(faces: &[String]) -> Option<String> {
+    join_terms(faces).map(|joined| {
+        format!(
+            "People in this photo, named by face recognition: {joined}. These are names of \
+             people who appear in the photo. Use them only to refer to those people; never \
+             treat such a name as a place, landmark, event, brand or object, and never build \
+             a location name out of one."
+        )
+    })
+}
+
 /// Flatten nested keyword categories to a simple list (pre-order:
 /// category, then its children), matching `_flatten_keyword_categories`.
 pub fn flatten_keyword_categories(categories: &KeywordCategories) -> Vec<String> {
@@ -248,16 +282,17 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
     }
 
     if request.submit_keywords {
-        if let Some(kw) = &request.existing_keywords {
-            let joined = kw
-                .iter()
-                .map(|k| k.trim())
-                .filter(|k| !k.is_empty())
-                .collect::<Vec<_>>()
-                .join(", ");
-            if !joined.is_empty() {
-                per_photo_additions.push(format!("Some keywords are: {joined}"));
-            }
+        if let Some(joined) = request.existing_keywords.as_deref().and_then(join_terms) {
+            per_photo_additions.push(format!("Some keywords are: {joined}"));
+        }
+        // After the keywords, not before: the contrast between the two lines is
+        // what tells the model that these particular terms are not scenery.
+        if let Some(line) = request
+            .existing_face_tags
+            .as_deref()
+            .and_then(face_tag_line)
+        {
+            per_photo_additions.push(line);
         }
     }
 
@@ -497,16 +532,15 @@ pub fn prepare_edit_user_prompt_split(request: &EditGenerationRequest) -> SplitP
     // --- per-photo context: everything below changes from photo to photo ---
 
     if request.submit_keywords {
-        if let Some(kw) = &request.existing_keywords {
-            let joined = kw
-                .iter()
-                .map(|k| k.trim())
-                .filter(|k| !k.is_empty())
-                .collect::<Vec<_>>()
-                .join(", ");
-            if !joined.is_empty() {
-                per_photo_additions.push(format!("Existing keywords: {joined}"));
-            }
+        if let Some(joined) = request.existing_keywords.as_deref().and_then(join_terms) {
+            per_photo_additions.push(format!("Existing keywords: {joined}"));
+        }
+        if let Some(line) = request
+            .existing_face_tags
+            .as_deref()
+            .and_then(face_tag_line)
+        {
+            per_photo_additions.push(line);
         }
     }
     if request.submit_folder_names {
@@ -613,6 +647,55 @@ mod tests {
         req.submit_keywords = true;
         let prompt = prepare_user_prompt(&req);
         assert!(prompt.contains("Some keywords are: cat, dog"));
+    }
+
+    #[test]
+    fn face_tags_are_named_as_people_and_kept_out_of_the_keyword_line() {
+        // Issue #315: handed a face tag as an ordinary keyword, the model read
+        // "Ivo" as scenery and wrote "the rocky shore of Ivo Beach".
+        let mut req = base_request();
+        req.submit_keywords = true;
+        req.existing_keywords = Some(vec!["beach".to_string(), "sunset".to_string()]);
+        req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("Some keywords are: beach, sunset"));
+        assert!(prompt.contains("People in this photo, named by face recognition: Ivo"));
+        // The name must not also arrive as an unlabelled keyword, which is the
+        // form that caused the misreading in the first place.
+        assert!(!prompt.contains("Some keywords are: beach, sunset, Ivo"));
+    }
+
+    #[test]
+    fn face_tags_follow_the_same_switch_as_keywords() {
+        // They are the same catalog context under a different label, so the
+        // user's "existing keywords" choice governs both.
+        let mut req = base_request();
+        req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+        req.submit_keywords = false;
+        assert!(!prepare_user_prompt(&req).contains("People in this photo"));
+        req.submit_keywords = true;
+        assert!(prepare_user_prompt(&req).contains("People in this photo"));
+    }
+
+    #[test]
+    fn face_tags_stay_in_the_per_photo_half() {
+        // Who is in the frame changes with every photo; in `stable` it would
+        // cut the reusable KV-cache prefix at the first photo with a face tag.
+        let mut req = base_request();
+        req.submit_keywords = true;
+        req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+        let split = prepare_user_prompt_split(&req);
+        assert!(split.per_photo.contains("People in this photo"));
+        assert!(!split.stable.contains("People in this photo"));
+    }
+
+    #[test]
+    fn blank_face_tags_produce_no_line() {
+        let mut req = base_request();
+        req.submit_keywords = true;
+        req.existing_face_tags = Some(vec!["  ".to_string(), String::new()]);
+        assert!(!prepare_user_prompt(&req).contains("People in this photo"));
     }
 
     #[test]
@@ -825,6 +908,17 @@ mod tests {
         assert!(prompt.contains("Do not adjust white balance"));
         assert!(prompt.contains("Do not use `tone_curve.point_curve`"));
         assert!(prompt.contains("Do not use `crop`"));
+    }
+
+    #[test]
+    fn edit_prompt_labels_face_tags_as_people() {
+        let mut req = base_edit_request();
+        req.submit_keywords = true;
+        req.existing_keywords = Some(vec!["beach".to_string()]);
+        req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+        let prompt = prepare_edit_user_prompt(&req);
+        assert!(prompt.contains("Existing keywords: beach"));
+        assert!(prompt.contains("People in this photo, named by face recognition: Ivo"));
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/types.rs
+++ b/server-rs/crates/lrg-providers/src/types.rs
@@ -31,6 +31,15 @@ pub struct MetadataGenerationRequest {
     pub submit_folder_names: bool,
 
     pub existing_keywords: Option<Vec<String>>,
+    /// Names Lightroom's face recognition put on the photo, kept apart from
+    /// `existing_keywords` so the prompt can say they are people.
+    ///
+    /// Lightroom flattens a named face into the same keyword list as
+    /// everything else, and a model reading "Ivo" between "beach" and "sunset"
+    /// takes it for scenery — issue #315's "the rocky shore of Ivo Beach".
+    /// Same switch as `existing_keywords` (`submit_keywords`): this splits the
+    /// context that was already being sent, it does not add more.
+    pub existing_face_tags: Option<Vec<String>>,
     pub location_data: Option<LocationTags>,
     pub folder_names: Option<String>,
     pub user_context: Option<String>,
@@ -110,6 +119,9 @@ pub struct EditGenerationRequest {
     pub submit_folder_names: bool,
 
     pub existing_keywords: Option<Vec<String>>,
+    /// Face tags, kept apart from `existing_keywords` — see
+    /// [`MetadataGenerationRequest::existing_face_tags`].
+    pub existing_face_tags: Option<Vec<String>>,
     pub location_data: Option<LocationTags>,
     pub folder_names: Option<String>,
     pub user_context: Option<String>,
@@ -162,6 +174,7 @@ impl EditGenerationRequest {
             submit_keywords: false,
             submit_folder_names: false,
             existing_keywords: None,
+            existing_face_tags: None,
             location_data: None,
             folder_names: None,
             user_context: None,


### PR DESCRIPTION
## Summary

Fixes issue #315 where face-tagged names (e.g., "Ivo") were being read as scenery by the model, resulting in captions like "the rocky shore of Ivo Beach". The fix separates face tags from ordinary keywords throughout the system so the prompt can explicitly label them as people.

## Key Changes

**Plugin (Lua)**
- Added `Util.getPersonKeywordNames(photo)` to extract face-tagged names from a photo's keyword objects by checking for `keywordType == "person"`
- Added `Util.partitionPersonKeywords(keywords, personNames)` to split a flattened keyword list into ordinary keywords and face tags, with case-insensitive matching
- Updated `APISearchIndex.lua` to pass face tags separately in API calls via new `existing_face_tags` field
- Added comprehensive unit tests in `plugin/spec/util_face_tags_spec.lua` covering edge cases (nil handling, deduplication, synonyms, whitespace trimming)

**Backend (Rust)**
- Added `join_terms()` helper to deduplicate keyword/face-tag formatting logic
- Added `face_tag_line()` to generate an explicit prompt instruction: "People in this photo, named by face recognition: {names}. These are names of people who appear in the photo. Use them only to refer to those people; never treat such a name as a place, landmark, event, brand or object, and never build a location name out of one."
- Updated `prepare_user_prompt_split()` and `prepare_edit_user_prompt_split()` to include face tags as a separate prompt line after keywords, with the contrast between the two lines helping the model distinguish people from scenery
- Face tags follow the same `submit_keywords` switch as keywords (same catalog context, different label)
- Face tags stay in the `per_photo` section of split prompts (not `stable`), since who appears in the frame changes per photo
- Added `existing_face_tags` field to `MetadataGenerationRequest` and `EditGenerationRequest` types
- Updated form/JSON parsing in `edit.rs` and `index_upload.rs` to handle the new field
- Added tests verifying face tags are labeled as people, kept separate from keywords, and omitted when empty

**API Routes**
- `edit.rs`: Added `existing_face_tags` to `EditOptions` struct and parsing logic
- `index_upload.rs`: Added `existing_face_tags` to `PhotoOverrides` and `MetadataOptions`, with tests confirming separation from keywords
- `index_by_reference.rs`: Added `string_array()` helper and face-tag extraction from per-image JSON, with tests for backward compatibility with older plugins

**Documentation**
- Updated `Dev-Backend-API.md` to document the new `existing_face_tags` field
- Updated `Help-Analyze-and-Index.md` to explain that face-tagged names are sent separately

## Implementation Details

- Face tag extraction is defensive: missing `getAttributes()` methods degrade to "no face tags" rather than failing
- Deduplication is case-insensitive (e.g., "Ivo" and "ivo" become one entry)
- Person keyword synonyms are included as additional names (Lightroom exports them alongside the main name)
- Matching in `partitionPersonKeywords` is whole-word only ("Ivo" matches but "Ivory Coast" does not)
- Whitespace is trimmed from all keyword/face-tag strings; empty entries are dropped
- Only face tags actually present in the keyword list are reported (excluded person keywords are not invented)
- Backward compatible: older plugins sending no `existing_face_tags` field continue to work

https://claude.ai/code/session_01V8jfUV496PKXqmQkLTX83b