### PR TITLE
Discard the species too when the review is discarded (#327)

### DIFF
--- a/docs/wiki/Help-Analyze-and-Index.md
+++ b/docs/wiki/Help-Analyze-and-Index.md
@@ -238,7 +238,11 @@ Extra information sent alongside the photo to improve accuracy:
   in the backend only, and you apply them later with *Retrieve Metadata from
   Backend*.
 - **Review/Edit each photo before saving** — opens a validation dialog per
-  photo.
+  photo. A species identification appears there too, read-only (there is
+  nothing to reword in a taxonomic name) with its own *Save species* tickbox.
+  **Discard** and **Cancel** now drop the species along with everything else —
+  before, the species fields, the look-up links and the species keywords were
+  written whichever button you pressed.
 - **Import metadata from catalog before indexing** — pushes the metadata you
   already have into the backend first, so the AI does not overwrite it blindly.
 

--- a/plugin/LrGeniusAI.lrdevplugin/MetadataManager.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/MetadataManager.lua
@@ -881,6 +881,14 @@ function MetadataManager.showValidationDialog(ctx, photo, response, options)
 	-- apply time in addKeywordRecursively, so there is nothing to preview here.
 	local kwVal, kwMeta, orderedIds = Util.extractAllKeywords(keywords or {})
 
+	-- ── Species ──────────────────────────────────────────────────────────
+	-- Shown read-only, unlike everything else here: a taxonomic identification
+	-- comes from a classifier over a fixed vocabulary, so there is nothing
+	-- sensible to reword. There *is* something to decide, though — before #327
+	-- the species keywords and links were written whichever button the user
+	-- pressed, so a discarded photo kept half its results.
+	local speciesSummary = MetadataManager.speciesSummary(response.species)
+
 	-- ── Property table initialisation ────────────────────────────────────
 	for _, id in ipairs(orderedIds) do
 		local fullPath = kwVal[id] or ""
@@ -900,6 +908,7 @@ function MetadataManager.showValidationDialog(ctx, photo, response, options)
 	propertyTable.saveTitle = title ~= nil and title ~= ""
 	propertyTable.saveCaption = caption ~= nil and caption ~= ""
 	propertyTable.saveAltText = altText ~= nil and altText ~= ""
+	propertyTable.saveSpecies = speciesSummary ~= nil
 
 	-- ── Keyword rows ──────────────────────────────────────────────────────
 	local keywordRows = { spacing = 2 }
@@ -917,6 +926,110 @@ function MetadataManager.showValidationDialog(ctx, photo, response, options)
 					width_in_chars = 45,
 					immediate = true,
 					enabled = bind("saveKeywords"),
+				}),
+			})
+		)
+	end
+
+	-- ── Right panel contents ────────────────────────────────────────────
+	local rightColumn = {
+		f:group_box({
+			title = LOC("$$$/LrGeniusAI/Keywords=Keywords"),
+			fill_horizontal = 1,
+			f:row({
+				f:spacer({ fill_horizontal = 1 }),
+				f:push_button({
+					title = LOC("$$$/LrGeniusAI/MetadataManager/SelectAll=Select All"),
+					action = function()
+						for _, id in ipairs(orderedIds) do
+							propertyTable["keywordsSel_" .. id] = true
+						end
+					end,
+				}),
+				f:push_button({
+					title = LOC("$$$/LrGeniusAI/MetadataManager/DeselectAll=Deselect All"),
+					action = function()
+						for _, id in ipairs(orderedIds) do
+							propertyTable["keywordsSel_" .. id] = false
+						end
+					end,
+				}),
+				f:checkbox({
+					value = bind("saveKeywords"),
+					title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveKeywords=Save keywords"),
+				}),
+			}),
+			f:scrolled_view({
+				height = 250,
+				width = 560,
+				f:column(keywordRows),
+			}),
+		}),
+
+		f:group_box({
+			title = LOC("$$$/LrGeniusAI/Metadata=Metadata"),
+			fill_horizontal = 1,
+			f:row({
+				f:checkbox({
+					value = bind("saveTitle"),
+					title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveTitle=Save title"),
+				}),
+				f:edit_field({
+					value = bind("title"),
+					fill_horizontal = 1,
+					height_in_lines = 1,
+					enabled = bind("saveTitle"),
+				}),
+			}),
+			f:row({
+				f:checkbox({
+					value = bind("saveCaption"),
+					title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveCaption=Save caption"),
+				}),
+				f:edit_field({
+					value = bind("caption"),
+					fill_horizontal = 1,
+					height_in_lines = 5,
+					enabled = bind("saveCaption"),
+				}),
+			}),
+			f:row({
+				f:checkbox({
+					value = bind("saveAltText"),
+					title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveAltText=Save alt text"),
+				}),
+				f:edit_field({
+					value = bind("altText"),
+					fill_horizontal = 1,
+					height_in_lines = 3,
+					enabled = bind("saveAltText"),
+				}),
+			}),
+		}),
+	}
+
+	-- Appended rather than written into the table above, because most photos
+	-- have no organism in them and an empty "Species" box on every one of
+	-- them would be worse than no box at all.
+	if speciesSummary then
+		local speciesLines = {
+			f:static_text({ title = speciesSummary.name, font = "<system/bold>", width = 500 }),
+			f:static_text({ title = speciesSummary.rank, width = 500 }),
+		}
+		if speciesSummary.taxonomy ~= "" then
+			table.insert(speciesLines, f:static_text({ title = speciesSummary.taxonomy, width = 500 }))
+		end
+		table.insert(
+			rightColumn,
+			f:group_box({
+				title = "Species",
+				fill_horizontal = 1,
+				f:row({
+					f:checkbox({
+						value = bind("saveSpecies"),
+						title = "Save species",
+					}),
+					f:column(speciesLines),
 				}),
 			})
 		)
@@ -948,82 +1061,8 @@ function MetadataManager.showValidationDialog(ctx, photo, response, options)
 			}),
 		}),
 
-		-- Right panel: keywords + metadata
-		f:column({
-			f:group_box({
-				title = LOC("$$$/LrGeniusAI/Keywords=Keywords"),
-				fill_horizontal = 1,
-				f:row({
-					f:spacer({ fill_horizontal = 1 }),
-					f:push_button({
-						title = LOC("$$$/LrGeniusAI/MetadataManager/SelectAll=Select All"),
-						action = function()
-							for _, id in ipairs(orderedIds) do
-								propertyTable["keywordsSel_" .. id] = true
-							end
-						end,
-					}),
-					f:push_button({
-						title = LOC("$$$/LrGeniusAI/MetadataManager/DeselectAll=Deselect All"),
-						action = function()
-							for _, id in ipairs(orderedIds) do
-								propertyTable["keywordsSel_" .. id] = false
-							end
-						end,
-					}),
-					f:checkbox({
-						value = bind("saveKeywords"),
-						title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveKeywords=Save keywords"),
-					}),
-				}),
-				f:scrolled_view({
-					height = 250,
-					width = 560,
-					f:column(keywordRows),
-				}),
-			}),
-
-			f:group_box({
-				title = LOC("$$$/LrGeniusAI/Metadata=Metadata"),
-				fill_horizontal = 1,
-				f:row({
-					f:checkbox({
-						value = bind("saveTitle"),
-						title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveTitle=Save title"),
-					}),
-					f:edit_field({
-						value = bind("title"),
-						fill_horizontal = 1,
-						height_in_lines = 1,
-						enabled = bind("saveTitle"),
-					}),
-				}),
-				f:row({
-					f:checkbox({
-						value = bind("saveCaption"),
-						title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveCaption=Save caption"),
-					}),
-					f:edit_field({
-						value = bind("caption"),
-						fill_horizontal = 1,
-						height_in_lines = 5,
-						enabled = bind("saveCaption"),
-					}),
-				}),
-				f:row({
-					f:checkbox({
-						value = bind("saveAltText"),
-						title = LOC("$$$/lrc-ai-assistant/AnalyzeImageTask/SaveAltText=Save alt text"),
-					}),
-					f:edit_field({
-						value = bind("altText"),
-						fill_horizontal = 1,
-						height_in_lines = 3,
-						enabled = bind("saveAltText"),
-					}),
-				}),
-			}),
-		}),
+		-- Right panel: keywords, metadata, and species when there is one.
+		f:column(rightColumn),
 	})
 
 	local result = LrDialogs.presentModalDialog({
@@ -1060,6 +1099,10 @@ function MetadataManager.showValidationDialog(ctx, photo, response, options)
 	results.saveCaption = propertyTable.saveCaption
 	results.altText = propertyTable.altText
 	results.saveAltText = propertyTable.saveAltText
+	-- False both when the user unticked it and when there was no
+	-- identification to offer, so a caller can simply ask "should I write the
+	-- species?" without re-deriving whether the box was even shown.
+	results.saveSpecies = propertyTable.saveSpecies
 	results.skipFromHere = propertyTable.skipFromHere
 
 	return result, results
@@ -1267,6 +1310,50 @@ function MetadataManager.getPhotoKeywordHierarchy(photo)
 
 	-- log:trace("Photo keyword hierarchy: " .. Util.dumpTable(hierarchy))
 	return hierarchy
+end
+
+---
+-- One-line-per-fact description of a species identification, for the review
+-- dialog.
+--
+-- Pure string work, so it is testable without a catalog (see
+-- `plugin/spec/metadata_manager_spec.lua`). Returning nil when nothing was
+-- identified is what keeps the section out of the dialog entirely, rather
+-- than showing an empty box on every photo that has no organism in it.
+--
+-- @param species table|nil Backend block: rank, taxonomy, scientific_name,
+--   common_name, confidence.
+-- @return table|nil `{ name = string, rank = string, taxonomy = string }`.
+function MetadataManager.speciesSummary(species)
+	if type(species) ~= "table" then
+		return nil
+	end
+	local rank = species.rank
+	if type(rank) ~= "string" or rank == "" or rank == "none" then
+		return nil
+	end
+	local scientific = type(species.scientific_name) == "string" and Util.trim(species.scientific_name) or ""
+	local common = type(species.common_name) == "string" and Util.trim(species.common_name) or ""
+	local name
+	if common ~= "" and scientific ~= "" then
+		name = common .. " (" .. scientific .. ")"
+	elseif common ~= "" then
+		name = common
+	elseif scientific ~= "" then
+		name = scientific
+	else
+		-- A rank with neither name behind it is not something to show a user.
+		return nil
+	end
+
+	local rankLine = rank
+	local confidence = tonumber(species.confidence)
+	if confidence then
+		rankLine = rankLine .. string.format(", %d%% confidence", math.floor(confidence * 100 + 0.5))
+	end
+
+	local taxonomy = type(species.taxonomy) == "string" and Util.trim(species.taxonomy) or ""
+	return { name = name, rank = rankLine, taxonomy = taxonomy }
 end
 
 ---

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -1042,6 +1042,25 @@ LrTasks.startAsyncTask(function()
 		-- rebuilt per photo. Also lets keywords resolved for earlier photos dedupe later ones.
 		local keywordSessionCache = {}
 
+		-- Writes one photo's species identification, when the run asked for
+		-- one. A function rather than an inline block because the call now
+		-- happens at three different points: the review path can only make it
+		-- once the dialog has said whether the results were kept (#327), and
+		-- the two paths without a dialog make it straight away.
+		--
+		-- `props.enableSpecies` gates all three. The inline path used to write
+		-- whatever species the backend had on file even on a run with species
+		-- switched off, which could add species keywords nobody asked for;
+		-- backfilling old identifications is what "Retrieve metadata" is for.
+		local function saveSpecies(photo, response)
+			if props.enableSpecies and response and response.species then
+				MetadataManager.applySpecies(photo, response.species, {
+					applySpeciesKeywords = props.speciesKeywords,
+					keywordSessionCache = keywordSessionCache,
+				})
+			end
+		end
+
 		-- When validation is disabled, apply metadata inline as each photo's analysis returns
 		-- so keywords/title/caption land on photos progressively instead of all at the end.
 		-- Validation-on keeps the two-phase flow because modal dialogs must serialize on the main task.
@@ -1050,12 +1069,7 @@ LrTasks.startAsyncTask(function()
 			usedInlineApply = true
 			options.onPhotoAnalyzed = function(photo, photoId, scope)
 				local response = SearchIndexAPI.getPhotoData(photoId)
-				if response and response.species then
-					MetadataManager.applySpecies(photo, response.species, {
-						applySpeciesKeywords = props.speciesKeywords,
-						keywordSessionCache = keywordSessionCache,
-					})
-				end
+				saveSpecies(photo, response)
 				if response and response.metadata then
 					MetadataManager.applyMetadata(photo, response, nil, {
 						applyKeywords = props.generateKeywords,
@@ -1097,10 +1111,7 @@ LrTasks.startAsyncTask(function()
 				if photoId then
 					local response = SearchIndexAPI.getPhotoData(photoId)
 					if response and response.species then
-						MetadataManager.applySpecies(photo, response.species, {
-							applySpeciesKeywords = props.speciesKeywords,
-							keywordSessionCache = keywordSessionCache,
-						})
+						saveSpecies(photo, response)
 						speciesCount = speciesCount + 1
 					end
 				end
@@ -1121,16 +1132,15 @@ LrTasks.startAsyncTask(function()
 				if photoId then
 					local response = SearchIndexAPI.getPhotoData(photoId)
 
-					-- Applied here rather than in the species-only pass below so
-					-- both features share this loop's one /get per photo. Species
-					-- deliberately skips the validation dialog: a taxonomic
-					-- identification is not free text to review and edit.
-					if props.enableSpecies and response and response.species then
-						MetadataManager.applySpecies(photo, response.species, {
-							applySpeciesKeywords = props.speciesKeywords,
-							keywordSessionCache = keywordSessionCache,
-						})
-					end
+					-- Written at the end of this iteration rather than here, so
+					-- it shares the loop's one /get per photo without being
+					-- written before the user has said what to do with the
+					-- photo's results. The review dialog shows the
+					-- identification read-only — a taxonomic call is not free
+					-- text to reword — but Discard has to discard it along
+					-- with everything else, and Cancel has to write nothing
+					-- at all (#327).
+					local writeSpecies = true
 
 					log:trace("Got generated data for photo: " .. (photo:getFormattedMetadata("fileName") or "unknown"))
 					log:trace("Response: " .. (Util.dumpTable(response) or "nil"))
@@ -1152,6 +1162,8 @@ LrTasks.startAsyncTask(function()
 								log:trace("Skipping validation from here for subsequent photos.")
 								skipFromHere = true
 							end
+
+							writeSpecies = result == "ok" and validatedData ~= nil and validatedData.saveSpecies == true
 
 							if result == "ok" and validatedData then
 								-- Apply validated metadata
@@ -1219,6 +1231,12 @@ LrTasks.startAsyncTask(function()
 							keywordSessionCache = keywordSessionCache,
 						})
 						savedCount = savedCount + 1
+					end
+
+					-- The deferred write from the top of the loop. Unreachable
+					-- on Cancel, which breaks out above — that is the point.
+					if writeSpecies then
+						saveSpecies(photo, response)
 					end
 				else
 					log:error("Skipping photo data retrieval due to missing photo_id: " .. tostring(photoIdErr))

--- a/plugin/LrGeniusAI.lrdevplugin/TaskRetrieveMetadata.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskRetrieveMetadata.lua
@@ -285,7 +285,13 @@ LrTasks.startAsyncTask(function()
 						-- and Wikipedia links, most recently). Keywords stay
 						-- off — retrieving stored metadata should not reshape
 						-- the catalog's keyword tree behind the user's back.
-						MetadataManager.applySpecies(photo, retrievedData.species, { applySpeciesKeywords = false })
+						--
+						-- `validatedData` is nil whenever no dialog was shown,
+						-- which is the case that must still write; when one
+						-- was shown, it carries the user's answer (#327).
+						if validatedData == nil or validatedData.saveSpecies then
+							MetadataManager.applySpecies(photo, retrievedData.species, { applySpeciesKeywords = false })
+						end
 						successCount = successCount + 1
 						log:trace("Metadata applied successfully for photo: " .. fileName)
 

--- a/plugin/spec/metadata_manager_spec.lua
+++ b/plugin/spec/metadata_manager_spec.lua
@@ -122,3 +122,48 @@ describe("MetadataManager.speciesKeywordChain", function()
 		assert.are.same({ "Plantae", "Tracheophyta", "Magnoliopsida", "Fagales", "Fagaceae", "Quercus" }, names(result))
 	end)
 end)
+
+-- The review dialog's species section. Its only job beyond formatting is
+-- deciding when there is nothing to show: issue #327 was the species being
+-- written no matter which button the user pressed, and the fix is a section
+-- with a checkbox — which must not appear on the overwhelming majority of
+-- photos, the ones with no organism in them.
+describe("MetadataManager.speciesSummary", function()
+	local summary = MetadataManager.speciesSummary
+
+	it("puts the common name first and the binomial in parentheses", function()
+		local result = summary({
+			rank = "species",
+			taxonomy = "Animalia > Chordata > Mammalia",
+			scientific_name = "Oryctolagus cuniculus",
+			common_name = "European Rabbit",
+			confidence = 0.873,
+		})
+		assert.are.equal("European Rabbit (Oryctolagus cuniculus)", result.name)
+		assert.are.equal("species, 87% confidence", result.rank)
+		assert.are.equal("Animalia > Chordata > Mammalia", result.taxonomy)
+	end)
+
+	it("falls back to whichever name the taxon has", function()
+		assert.are.equal("Leporidae", summary({ rank = "family", scientific_name = "Leporidae" }).name)
+		assert.are.equal("Rabbits", summary({ rank = "family", common_name = "Rabbits" }).name)
+	end)
+
+	it("leaves out the confidence when the backend sent none", function()
+		assert.are.equal("genus", summary({ rank = "genus", scientific_name = "Quercus" }).rank)
+	end)
+
+	it("shows nothing when the photo holds no organism", function()
+		assert.is_nil(summary({ rank = "none", scientific_name = "", common_name = "" }))
+		assert.is_nil(summary({ rank = "" }))
+		assert.is_nil(summary(nil))
+		assert.is_nil(summary("not a table"))
+	end)
+
+	-- A rank with neither name behind it would show an empty box with a
+	-- checkbox and nothing to decide about.
+	it("shows nothing when the identification has no name", function()
+		assert.is_nil(summary({ rank = "species", scientific_name = "", common_name = "" }))
+		assert.is_nil(summary({ rank = "species" }))
+	end)
+end)


### PR DESCRIPTION
Closes #327.

## The problem

With *Identify animal and plant species* on and the results discarded (or cancelled) in the review dialog, the species fields, the iNaturalist/Wikipedia links and the species keywords were written anyway. Only the normal keywords honoured the button, so a rejected photo kept half its results — and unlike a title, a keyword branch under `Species` reshapes the catalog's keyword tree and travels with exported files.

## Why it happened

The write ran *before* the dialog was shown, on the reasoning recorded in the code: a taxonomic identification is not free text to review and edit.

That is still true of **editing** it, but not of **deciding** about it.

## The change

The identification is now shown in the review dialog — read-only, with its own **Save species** tickbox — and the write waits for the dialog's answer.

- **Discard** and **Cancel** drop the species along with everything else.
- Every path that shows no dialog (validation off, *save following without reviewing*, no metadata to review) writes it exactly as before.
- *Retrieve Metadata from Backend* reads the same answer, since it shares the dialog.

The three call sites now go through one `saveSpecies` helper. That also fixes an inconsistency between them: the inline-apply path wrote whatever species the backend had on file even on a run with species switched off, which could add species keywords nobody asked for. Backfilling old identifications is what *Retrieve Metadata* is for.

The box only appears when there is something identified — `speciesSummary` returns nil for the overwhelming majority of photos, and an empty "Species" box on every one of them would be worse than no box.

## Tests

3 new busted cases for `MetadataManager.speciesSummary` (name formatting and, above all, the cases that must show nothing). 276/276 green, stylua and luacheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfJipuaUzNBbhQcTQBuUHg
