### PR TITLE
Let the species classifier, not the LLM, name the animal (#326)

### DIFF
--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -87,6 +87,17 @@ properties of the individual photo.
 `/v1/edit/recipe` and `/v1/edit/recipe/base64` accept the same
 `existing_keywords`/`existing_face_tags` pair, under the same switch.
 
+**Species reaches the prompt, not the request.** When `tasks` includes
+`species`, BioCLIP 2 runs *before* the LLM call rather than after it, and the
+identification is written into that photo's prompt as the answer to use (issue
+#326 — a general vision model captioned two rabbits as sheep while the species
+field on the same photo read "European Rabbit"). A coarse rank is passed on as
+a ceiling instead of a name. There is no request field for this: a photo
+identified by an earlier run contributes its *stored* identification, so a
+metadata-only re-run over already-identified photos benefits too. The line sits
+in the per-photo half of the split prompt, so the run-constant KV-cache prefix
+is unaffected.
+
 **Response:** `{status, success_count, failure_count, error_messages, warnings, results}`.
 
 `warnings` is where a *degraded success* is reported: the photo was indexed, but

--- a/docs/wiki/Help-Analyze-and-Index.md
+++ b/docs/wiki/Help-Analyze-and-Index.md
@@ -131,6 +131,24 @@ Both fields are filled in as photos are analyzed, so photos identified before
 this feature existed have them empty; re-running *Analyze & Index* over them,
 or *Retrieve Metadata from Backend*, fills them in.
 
+### The AI model is told what the classifier found
+
+When species identification and AI metadata run together, the identification
+is put into the prompt before the LLM writes anything, and the prompt says to
+use it. A general vision model is confident and often wrong about animals and
+plants — a photo of two rabbits came back titled *"Sheep in Green Pasture"*
+while the species field on the same photo read *European Rabbit* — and BioCLIP
+is a specialist trained on the tree of life, so where the two disagree the
+classifier wins.
+
+A coarse answer is passed on as a limit rather than a name: told *family:
+Leporidae*, the model is asked to stay at that level instead of inventing a
+species. Photos with no identification are unaffected, and a photo identified
+by an earlier run contributes its stored answer to a later metadata-only run.
+
+This needs no separate switch — ticking *Identify animal and plant species*
+is what turns it on.
+
 ### Why the answer is sometimes just "Aves"
 
 The model reports the **deepest rank it is actually confident about**. A clear

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -1010,6 +1010,13 @@ struct PreparedPhoto {
     existing_vector: Option<Vec<f32>>,
     existing_has_embedding: bool,
     new_embedding: Option<Vec<f32>>,
+    /// BioCLIP 2's embedding, when species identification ran and the organism
+    /// gate let the photo through. Phase 3 writes it to `SPECIES_TABLE`; the
+    /// identification itself is already folded into `main_metadata`.
+    species_vector: Option<Vec<f32>>,
+    /// Degradations phase 1 has to report — currently only species
+    /// identification, which produces one here instead of failing the photo.
+    warnings: Vec<String>,
     /// `Some` when this photo still needs an LLM call. `None` covers both
     /// "metadata generation is off" and "it already has metadata".
     llm_request: Option<lrg_providers::types::MetadataGenerationRequest>,
@@ -1238,6 +1245,47 @@ async fn prepare_one(
         new_embedding = Some(emb);
     }
 
+    // Species identification, ahead of the LLM call rather than after it.
+    // Identifying the organism is the one thing a general vision model is
+    // reliably bad at — issue #326 had a photo captioned "Sheep in Green
+    // Pasture" while the species field on the same photo read "European
+    // Rabbit" — and BioCLIP's answer can only correct the caption if it
+    // exists before the prompt is built. Everything it writes still goes into
+    // `main_metadata`, which phase 3 persists in its one coalesced upsert.
+    let mut species_vector: Option<Vec<f32>> = None;
+    let mut warnings: Vec<String> = Vec::new();
+    if options.compute_species {
+        let already_checked = main_metadata
+            .get("species_checked")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if options.regenerate_metadata || !already_checked {
+            // The organism gate scores the SigLIP embedding, which is this
+            // pass's when it computed one and the stored one otherwise —
+            // the same fallback phase 3 used to apply to `final_vector`.
+            let gate_vector = match &new_embedding {
+                Some(v) => Some(v.as_slice()),
+                None => existing
+                    .as_ref()
+                    .filter(|_| existing_has_embedding)
+                    .and_then(|r| r.vector.as_deref()),
+            };
+            match run_species(state, options, photo_id, image_bytes, gate_vector) {
+                Ok((prediction, vector)) => {
+                    apply_species_metadata(&mut main_metadata, &prediction, &state.bioclip);
+                    species_vector = vector;
+                }
+                Err(e) => {
+                    // Same contract as faces: an optional signal must never
+                    // sink the photo, and `species_checked` stays unset so a
+                    // later run retries rather than treating this as done.
+                    log::warn!("Species identification failed for {photo_id}: {e}");
+                    warnings.push(format!("{filename} species: {e}"));
+                }
+            }
+        }
+    }
+
     let llm_request = if options.compute_metadata {
         let has_any_metadata = ["title", "caption", "alt_text", "keywords"]
             .iter()
@@ -1250,7 +1298,14 @@ async fn prepare_one(
                 })
             });
         let need_metadata = options.regenerate_metadata || !has_any_metadata;
-        need_metadata.then(|| build_metadata_request(options, overrides, image_bytes, photo_id))
+        // Read back out of the metadata blob rather than from the prediction
+        // above, so a photo whose species was identified by an *earlier* run
+        // (and therefore skipped here) still gets to correct this run's
+        // prompt.
+        let detected_species = species_for_prompt(&main_metadata);
+        need_metadata.then(|| {
+            build_metadata_request(options, overrides, image_bytes, photo_id, detected_species)
+        })
     } else {
         None
     };
@@ -1263,8 +1318,43 @@ async fn prepare_one(
         existing_vector: existing.as_ref().and_then(|r| r.vector.clone()),
         existing_has_embedding,
         new_embedding,
+        species_vector,
+        warnings,
         llm_request,
     })
+}
+
+/// The species block of a photo's metadata, in the shape the prompt wants.
+///
+/// Reads the stored fields rather than taking a `TaxonomyPrediction` so it
+/// covers both cases with one path: the identification this run just made, and
+/// the one an earlier run left behind on a photo that is only here for its
+/// metadata. Returns `None` when there is no usable identification, which is
+/// what keeps the line out of the prompt entirely.
+fn species_for_prompt(
+    metadata: &Map<String, Value>,
+) -> Option<lrg_providers::types::DetectedSpecies> {
+    let field = |key: &str| {
+        metadata
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string()
+    };
+    let rank = field("species_rank");
+    if rank.is_empty() || rank == "none" {
+        return None;
+    }
+    let species = lrg_providers::types::DetectedSpecies {
+        rank,
+        taxonomy: field("species_taxonomy"),
+        scientific_name: field("species_scientific_name"),
+        common_name: field("species_common_name"),
+    };
+    if species.scientific_name.is_empty() && species.common_name.is_empty() {
+        return None;
+    }
+    Some(species)
 }
 
 /// Fields the "Replace ß with ss" option applies to: the generated text, and
@@ -1310,6 +1400,8 @@ async fn finish_one(
         existing_vector,
         existing_has_embedding,
         new_embedding,
+        species_vector,
+        warnings: warnings_from_phase_1,
         llm_request,
     } = prepared;
     let photo_id = photo_id.as_str();
@@ -1319,7 +1411,11 @@ async fn finish_one(
     // degrade independently, and a single `Option` meant whichever failed
     // second erased the other's report — the user was told about the species
     // model while the missing face model went unmentioned.
-    let mut warnings: Vec<String> = Vec::new();
+    //
+    // Seeded from phase 1 rather than started empty: species identification
+    // runs there now (its answer has to reach the prompt), and a warning it
+    // raised is the user's only sign that a photo indexed without one.
+    let mut warnings: Vec<String> = warnings_from_phase_1;
 
     if llm_request.is_some() {
         let response =
@@ -1626,40 +1722,6 @@ async fn finish_one(
                 Err(e) => {
                     log::warn!("Face detection/indexing failed for {photo_id}: {e}");
                     warnings.push(format!("{filename} faces: {e}"));
-                }
-            }
-        }
-    }
-
-    // Species identification. Runs before the coalesced write below so its
-    // results land in the same upsert as everything else — see the comment
-    // above the face block for why nothing here gets its own `merge_insert`.
-    // The 768-d BioCLIP vector is the one thing that cannot go in that write,
-    // and it goes to SPECIES_TABLE after it, like the Vertex embedding.
-    let mut species_vector: Option<Vec<f32>> = None;
-    if options.compute_species {
-        let already_checked = main_metadata
-            .get("species_checked")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        if options.regenerate_metadata || !already_checked {
-            match run_species(
-                state,
-                options,
-                photo_id,
-                &image_bytes,
-                final_vector.as_deref(),
-            ) {
-                Ok((prediction, vector)) => {
-                    apply_species_metadata(&mut main_metadata, &prediction, &state.bioclip);
-                    species_vector = vector;
-                }
-                Err(e) => {
-                    // Same contract as faces: an optional signal must never
-                    // sink the photo, and `species_checked` stays unset so a
-                    // later run retries rather than treating this as done.
-                    log::warn!("Species identification failed for {photo_id}: {e}");
-                    warnings.push(format!("{filename} species: {e}"));
                 }
             }
         }
@@ -2017,6 +2079,7 @@ fn build_metadata_request(
     overrides: &PhotoOverrides,
     image_bytes: &[u8],
     photo_id: &str,
+    detected_species: Option<lrg_providers::types::DetectedSpecies>,
 ) -> lrg_providers::types::MetadataGenerationRequest {
     let provider = provider_name(options);
     let model = options.model.clone().unwrap_or_default();
@@ -2055,6 +2118,7 @@ fn build_metadata_request(
             .existing_face_tags
             .clone()
             .or_else(|| mo.existing_face_tags.clone()),
+        detected_species,
         location_data,
         folder_names: overrides
             .folder_names
@@ -2221,7 +2285,7 @@ mod keyword_option_tests {
             exposure_bias: None,
             is_raw: None,
         };
-        let req = build_metadata_request(&opts, &overrides, &[], "p1");
+        let req = build_metadata_request(&opts, &overrides, &[], "p1", None);
         assert_eq!(req.date_time.as_deref(), Some("2026-08-07 12:00:00"));
         assert_eq!(req.existing_keywords, Some(vec!["mine".to_string()]));
         assert_eq!(req.existing_face_tags, Some(vec!["Ivo".to_string()]));
@@ -2237,7 +2301,7 @@ mod keyword_option_tests {
             ("existing_keywords", r#"["batch"]"#),
             ("folder_names", "BatchFolder"),
         ]));
-        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1");
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None);
         assert_eq!(req.date_time.as_deref(), Some("2026-01-01 00:00:00"));
         assert_eq!(req.existing_keywords, Some(vec!["batch".to_string()]));
         assert_eq!(req.folder_names.as_deref(), Some("BatchFolder"));
@@ -2251,7 +2315,7 @@ mod keyword_option_tests {
             ("existing_keywords", r#"["beach","sunset"]"#),
             ("existing_face_tags", r#"["Ivo"]"#),
         ]));
-        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1");
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None);
         assert_eq!(
             req.existing_keywords,
             Some(vec!["beach".to_string(), "sunset".to_string()])
@@ -2259,12 +2323,52 @@ mod keyword_option_tests {
         assert_eq!(req.existing_face_tags, Some(vec!["Ivo".to_string()]));
     }
 
+    /// Issue #326: the classifier's answer only helps if it reaches the
+    /// prompt, and it reaches it through the photo's stored metadata.
+    #[test]
+    fn a_stored_identification_becomes_prompt_context() {
+        let mut m = Map::new();
+        m.insert("species_rank".into(), json!("species"));
+        m.insert(
+            "species_taxonomy".into(),
+            json!("Animalia > Chordata > Mammalia"),
+        );
+        m.insert(
+            "species_scientific_name".into(),
+            json!("Oryctolagus cuniculus"),
+        );
+        m.insert("species_common_name".into(), json!("European Rabbit"));
+        let species = species_for_prompt(&m).expect("an identification");
+        assert_eq!(species.rank, "species");
+        assert_eq!(species.common_name, "European Rabbit");
+        assert_eq!(species.scientific_name, "Oryctolagus cuniculus");
+    }
+
+    /// The two shapes a photo without an organism produces: never checked, and
+    /// checked with nothing found. Neither may put a line in the prompt.
+    #[test]
+    fn no_identification_produces_no_prompt_context() {
+        assert!(species_for_prompt(&Map::new()).is_none());
+        let mut m = Map::new();
+        m.insert("species_rank".into(), json!("none"));
+        m.insert("species_checked".into(), json!(true));
+        assert!(species_for_prompt(&m).is_none());
+    }
+
+    /// A rank with neither name behind it says nothing a model could use.
+    #[test]
+    fn a_nameless_rank_produces_no_prompt_context() {
+        let mut m = Map::new();
+        m.insert("species_rank".into(), json!("genus"));
+        assert!(species_for_prompt(&m).is_none());
+    }
+
     /// A plugin build that predates the split sends only `existing_keywords`;
     /// it must keep working, with no face-tag line in the prompt.
     #[test]
     fn absent_face_tags_leave_the_request_unchanged() {
         let opts = parse_options(&fields(&[("existing_keywords", r#"["beach"]"#)]));
-        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1");
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None);
         assert_eq!(req.existing_keywords, Some(vec!["beach".to_string()]));
         assert_eq!(req.existing_face_tags, None);
     }

--- a/server-rs/crates/lrg-providers/src/prompts.rs
+++ b/server-rs/crates/lrg-providers/src/prompts.rs
@@ -14,7 +14,9 @@
 use lrg_imaging::location::format_location_for_prompt;
 
 use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
-use crate::types::{EditGenerationRequest, KeywordCategories, MetadataGenerationRequest};
+use crate::types::{
+    DetectedSpecies, EditGenerationRequest, KeywordCategories, MetadataGenerationRequest,
+};
 
 pub const DEFAULT_SYSTEM_PROMPT: &str = "You are a professional photography analyst with expertise in object recognition and computer-generated image description. \nYou also try to identify famous buildings and landmarks as well as the location where the photo was taken. \nFurthermore, you aim to specify animal and plant species as accurately as possible. \nYou also describe objects—such as vehicle types and manufacturers—as specifically as you can.";
 
@@ -99,6 +101,66 @@ fn face_tag_line(faces: &[String]) -> Option<String> {
              a location name out of one."
         )
     })
+}
+
+/// What the classifier's kingdom says the subject is, for the prompt's first
+/// word. Falls back to "organism" for the kingdoms a photographer will
+/// essentially never hit (and for a taxonomy string that arrived empty).
+fn subject_noun(taxonomy: &str) -> &'static str {
+    match taxonomy.split('>').next().map(str::trim) {
+        Some("Animalia") => "animal",
+        Some("Plantae") => "plant",
+        Some("Fungi") => "fungus",
+        _ => "organism",
+    }
+}
+
+/// The prompt line that hands BioCLIP 2's identification to the LLM.
+///
+/// The system prompt asks the model to "specify animal and plant species as
+/// accurately as possible", and a general vision model obliges with a
+/// confident wrong answer — issue #326's pair of rabbits described as sheep
+/// while the species field on the same photo read "European Rabbit". The
+/// classifier is a domain model over the tree of life, so when it has spoken
+/// the LLM's job is to use its answer, not to re-guess it.
+///
+/// Two shapes, because a coarse identification is a different instruction from
+/// a precise one: at genus or species rank there is a name to use, while a
+/// class- or family-level call means "do not go deeper than this", which is
+/// exactly the mistake being fixed.
+fn species_line(species: &DetectedSpecies) -> Option<String> {
+    let rank = species.rank.trim();
+    if rank.is_empty() || rank == "none" {
+        return None;
+    }
+    let scientific = species.scientific_name.trim();
+    let common = species.common_name.trim();
+    let name = match (common.is_empty(), scientific.is_empty()) {
+        (true, true) => return None,
+        (true, false) => scientific.to_string(),
+        (false, true) => common.to_string(),
+        (false, false) => format!("{common} ({scientific})"),
+    };
+    let noun = subject_noun(&species.taxonomy);
+
+    if rank == "species" || rank == "genus" {
+        Some(format!(
+            "The {noun} in this photo has been identified by a specialist biological \
+             classifier as: {name}. That classifier is trained on the tree of life and is \
+             more reliable here than judging the {noun} from the picture, so use this \
+             identification wherever you name the {noun} — in the title, the caption, the \
+             alt text and the keywords — and never name a different species. Only ignore it \
+             if the photo plainly contains no {noun} at all."
+        ))
+    } else {
+        Some(format!(
+            "A specialist biological classifier placed the {noun} in this photo at {rank} \
+             rank only: {name}. Describe it at that level or in plain everyday words; do not \
+             invent a more precise species or genus than the classifier gave, and do not name \
+             a different group. Only ignore this if the photo plainly contains no {noun} at \
+             all."
+        ))
+    }
 }
 
 /// Flatten nested keyword categories to a simple list (pre-order:
@@ -308,6 +370,15 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
         if !dt.trim().is_empty() {
             per_photo_additions.push(format!("Capture Time: {dt}"));
         }
+    }
+
+    // Last of the per-photo lines on purpose. It is the most specific claim
+    // anything here makes about the frame, and it has to win against the
+    // system prompt's standing instruction to name species as accurately as
+    // possible — so it sits immediately before the image, not buried between
+    // the keyword list and the folder names.
+    if let Some(line) = request.detected_species.as_ref().and_then(species_line) {
+        per_photo_additions.push(line);
     }
 
     split_from_parts(base_prompt, context_additions, per_photo_additions)
@@ -696,6 +767,87 @@ mod tests {
         req.submit_keywords = true;
         req.existing_face_tags = Some(vec!["  ".to_string(), String::new()]);
         assert!(!prepare_user_prompt(&req).contains("People in this photo"));
+    }
+
+    fn rabbit() -> DetectedSpecies {
+        DetectedSpecies {
+            rank: "species".to_string(),
+            taxonomy:
+                "Animalia > Chordata > Mammalia > Lagomorpha > Leporidae > Oryctolagus > cuniculus"
+                    .to_string(),
+            scientific_name: "Oryctolagus cuniculus".to_string(),
+            common_name: "European Rabbit".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_detected_species_is_handed_to_the_model_as_the_answer() {
+        // Issue #326: BioCLIP said "European Rabbit" and the LLM, looking at
+        // the same photo unaided, titled it "Sheep in Green Pasture".
+        let mut req = base_request();
+        req.detected_species = Some(rabbit());
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("European Rabbit (Oryctolagus cuniculus)"));
+        assert!(prompt.contains("The animal in this photo"));
+        assert!(prompt.contains("never name a different species"));
+    }
+
+    #[test]
+    fn a_coarse_identification_forbids_guessing_deeper() {
+        // The classifier reporting "family" is it saying it does not know the
+        // species. Handing that over as if it were one would reintroduce the
+        // confident wrong answer from the other direction.
+        let mut req = base_request();
+        req.detected_species = Some(DetectedSpecies {
+            rank: "family".to_string(),
+            scientific_name: "Leporidae".to_string(),
+            common_name: String::new(),
+            ..rabbit()
+        });
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("at family rank only: Leporidae"));
+        assert!(prompt.contains("do not invent a more precise species"));
+    }
+
+    #[test]
+    fn the_kingdom_decides_what_the_subject_is_called() {
+        let mut req = base_request();
+        req.detected_species = Some(DetectedSpecies {
+            taxonomy: "Plantae > Tracheophyta > Magnoliopsida".to_string(),
+            scientific_name: "Bellis perennis".to_string(),
+            common_name: "Common Daisy".to_string(),
+            ..rabbit()
+        });
+        assert!(prepare_user_prompt(&req).contains("The plant in this photo"));
+    }
+
+    #[test]
+    fn no_identification_means_no_species_line() {
+        let mut req = base_request();
+        assert!(!prepare_user_prompt(&req).contains("in this photo has been identified"));
+        // What a photo with no organism in it gets from the classifier.
+        req.detected_species = Some(DetectedSpecies {
+            rank: "none".to_string(),
+            ..Default::default()
+        });
+        assert!(!prepare_user_prompt(&req).contains("in this photo has been identified"));
+        // A rank with no name behind it is nothing to tell the model about.
+        req.detected_species = Some(DetectedSpecies {
+            rank: "species".to_string(),
+            ..Default::default()
+        });
+        assert!(!prepare_user_prompt(&req).contains("in this photo has been identified"));
+    }
+
+    #[test]
+    fn the_species_line_stays_in_the_per_photo_half() {
+        // It is the most per-photo fact there is; in `stable` it would cut the
+        // reusable KV-cache prefix at the first identified organism.
+        let mut req = base_request();
+        req.detected_species = Some(rabbit());
+        let split = prepare_user_prompt_split(&req);
+        assert!(split.per_photo.contains("European Rabbit"));
+        assert!(!split.stable.contains("European Rabbit"));
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/types.rs
+++ b/server-rs/crates/lrg-providers/src/types.rs
@@ -40,6 +40,14 @@ pub struct MetadataGenerationRequest {
     /// Same switch as `existing_keywords` (`submit_keywords`): this splits the
     /// context that was already being sent, it does not add more.
     pub existing_face_tags: Option<Vec<String>>,
+    /// What the local BioCLIP 2 classifier made of the organism in the frame,
+    /// when species identification ran for this photo.
+    ///
+    /// A vision LLM guesses at animals and plants from the whole scene and
+    /// gets them confidently wrong — issue #326's two rabbits captioned as
+    /// sheep. The classifier is a domain model over a taxonomy, so where it
+    /// speaks it outranks the LLM, and the prompt says so.
+    pub detected_species: Option<DetectedSpecies>,
     pub location_data: Option<LocationTags>,
     pub folder_names: Option<String>,
     pub user_context: Option<String>,
@@ -53,6 +61,25 @@ pub struct MetadataGenerationRequest {
 
     pub ollama_base_url: Option<String>,
     pub lmstudio_base_url: Option<String>,
+}
+
+/// One taxonomic identification, as the prompt needs it.
+///
+/// A flattened view of `lrg_ml::bioclip::TaxonomyPrediction` rather than the
+/// type itself: `lrg-providers` does not depend on `lrg-ml`, and the prompt
+/// only ever wants the winning candidate's names and how deep the classifier
+/// was willing to go.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DetectedSpecies {
+    /// `"species"` / `"genus"` / ... / `"kingdom"`. Empty or `"none"` means
+    /// the classifier declined to name anything.
+    pub rank: String,
+    /// Kingdom-down-to-rank path, `>`-joined. Not put in the prompt itself —
+    /// it is what tells the line whether to say "animal" or "plant".
+    pub taxonomy: String,
+    pub scientific_name: String,
+    /// GBIF vernacular name; often empty above species rank.
+    pub common_name: String,
 }
 
 /// Keyword hierarchy: either a flat list of category names, or a nested


### PR DESCRIPTION
Closes #326.

## The problem

BioCLIP 2 identified a photo's two rabbits as *European Rabbit*, and the LLM looking at the same frame titled it **"Sheep in Green Pasture"**. Both answers landed on the same photo, because species identification ran in phase 3 — *after* the LLM had already answered. The one model that actually knows the tree of life could never correct the one guessing from the whole scene.

## The change

Species identification moves from `finish_one` (phase 3) to `prepare_one` (phase 1), alongside the embedding and before the prompt is built, and the identification is handed to the LLM as the answer to use.

- `PreparedPhoto` carries BioCLIP's vector and any warning forward, so the coalesced phase-3 upsert, the `SPECIES_TABLE` write and the degraded-success warning chain behave exactly as before.
- **Two shapes of prompt line**, because a coarse call is a different instruction from a precise one. At genus/species rank it names the organism and forbids naming a different species; a class- or family-level call is passed on as a *ceiling* — "do not invent a more precise species than the classifier gave", which is the same mistake from the other direction.
- Both end with an escape hatch for a photo that plainly holds no organism. That is what keeps a junk coarse call out of the caption — BioCLIP answers "Insecta" at 0.48 for a human portrait.
- The line is read back out of the photo's **stored** metadata rather than from the fresh prediction, so a photo identified by an earlier species-only pass still corrects a later metadata run.
- It sits last in the per-photo half of the split prompt, leaving the run-constant KV-cache prefix untouched.

No new request field and no new switch: ticking *Identify animal and plant species* is the opt-in. One production call site (`build_metadata_request`) covers all three indexing transports.

## Verification

Live run against the built binary — `gemma-4-e4b-it-4bit` via MLX, same photo, same model:

| | title | caption |
|---|---|---|
| before | Field Hare in Dry Grassland | A medium-sized European Hare (*Lepus europaeus*)… |
| after | European Rabbit in Dry Grassland Habitat | A European rabbit (*Oryctolagus cuniculus*)… |

Also confirmed:
- a species-only pass followed by a metadata-only pass picks up the stored identification;
- `astronaut.jpg`, where BioCLIP returns a junk class-level "Insecta", still gets a caption about Buzz Aldrin — the escape hatch holds.

5 new prompt tests and 3 for `species_for_prompt`. `cargo clippy --workspace --all-targets` clean, `cargo test --workspace` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfJipuaUzNBbhQcTQBuUHg
