### PR TITLE
Get the place and the people into the title and the caption (#321)

### DIFF
--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -78,12 +78,16 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 | `is_raw` | bool | Whether the original is raw. Stored on the photo so later work (style training above all) can keep raw and rendered originals apart. Omit when unknown |
 | `extra_context` | object | Optional context hints (folder, date, GPS, keywords) |
 | `existing_keywords` | string[] | The photo's keywords, *without* face tags. Only reaches the prompt when `submit_keywords` is set |
-| `existing_face_tags` | string[] | Names Lightroom's face recognition put on the photo. Sent apart from `existing_keywords` and labelled as people in the prompt, so a person's name is not read as a place (issue #315), and asked for by name in the title and caption rather than "a man and a woman" (issue #321). Same `submit_keywords` switch; omit it and the request behaves exactly as before the field existed |
+| `existing_face_tags` | string[] | Names Lightroom's face recognition put on the photo. Sent apart from `existing_keywords` and labelled as people in the prompt, so a person's name is not read as a place (issue #315), and asked for by name in the title and caption rather than "a man and a woman" (issue #321) |
+| `submit_face_tags` | bool | Whether `existing_face_tags` may reach the prompt. **Defaults to true**, unlike `submit_keywords`: a client old enough not to send this field only puts the names on the wire when its own keyword switch is on, so trusting what arrived leaves that client's behaviour unchanged. Governs the edit routes too |
 | `location_sublocation`, `location_city`, `location_state`, `location_country`, `location_country_code` | string | Where the catalog says the photo was taken. Omit a field the catalog has no value for — an empty string counts as "a place is known" and suppresses the GPS lookup below |
 | `gps_latitude`, `gps_longitude` | float | The photo's coordinates. Both or neither; a lone latitude is discarded |
 
 All seven location fields are governed by `submit_gps` (default on) and, like the
-keyword fields, are only read when metadata is generated.
+keyword fields, are only read when metadata is generated. `submit_keywords` and
+`submit_face_tags` are separate switches on purpose: sending "beach, sunset" and
+naming the people in a private photo to a cloud provider are different
+decisions, and each is expressible without the other.
 
 `/v1/index/photos/by-path` carries `exposure_bias`, `is_raw`, `existing_keywords`,
 `existing_face_tags` and the seven location fields per image inside the `images`

--- a/docs/wiki/Dev-Backend-API.md
+++ b/docs/wiki/Dev-Backend-API.md
@@ -78,11 +78,30 @@ Indexes a batch of photos sent as multipart file uploads. Generates embeddings a
 | `is_raw` | bool | Whether the original is raw. Stored on the photo so later work (style training above all) can keep raw and rendered originals apart. Omit when unknown |
 | `extra_context` | object | Optional context hints (folder, date, GPS, keywords) |
 | `existing_keywords` | string[] | The photo's keywords, *without* face tags. Only reaches the prompt when `submit_keywords` is set |
-| `existing_face_tags` | string[] | Names Lightroom's face recognition put on the photo. Sent apart from `existing_keywords` and labelled as people in the prompt, so a person's name is not read as a place (issue #315). Same `submit_keywords` switch; omit it and the request behaves exactly as before the field existed |
+| `existing_face_tags` | string[] | Names Lightroom's face recognition put on the photo. Sent apart from `existing_keywords` and labelled as people in the prompt, so a person's name is not read as a place (issue #315), and asked for by name in the title and caption rather than "a man and a woman" (issue #321). Same `submit_keywords` switch; omit it and the request behaves exactly as before the field existed |
+| `location_sublocation`, `location_city`, `location_state`, `location_country`, `location_country_code` | string | Where the catalog says the photo was taken. Omit a field the catalog has no value for — an empty string counts as "a place is known" and suppresses the GPS lookup below |
+| `gps_latitude`, `gps_longitude` | float | The photo's coordinates. Both or neither; a lone latitude is discarded |
 
-`/v1/index/photos/by-path` carries `exposure_bias`, `is_raw`, `existing_keywords` and
-`existing_face_tags` per image inside the `images` array instead, since all four are
-properties of the individual photo.
+All seven location fields are governed by `submit_gps` (default on) and, like the
+keyword fields, are only read when metadata is generated.
+
+`/v1/index/photos/by-path` carries `exposure_bias`, `is_raw`, `existing_keywords`,
+`existing_face_tags` and the seven location fields per image inside the `images`
+array instead, since they are properties of the individual photo.
+
+**Where the location comes from, in order.** The catalog fields above win,
+because they are the most current — a city corrected in Lightroom is never
+written back into a raw original. What they leave open is filled from the file
+itself: its EXIF/IPTC, read *before* normalisation, plus any XMP sidecar beside
+it. Failing a place name entirely, the coordinates are reverse-geocoded offline
+against GeoNames' `cities1000` and the prompt says the name was looked up and
+how far away it is.
+
+Reading the file's metadata before normalisation is the fix for issue #321:
+normalising re-encodes every raw original and every JPEG over 2048 px, and the
+JPEG that comes out has neither EXIF nor IPTC — so location context reached the
+model only for small exported JPEGs, and silently vanished for anyone using
+"submit originals" or an export size above 2048 px.
 
 `/v1/edit/recipe` and `/v1/edit/recipe/base64` accept the same
 `existing_keywords`/`existing_face_tags` pair, under the same switch.

--- a/docs/wiki/Dev-Plugin-README.md
+++ b/docs/wiki/Dev-Plugin-README.md
@@ -181,7 +181,10 @@ In the plugin settings dialog you can configure:
   The section reports why it is unavailable when the host cannot use it — a
   source build without the `llamacpp` feature, or a missing MLX helper.
 - Export size and quality used for AI processing
-- Prompt presets
+- Prompt presets — two ship with the plug-in: **Default** (the analytical voice)
+  and **Family & Everyday Photos** (who, where, what for, using the names your
+  catalog has on the faces). Both editable; each is offered once, so an edit or
+  a deletion sticks.
 - Optional CLIP model download for advanced search
 
 ---

--- a/docs/wiki/Help-Analyze-and-Index.md
+++ b/docs/wiki/Help-Analyze-and-Index.md
@@ -230,6 +230,24 @@ One checkbox each for **Keywords**, **Title**, **Caption**, **Alt Text**.
 
 Prompt templates, plus a free-text custom prompt appended to the built-in one.
 
+Two templates ship with the plug-in:
+
+- **Default** — the analytical voice: species, landmarks, vehicle makes,
+  described precisely. Unchanged, and still what every catalog uses unless you
+  pick otherwise.
+- **Family & Everyday Photos** — the album voice: who is in the picture, what
+  they are doing, where, and what the occasion appears to be. It asks for the
+  people by the names your catalog already has on them and for the place in the
+  title, and it is explicitly forbidden to invent what it was not given — no
+  relationships, no birthdays or weddings, no landmark the photo's own data
+  does not support. Pair it with **People's names from face recognition** and
+  **Location** below; without those it has nothing to name.
+
+Both are ordinary templates once they appear: edit them, add your own, delete
+what you do not want. A template you delete stays deleted, and one you rewrite
+stays rewritten — the plug-in only ever offers each built-in once. "Reset to
+defaults" in the prompt dialog brings both back.
+
 ---
 
 ## Context & Save
@@ -238,12 +256,23 @@ Prompt templates, plus a free-text custom prompt appended to the built-in one.
 
 Extra information sent alongside the photo to improve accuracy:
 
-- **Existing Keywords** — the photo's keywords go into the prompt. Names that
-  Lightroom's face recognition put on the photo are sent separately from the
-  rest, and labelled as the people in the picture, so a person called *Ivo* is
-  no longer read as scenery and turned into "Ivo Beach". The model is also
-  asked to *use* those names: a photo of two tagged people gets "Ivo and
-  Myriam on the beach" rather than "a man and a woman on a beach".
+- **Existing Keywords** — the photo's keywords go into the prompt.
+- **People's names from face recognition** — the names Lightroom put on the
+  faces are sent, separately from the keywords and labelled as the people in
+  the picture. Two things follow: a person called *Ivo* is no longer read as
+  scenery and turned into "Ivo Beach", and the model is asked to *use* the
+  names, so a photo of two tagged people gets "Ivo and Myriam on the beach"
+  rather than "a man and a woman on a beach". With several people named and no
+  way to tell which face is which, it names them together rather than guessing
+  who is who.
+
+  Its own switch since it is its own decision: a name identifies a person, and
+  a household happy to send "beach, sunset" to a cloud provider may well not
+  want to send "Ivo, Myriam" with it. Untick it and no name from your catalog
+  leaves the computer — for AI edits either, which never had a checkbox of
+  their own and follow this one. On upgrade it inherits whatever **Existing
+  Keywords** was set to, so nothing starts being sent that was not being sent
+  before.
 - **Folder Names**
 - **Location** — on by default, and the place reaches the prompt from whichever
   of these knows it:

--- a/docs/wiki/Help-Analyze-and-Index.md
+++ b/docs/wiki/Help-Analyze-and-Index.md
@@ -241,12 +241,33 @@ Extra information sent alongside the photo to improve accuracy:
 - **Existing Keywords** — the photo's keywords go into the prompt. Names that
   Lightroom's face recognition put on the photo are sent separately from the
   rest, and labelled as the people in the picture, so a person called *Ivo* is
-  no longer read as scenery and turned into "Ivo Beach".
+  no longer read as scenery and turned into "Ivo Beach". The model is also
+  asked to *use* those names: a photo of two tagged people gets "Ivo and
+  Myriam on the beach" rather than "a man and a woman on a beach".
 - **Folder Names**
-- **Location (looked up from the photo's GPS coordinates)** — on by default.
-  The backend turns the photo's own EXIF position into a place name and puts
-  that in the prompt; raw coordinates are never sent. Untick it and nothing
-  about where the photo was taken leaves your machine.
+- **Location** — on by default, and the place reaches the prompt from whichever
+  of these knows it:
+  1. Lightroom's own location fields (Sublocation, City, State/Province,
+     Country) as the catalog holds them, which is also the only version that
+     includes a place you corrected after import;
+  2. failing that, what the file itself carries — its IPTC/EXIF, and the XMP
+     sidecar beside a raw original;
+  3. failing that, the photo's GPS coordinates, looked up against an offline
+     list of ~145,000 places (GeoNames `cities1000`, bundled — nothing is asked
+     of the network). This is what covers the common case where Lightroom's
+     address lookup only ever *suggested* a city and you never confirmed it:
+     the suggestions are not stored anywhere the plug-in can read, but the
+     coordinates are. The prompt marks a looked-up place as looked up, and says
+     "near" when the nearest known place is more than 5 km away, so the model
+     names the area rather than inventing a landmark.
+
+  Raw coordinates only leave your machine if no place name can be worked out at
+  all. Untick the option and nothing about where the photo was taken is sent.
+
+  Two configurations used to lose the location silently, and no longer do:
+  **Submit originals instead of exports** (Plug-in Manager) and an **export size
+  above 2048 px**. Both make the backend re-encode the image, and the JPEG it
+  produces has no metadata left to read.
 - **Ask for context before each batch** — opens a dialog where you can type
   context for the upcoming photos by hand
 

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -144,6 +144,36 @@ local EXPORT_SETTINGS = {
 	LR_embeddedMetadataOption = "all",
 }
 
+--- Appends the catalog's location fields to a multipart request.
+---
+--- Shared by both upload transports, and skipped field by field: a photo the
+--- catalog knows no city for must not arrive with an empty one, because an
+--- empty string still counts as "a place is known" and would stop the backend
+--- from looking one up from the coordinates.
+---
+--- @param mimeChunks table The multipart chunk list, appended to in place.
+--- @param options table The photo's request options.
+local function appendLocationChunks(mimeChunks, options)
+	local textFields = {
+		"location_sublocation",
+		"location_city",
+		"location_state",
+		"location_country",
+		"location_country_code",
+	}
+	for _, field in ipairs(textFields) do
+		local value = options[field]
+		if type(value) == "string" and value ~= "" then
+			table.insert(mimeChunks, { name = field, value = value })
+		end
+	end
+	for _, field in ipairs({ "gps_latitude", "gps_longitude" }) do
+		if type(options[field]) == "number" then
+			table.insert(mimeChunks, { name = field, value = tostring(options[field]) })
+		end
+	end
+end
+
 -- Forward declarations for private helper functions
 local _request
 local _requestMultipart
@@ -821,6 +851,16 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 		catalog_keywords = options.catalog_keywords and JSON:encode(options.catalog_keywords) or nil,
 		date_time = options.date_time,
 		date_time_unix = options.date_time_unix,
+		-- Where the catalog says the photo was taken; absent when it does not
+		-- know, which is when the backend falls back to the file and then to
+		-- the GPS coordinates.
+		location_sublocation = options.location_sublocation,
+		location_city = options.location_city,
+		location_state = options.location_state,
+		location_country = options.location_country,
+		location_country_code = options.location_country_code,
+		gps_latitude = options.gps_latitude and tostring(options.gps_latitude) or nil,
+		gps_longitude = options.gps_longitude and tostring(options.gps_longitude) or nil,
 		ollama_base_url = options.ollama_base_url or (prefs and prefs.ollamaBaseUrl),
 		lmstudio_base_url = options.lmstudio_base_url or (prefs and prefs.lmstudioBaseUrl),
 		vertex_project_id = options.vertex_project_id,
@@ -910,6 +950,13 @@ function SearchIndexAPI.analyzeAndIndexPhotosByReference(entries, options)
 			folder_names = po.folder_names,
 			exposure_bias = po.exposure_bias,
 			is_raw = po.is_raw,
+			location_sublocation = po.location_sublocation,
+			location_city = po.location_city,
+			location_state = po.location_state,
+			location_country = po.location_country,
+			location_country_code = po.location_country_code,
+			gps_latitude = po.gps_latitude,
+			gps_longitude = po.gps_longitude,
 		})
 	end
 
@@ -1264,6 +1311,7 @@ function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 	if options.date_time then
 		table.insert(mimeChunks, { name = "date_time", value = options.date_time })
 	end
+	appendLocationChunks(mimeChunks, options)
 	if options.ollama_base_url or (prefs and prefs.ollamaBaseUrl) then
 		table.insert(mimeChunks, { name = "ollama_base_url", value = options.ollama_base_url or prefs.ollamaBaseUrl })
 	end
@@ -1374,6 +1422,7 @@ function SearchIndexAPI.analyzeAndIndexPhoto(photoId, filepath, options)
 	if options.date_time then
 		table.insert(mimeChunks, { name = "date_time", value = options.date_time })
 	end
+	appendLocationChunks(mimeChunks, options)
 	-- Exposure compensation, needed by culling's bracket detection. Only sent
 	-- when the camera recorded it; see the note in buildPhotoOptions.
 	if type(options.exposure_bias) == "number" then
@@ -2063,11 +2112,16 @@ local function buildPhotoOptions(photo, photoId, options)
 	for k, v in pairs(options) do
 		photoOptions[k] = v
 	end
-	-- No `gps_coordinates` here on purpose. The plug-in used to attach the raw
-	-- coordinates to every request and the backend never read the field: it
-	-- derives place names from the photo's own EXIF instead, which is why
-	-- `submit_gps` is the switch that matters. Sending coordinates nothing
-	-- consumes is noise, and privacy-sensitive noise at that.
+	-- The catalog's own location fields, and only under `submit_gps`: this is
+	-- the same context the switch has always governed, just taken from the
+	-- source that survives. Reading it out of the image bytes found nothing at
+	-- all for a raw original or a full-size JPEG, because normalising those
+	-- re-encodes them and the metadata does not survive (issue #321).
+	if options.submit_gps ~= false then
+		for field, value in pairs(Util.getPhotoLocation(photo)) do
+			photoOptions[field] = value
+		end
+	end
 	if options.submit_keywords then
 		local keywords = photo:getFormattedMetadata("keywordTagsForExport")
 		if keywords then

--- a/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/APISearchIndex.lua
@@ -23,6 +23,23 @@ function SearchIndexAPI.isLocalBackend()
 	return url:match("^https?://127%.0%.0%.1:") or url:match("^https?://localhost:")
 end
 
+-- Whether the names Lightroom's face recognition put on a photo may be sent
+-- with this request.
+--
+-- A caller that asked the user -- the Analyze & Index dialog has the checkbox
+-- -- passes the answer in `options.submit_face_tags`. Any other caller (the AI
+-- edit task, an automated test) says nothing, and then the saved preference
+-- decides: unticking the box in the one dialog that owns it must not be undone
+-- by a task that never asks. Only an explicit `false` turns the names off, so
+-- a missing preference still sends them, which is what every install did
+-- before the switch existed (issue #321).
+function SearchIndexAPI.wantsFaceNames(options)
+	if options ~= nil and options.submit_face_tags ~= nil then
+		return options.submit_face_tags ~= false
+	end
+	return not (prefs ~= nil and prefs.submitFaceNames == false)
+end
+
 -- Backend paths, grouped by domain. Everything lives under `/v1` except the
 -- five-path bootstrap contract below, which is deliberately unversioned: a
 -- plug-in that updates ahead of its backend still has to reach `/ping`,
@@ -836,6 +853,7 @@ function SearchIndexAPI.analyzeAndIndexPhotoByReference(photoId, filePath, optio
 		-- regardless, so a caller that does not mention it must not now lose it.
 		submit_gps = tostring(options.submit_gps ~= false),
 		submit_keywords = tostring(options.submit_keywords or false),
+		submit_face_tags = tostring(SearchIndexAPI.wantsFaceNames(options)),
 		submit_folder_names = tostring(options.submit_folder_names or false),
 		user_context = options.user_context,
 		existing_keywords = options.existing_keywords and JSON:encode(options.existing_keywords) or nil,
@@ -983,6 +1001,7 @@ function SearchIndexAPI.analyzeAndIndexPhotosByReference(entries, options)
 		-- regardless, so a caller that does not mention it must not now lose it.
 		submit_gps = tostring(options.submit_gps ~= false),
 		submit_keywords = tostring(options.submit_keywords or false),
+		submit_face_tags = tostring(SearchIndexAPI.wantsFaceNames(options)),
 		submit_folder_names = tostring(options.submit_folder_names or false),
 		user_context = base.user_context or options.user_context,
 		prompt = options.prompt,
@@ -1253,6 +1272,7 @@ function SearchIndexAPI.generateEditRecipePhoto(photoId, filepath, options)
 	-- at all (see the module comment in `routes/edit.rs`), so this stays off.
 	table.insert(mimeChunks, { name = "submit_gps", value = tostring(options.submit_gps or false) })
 	table.insert(mimeChunks, { name = "submit_keywords", value = tostring(options.submit_keywords or false) })
+	table.insert(mimeChunks, { name = "submit_face_tags", value = tostring(SearchIndexAPI.wantsFaceNames(options)) })
 	table.insert(mimeChunks, { name = "submit_folder_names", value = tostring(options.submit_folder_names or false) })
 	table.insert(mimeChunks, { name = "include_masks", value = tostring(options.include_masks ~= false) })
 
@@ -1389,6 +1409,7 @@ function SearchIndexAPI.analyzeAndIndexPhoto(photoId, filepath, options)
 	-- Absent means enabled; see the note in indexPhotosByReference.
 	table.insert(mimeChunks, { name = "submit_gps", value = tostring(options.submit_gps ~= false) })
 	table.insert(mimeChunks, { name = "submit_keywords", value = tostring(options.submit_keywords or false) })
+	table.insert(mimeChunks, { name = "submit_face_tags", value = tostring(SearchIndexAPI.wantsFaceNames(options)) })
 	table.insert(mimeChunks, { name = "submit_folder_names", value = tostring(options.submit_folder_names or false) })
 
 	if options.user_context then
@@ -2122,7 +2143,11 @@ local function buildPhotoOptions(photo, photoId, options)
 			photoOptions[field] = value
 		end
 	end
-	if options.submit_keywords then
+	-- The keyword list is read once and split, but the two halves leave the
+	-- machine under their own switches: sending "beach, sunset" and naming the
+	-- people in a private photo are different decisions (issue #321).
+	local wantsFaceNames = SearchIndexAPI.wantsFaceNames(options)
+	if options.submit_keywords or wantsFaceNames then
 		local keywords = photo:getFormattedMetadata("keywordTagsForExport")
 		if keywords then
 			local keywordList
@@ -2137,8 +2162,13 @@ local function buildPhotoOptions(photo, photoId, options)
 			-- scenery: "the rocky shore of Ivo Beach" (issue #315). Splitting
 			-- them here lets the prompt say which names are people.
 			local plainKeywords, faceTags = Util.partitionPersonKeywords(keywordList, Util.getPersonKeywordNames(photo))
-			photoOptions.existing_keywords = plainKeywords
-			if #faceTags > 0 then
+			if options.submit_keywords then
+				photoOptions.existing_keywords = plainKeywords
+			end
+			-- Never both: with names off, the split still has to happen, or the
+			-- names would ride along inside existing_keywords — which is the
+			-- bug #315 fixed, and here it would also defeat the switch.
+			if wantsFaceNames and #faceTags > 0 then
 				photoOptions.existing_face_tags = faceTags
 			end
 		end
@@ -5100,6 +5130,7 @@ function SearchIndexAPI.styleEdit(photoId, filepath, options)
 	addEditOpt("date_time", options.date_time)
 	addEditOpt("folder_names", options.folder_names)
 	addEditOpt("submit_keywords", options.submit_keywords)
+	addEditOpt("submit_face_tags", SearchIndexAPI.wantsFaceNames(options))
 	addEditOpt("submit_folder_names", options.submit_folder_names)
 	addEditOpt("include_masks", options.include_masks)
 	addEditOpt("adjust_white_balance", options.adjust_white_balance)

--- a/plugin/LrGeniusAI.lrdevplugin/Defaults.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Defaults.lua
@@ -137,6 +137,46 @@ Defaults.defaultExportSize = "3072"
 
 Defaults.defaultSystemInstruction =
 	"You are a professional photography analyst with expertise in object recognition and computer-generated image description. You also try to identify famous buildings and landmarks as well as the location where the photo was taken. Furthermore, you aim to specify animal and plant species as accurately as possible. You also describe objects—such as vehicle types and manufacturers—as specifically as you can."
+
+Defaults.familyPromptName = "Family & Everyday Photos"
+
+-- The prompts that ship with the plugin, in menu order. `Default` is the
+-- catalogue-and-stock voice the plugin has always used: it names species,
+-- landmarks and vehicle makes, and describes the people in a frame as "a man
+-- and a woman" because that is what it was asked for. That voice is wrong for
+-- the shoebox of family photos issue #321 was about, where the answer wanted is
+-- who, where and what for. Hence a second preset rather than a different
+-- default: nobody's existing output changes, and the other job is one menu
+-- pick away.
+--
+-- Both are ordinary editable prompts once seeded. Init.lua adds each one once,
+-- so a preset the user rewrites stays rewritten and one they delete stays
+-- deleted.
+Defaults.builtinPrompts = {
+	{ name = Defaults.defaultPromptName, instruction = Defaults.defaultSystemInstruction },
+	{
+		name = Defaults.familyPromptName,
+		instruction = "You are describing personal and family photographs for the people who took them. "
+			.. "Write the way someone would label their own album: say who is in the picture, what they are doing, where it happened, and what the occasion appears to be. "
+			.. "When the photo's data names the people in it, use those names in the title and the caption instead of describing them as a man, a woman or a couple. "
+			.. "When it names the place, put the place in the title where it reads naturally. "
+			.. "Prefer the people, the place and the occasion over generic scene words, and keep the tone plain and warm rather than promotional. "
+			.. "Never invent what you were not given: no names, no relationships between the people, no birthdays, weddings or holidays, and no landmark or town that the photo and its data do not support. "
+			.. "Say only what you can see or were told.",
+	},
+}
+-- The built-in prompts as the `name -> instruction` table `prefs.prompts`
+-- holds. Used by "Reset to defaults", which restores every built-in rather
+-- than only `Default` -- a reset that quietly dropped the other preset would
+-- be a reset that removes a feature.
+function Defaults.builtinPromptTable()
+	local prompts = {}
+	for _, preset in ipairs(Defaults.builtinPrompts) do
+		prompts[preset.name] = preset.instruction
+	end
+	return prompts
+end
+
 Defaults.defaultEditSystemInstruction =
 	"You are a senior Lightroom Classic retoucher. Return only a structured Lightroom edit recipe that matches the schema exactly. No prose, no markdown, no unsupported controls. Build edits in this order: white balance and exposure foundation, tonal shaping, color refinement, detail/effects. Use masks only when materially beneficial and only for subject, sky, or background. Prefer subtle, natural, premium output unless explicitly asked for a stylized look. When a curve-shaped response is needed, prefer explicit tone_curve point curves over simulating everything with contrast alone."
 Defaults.defaultEditIntent = "Natural professional Lightroom edit"

--- a/plugin/LrGeniusAI.lrdevplugin/Init.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Init.lua
@@ -129,6 +129,16 @@ if _G.prefs.submitKeywords == nil then
 	_G.prefs.submitKeywords = true
 end
 
+-- Seeded from the keyword switch rather than simply defaulting to true.
+-- Until now the names Lightroom put on faces travelled with the keywords and
+-- were sent only when that box was ticked, so anyone who had it off had never
+-- sent a name to a cloud provider. Defaulting the new switch on would start
+-- doing that silently on upgrade; taking the answer they already gave keeps
+-- every install exactly where it was. From here the two are independent.
+if _G.prefs.submitFaceNames == nil then
+	_G.prefs.submitFaceNames = _G.prefs.submitKeywords ~= false
+end
+
 if _G.prefs.temperature == nil then
 	_G.prefs.temperature = Defaults.defaultTemperature
 end
@@ -145,8 +155,15 @@ if _G.prefs.useTopLevelKeyword == nil then
 	_G.prefs.useTopLevelKeyword = true
 end
 
-if _G.prefs.prompts == nil then
-	_G.prefs.prompts = { Default = Defaults.defaultSystemInstruction }
+-- The prompts that ship with the plugin, added once each -- see
+-- Util.seedBuiltinPrompts for why "once" and not "whenever missing".
+local seededPrompts, offeredPrompts, promptsChanged =
+	Util.seedBuiltinPrompts(_G.prefs.prompts, _G.prefs.seededPrompts, Defaults.builtinPrompts)
+if promptsChanged then
+	-- Assigned back, not mutated in place: LrPrefs persists a table field when
+	-- it is written, not when its contents change.
+	_G.prefs.prompts = seededPrompts
+	_G.prefs.seededPrompts = offeredPrompts
 end
 
 if _G.prefs.prompt == nil then

--- a/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PluginInfoDialogSections.lua
@@ -71,10 +71,7 @@ function PluginInfoDialogSections.startDialog(propertyTable)
 	propertyTable.exportQuality = prefs.exportQuality
 	propertyTable.indexSubmitOriginals = (prefs.indexSubmitOriginals == true)
 
-	propertyTable.promptTitles = {}
-	for title in pairs(prefs.prompts) do
-		table.insert(propertyTable.promptTitles, { title = title, value = title })
-	end
+	propertyTable.promptTitles = Util.promptMenuItems(prefs.prompts, Defaults.defaultPromptName)
 
 	propertyTable.prompt = prefs.prompt
 	propertyTable.prompts = prefs.prompts

--- a/plugin/LrGeniusAI.lrdevplugin/PromptConfigProvider.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/PromptConfigProvider.lua
@@ -2,7 +2,7 @@ PromptConfigProvider = {}
 
 function PromptConfigProvider.deletePrompt(props)
 	local promptTitle = props.prompt
-	if promptTitle == "Default" then
+	if promptTitle == Defaults.defaultPromptName then
 		LrDialogs.showError(
 			LOC("$$$/LrGeniusAI/PromptConfig/DefaultPromptCannotDelete=Default prompt cannot be deleted.")
 		)
@@ -16,16 +16,15 @@ function PromptConfigProvider.deletePrompt(props)
 				.. promptTitle
 		) == "ok"
 	then
-		for k, v in pairs(props.promptTitles) do
-			if v.title == promptTitle then
-				props.promptTitles[k] = nil
-			end
-		end
 		props.prompts[promptTitle] = nil
+		-- Rebuilt rather than nil'd out of the array: clearing one slot of a
+		-- Lua array leaves a hole, and the menu then stops at it, hiding every
+		-- prompt after the deleted one.
+		props.promptTitles = Util.promptMenuItems(props.prompts, Defaults.defaultPromptName)
 		props.promptTitleMenu.items = props.promptTitles
 
 		if props.prompt == promptTitle then
-			props.prompt = "Default"
+			props.prompt = Defaults.defaultPromptName
 		end
 	end
 end
@@ -76,7 +75,7 @@ function PromptConfigProvider.addPrompt(props)
 	if result == "ok" then
 		props.prompts[propertyTable.name] = propertyTable.prompt
 		props.prompt = propertyTable.name
-		table.insert(props.promptTitles, { title = propertyTable.name, value = propertyTable.name })
+		props.promptTitles = Util.promptMenuItems(props.prompts, Defaults.defaultPromptName)
 		props.promptTitleMenu.items = props.promptTitles
 		return propertyTable.name
 	end
@@ -89,10 +88,7 @@ function PromptConfigProvider.showPromptConfigDialog(propertyTable)
 	local bind = LrView.bind
 	local share = LrView.share
 
-	propertyTable.promptTitles = {}
-	for title in pairs(prefs.prompts) do
-		table.insert(propertyTable.promptTitles, { title = title, value = title })
-	end
+	propertyTable.promptTitles = Util.promptMenuItems(prefs.prompts, Defaults.defaultPromptName)
 
 	propertyTable.prompts = prefs.prompts
 
@@ -178,7 +174,15 @@ function PromptConfigProvider.showPromptConfigDialog(propertyTable)
 		prefs.prompts = propertyTable.prompts
 		prefs.prompt = propertyTable.prompt
 	elseif result == "other" then
-		prefs.prompts = { Default = Defaults.defaultSystemInstruction }
-		prefs.prompt = "Default"
+		prefs.prompts = Defaults.builtinPromptTable()
+		prefs.prompt = Defaults.defaultPromptName
+		-- The built-ins are back, so the record of what has been offered has to
+		-- agree with that; otherwise nothing changes, since each name is only
+		-- ever seeded once.
+		local seeded = {}
+		for _, preset in ipairs(Defaults.builtinPrompts) do
+			seeded[preset.name] = true
+		end
+		prefs.seededPrompts = seeded
 	end
 end

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -40,10 +40,7 @@ local function showAnalyzeAndIndexDialog(ctx)
 
 	-- Metadata generation options
 	props.temperature = prefs.temperature or 0.1
-	props.promptTitles = {}
-	for title in pairs(prefs.prompts) do
-		table.insert(props.promptTitles, { title = title, value = title })
-	end
+	props.promptTitles = Util.promptMenuItems(prefs.prompts, Defaults.defaultPromptName)
 
 	props.prompt = prefs.prompt
 	props.prompts = prefs.prompts
@@ -109,6 +106,11 @@ local function showAnalyzeAndIndexDialog(ctx)
 
 	-- Context options
 	props.submitKeywords = prefs.submitKeywords or false
+	-- Its own switch since #321: whether the names Lightroom put on the faces
+	-- may be sent is a different question from how much scenery vocabulary the
+	-- model gets, and a name is the one piece of context here that identifies a
+	-- person. Init.lua seeds it from submitKeywords so upgrades change nothing.
+	props.submitFaceNames = prefs.submitFaceNames ~= false
 	props.submitFolderName = prefs.submitFolderName or false
 	-- Defaults on: the backend has always read the photo's GPS and put the
 	-- place name in the prompt, so switching it off by default would silently
@@ -521,6 +523,14 @@ local function showAnalyzeAndIndexDialog(ctx)
 					f:row({
 						f:spacer({ width = share("ctxLabelWidth") }),
 						f:checkbox({
+							value = bind("submitFaceNames"),
+							title = "People's names from face recognition",
+							tooltip = 'Lets the AI write "Ivo and Myriam at the beach" instead of "a couple at the beach". Turn it off to keep the names of the people in your photos on this computer.',
+						}),
+					}),
+					f:row({
+						f:spacer({ width = share("ctxLabelWidth") }),
+						f:checkbox({
 							value = bind("submitFolderName"),
 							title = LOC("$$$/lrc-ai-assistant/PluginInfoDialogSections/folderNames=Folder Names"),
 						}),
@@ -675,6 +685,7 @@ local function showAnalyzeAndIndexDialog(ctx)
 		prefs.temperature = props.temperature
 		prefs.maxTokens = props.maxTokens
 		prefs.submitKeywords = props.submitKeywords
+		prefs.submitFaceNames = props.submitFaceNames
 		prefs.submitFolderName = props.submitFolderName
 		prefs.submitGps = props.submitGps
 		prefs.showPhotoContextDialog = props.showPhotoContextDialog
@@ -879,6 +890,7 @@ LrTasks.startAsyncTask(function()
 			generate_title = props.generateTitle,
 			generate_alt_text = props.generateAltText,
 			submit_keywords = props.submitKeywords,
+			submit_face_tags = props.submitFaceNames,
 			submit_folder_names = props.submitFolderName,
 			submit_gps = props.submitGps,
 			submit_user_context = props.showPhotoContextDialog,

--- a/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/TaskAnalyzeAndIndex.lua
@@ -529,9 +529,9 @@ local function showAnalyzeAndIndexDialog(ctx)
 						f:spacer({ width = share("ctxLabelWidth") }),
 						f:checkbox({
 							value = bind("submitGps"),
-							title = LOC(
-								"$$$/LrGeniusAI/AnalyzeAndIndex/SubmitGps=Location (looked up from the photo's GPS coordinates)"
-							),
+							-- Plain text, not LOC: new strings are written as
+							-- finished English (see CLAUDE.md).
+							title = "Location (from the catalog, the file, or looked up from the GPS coordinates)",
 						}),
 					}),
 					f:separator({ fill_horizontal = 1 }),

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -244,6 +244,60 @@ function Util.isRawPhoto(photo)
 end
 
 ---
+-- Where the catalog says a photo was taken.
+--
+-- The backend used to read this out of the image bytes it was handed, which
+-- worked only for the small exported JPEGs: normalising a raw original -- or
+-- any JPEG over the server's 2048 px limit -- re-encodes it, and the JPEG that
+-- comes out carries neither EXIF nor IPTC. So a run with "submit originals"
+-- turned on sent no location at all, however carefully the user had set the
+-- switch (issue #321). The catalog does not have that problem, and it is also
+-- the only source that reflects a place corrected in Lightroom after import.
+--
+-- Only the confirmed fields are here. Lightroom's reverse-geocoding
+-- *suggestions* (the greyed-out ones) are not reachable through the SDK and do
+-- not reach the exported file or the XMP sidecar either -- the backend turns
+-- the coordinates into a place name itself for exactly that case.
+--
+-- @param photo LrPhoto The photo object.
+-- @return table Fields to merge into a photo's request options; empty when the
+--         catalog knows nothing about where the photo was taken.
+--
+function Util.getPhotoLocation(photo)
+	local location = {}
+	if photo == nil then
+		return location
+	end
+
+	local fields = {
+		location_sublocation = "location",
+		location_city = "city",
+		location_state = "stateProvince",
+		location_country = "country",
+		location_country_code = "isoCountryCode",
+	}
+	for field, metadataKey in pairs(fields) do
+		local value = safeGetFormattedMetadata(photo, metadataKey)
+		if type(value) == "string" then
+			local cleaned = trim(value)
+			if cleaned ~= "" then
+				location[field] = cleaned
+			end
+		end
+	end
+
+	-- Both halves or neither: a latitude on its own is not a position, and the
+	-- backend would have nothing to look a place name up with.
+	local gps = safeGetRawMetadata(photo, "gps")
+	if type(gps) == "table" and type(gps.latitude) == "number" and type(gps.longitude) == "number" then
+		location.gps_latitude = gps.latitude
+		location.gps_longitude = gps.longitude
+	end
+
+	return location
+end
+
+---
 -- Names of the people Lightroom's face recognition has tagged on a photo.
 --
 -- Lightroom stores a named face as an ordinary keyword whose `keywordType`

--- a/plugin/LrGeniusAI.lrdevplugin/Util.lua
+++ b/plugin/LrGeniusAI.lrdevplugin/Util.lua
@@ -368,6 +368,85 @@ function Util.getPersonKeywordNames(photo)
 end
 
 ---
+-- Adds the prompts that ship with the plugin to the user's set, once each.
+--
+-- "Add it if it is missing" would put a preset the user deleted back on every
+-- launch; "add it only on a fresh install" would never reach the people who
+-- already have the plugin, who are exactly the ones a new preset is for. So
+-- what is remembered is not which prompts exist but which have already been
+-- offered: seeded once, then the user's set is theirs — edits stay edited and
+-- deletions stay deleted.
+--
+-- @param prompts table|nil Map of prompt name -> instruction (the user's set).
+-- @param seeded table|nil Map of prompt name -> true, the names already offered.
+-- @param builtins table Array of `{ name = ..., instruction = ... }`, in order.
+-- @return table The prompts, with any newly offered built-in added.
+-- @return table The record of offered names, updated.
+-- @return boolean Whether anything changed and the two are worth storing.
+--
+function Util.seedBuiltinPrompts(prompts, seeded, builtins)
+	local result = prompts or {}
+	local offered = seeded or {}
+	local changed = prompts == nil or seeded == nil
+
+	for _, preset in ipairs(builtins or {}) do
+		if not offered[preset.name] then
+			-- Only when the name is free: a user who wrote their own "Default"
+			-- keeps it, and it is still marked as offered so this never runs
+			-- against that name again.
+			if result[preset.name] == nil then
+				result[preset.name] = preset.instruction
+			end
+			offered[preset.name] = true
+			changed = true
+		end
+	end
+
+	return result, offered, changed
+end
+
+---
+-- Builds the items for a prompt-picker popup menu, in a fixed order.
+--
+-- Three dialogs each built this list by iterating the prompts table with
+-- `pairs`, whose order Lua does not define and which changes between runs.
+-- With a single prompt that was invisible; the moment a second one shipped it
+-- became a menu that reorders itself behind the user's back.
+--
+-- @param prompts table Map of prompt name -> instruction text (may be nil).
+-- @param firstName string|nil A name to pin to the top (the default prompt).
+-- @return table Array of `{ title = name, value = name }`, `firstName` first
+--   and the rest alphabetically, compared case-insensitively so "beach" and
+--   "Beach" do not depend on the locale's idea of order.
+--
+function Util.promptMenuItems(prompts, firstName)
+	local names = {}
+	for name in pairs(prompts or {}) do
+		table.insert(names, name)
+	end
+	table.sort(names, function(a, b)
+		if firstName ~= nil then
+			if a == firstName then
+				return b ~= firstName
+			elseif b == firstName then
+				return false
+			end
+		end
+		local la, lb = string.lower(a), string.lower(b)
+		if la == lb then
+			return a < b
+		end
+		return la < lb
+	end)
+
+	local items = {}
+	for _, name in ipairs(names) do
+		table.insert(items, { title = name, value = name })
+	end
+	return items
+end
+
+---
 -- Splits a flattened keyword list into ordinary keywords and face tags.
 --
 -- `keywordTagsForExport` flattens person keywords and the rest of the

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -177,7 +177,10 @@ In the plugin settings dialog you can configure:
   The section reports why it is unavailable when the host cannot use it — a
   source build without the `llamacpp` feature, or a missing MLX helper.
 - Export size and quality used for AI processing
-- Prompt presets
+- Prompt presets — two ship with the plug-in: **Default** (the analytical voice)
+  and **Family & Everyday Photos** (who, where, what for, using the names your
+  catalog has on the faces). Both editable; each is offered once, so an edit or
+  a deletion sticks.
 - Optional CLIP model download for advanced search
 
 ---

--- a/plugin/spec/api_search_index_spec.lua
+++ b/plugin/spec/api_search_index_spec.lua
@@ -210,3 +210,36 @@ describe("SearchIndexAPI.summarizeRun", function()
 		assert.is_nil(warnings)
 	end)
 end)
+
+describe("SearchIndexAPI.wantsFaceNames", function()
+	local savedPref
+
+	before_each(function()
+		savedPref = prefs.submitFaceNames
+	end)
+
+	after_each(function()
+		prefs.submitFaceNames = savedPref
+	end)
+
+	it("takes the caller's answer when it has one", function()
+		prefs.submitFaceNames = true
+		assert.is_false(SearchIndexAPI.wantsFaceNames({ submit_face_tags = false }))
+		prefs.submitFaceNames = false
+		assert.is_true(SearchIndexAPI.wantsFaceNames({ submit_face_tags = true }))
+	end)
+
+	it("falls back to the saved preference when the caller says nothing", function()
+		-- The AI edit task has no checkbox of its own; unticking the box in the
+		-- Analyze dialog still has to keep the names off its requests.
+		prefs.submitFaceNames = false
+		assert.is_false(SearchIndexAPI.wantsFaceNames({}))
+		assert.is_false(SearchIndexAPI.wantsFaceNames(nil))
+	end)
+
+	it("sends the names when nobody has said otherwise", function()
+		prefs.submitFaceNames = nil
+		assert.is_true(SearchIndexAPI.wantsFaceNames({}))
+		assert.is_true(SearchIndexAPI.wantsFaceNames(nil))
+	end)
+end)

--- a/plugin/spec/util_location_spec.lua
+++ b/plugin/spec/util_location_spec.lua
@@ -1,0 +1,83 @@
+-- Unit tests for Util.getPhotoLocation.
+--
+-- The backend used to read the place a photo was taken out of the image bytes
+-- it was handed, which found nothing for a raw original or a full-size JPEG:
+-- normalising those re-encodes them, and the JPEG that comes out has neither
+-- EXIF nor IPTC (issue #321). Reading the catalog instead is what makes the
+-- location independent of what survives a conversion.
+
+local Util = require("Util")
+
+--- A photo double with the given formatted metadata and raw GPS.
+local function photoWith(formatted, gps)
+	return {
+		getFormattedMetadata = function(_, key)
+			return formatted[key]
+		end,
+		getRawMetadata = function(_, key)
+			if key == "gps" then
+				return gps
+			end
+			return nil
+		end,
+	}
+end
+
+describe("Util.getPhotoLocation", function()
+	it("maps Lightroom's location fields onto the request fields", function()
+		local photo = photoWith({
+			location = "Praia das Catedrais",
+			city = "Ribadeo",
+			stateProvince = "Galicia",
+			country = "Spain",
+			isoCountryCode = "ES",
+		}, { latitude = 43.537, longitude = -7.0409 })
+
+		assert.are.same({
+			location_sublocation = "Praia das Catedrais",
+			location_city = "Ribadeo",
+			location_state = "Galicia",
+			location_country = "Spain",
+			location_country_code = "ES",
+			gps_latitude = 43.537,
+			gps_longitude = -7.0409,
+		}, Util.getPhotoLocation(photo))
+	end)
+
+	it("sends coordinates alone when the address was never confirmed", function()
+		-- The common case behind issue #321: Lightroom's address lookup only
+		-- ever suggested a city, so nothing but the GPS fix exists. The backend
+		-- turns these into a place name itself.
+		local photo = photoWith({}, { latitude = 48.45964, longitude = 12.089297 })
+		assert.are.same({ gps_latitude = 48.45964, gps_longitude = 12.089297 }, Util.getPhotoLocation(photo))
+	end)
+
+	it("drops empty and blank fields rather than sending them", function()
+		-- An empty city still reads as "a place is known" on the far side and
+		-- would stop the coordinates from being looked up.
+		local photo = photoWith({ city = "  ", country = "Spain" }, nil)
+		assert.are.same({ location_country = "Spain" }, Util.getPhotoLocation(photo))
+	end)
+
+	it("ignores half a coordinate pair", function()
+		local photo = photoWith({}, { latitude = 43.537 })
+		assert.are.same({}, Util.getPhotoLocation(photo))
+	end)
+
+	it("returns an empty table when the catalog knows nothing", function()
+		assert.are.same({}, Util.getPhotoLocation(photoWith({}, nil)))
+		assert.are.same({}, Util.getPhotoLocation(nil))
+	end)
+
+	it("survives a photo whose metadata cannot be read", function()
+		local unreadable = {
+			getFormattedMetadata = function()
+				error("photo is offline")
+			end,
+			getRawMetadata = function()
+				error("photo is offline")
+			end,
+		}
+		assert.are.same({}, Util.getPhotoLocation(unreadable))
+	end)
+end)

--- a/plugin/spec/util_spec.lua
+++ b/plugin/spec/util_spec.lua
@@ -153,3 +153,85 @@ describe("Util.keywordToHierarchyString", function()
 		assert.are.equal("Animal", Util.keywordToHierarchyString(fakeKeyword("Animal", nil)))
 	end)
 end)
+
+describe("Util.promptMenuItems", function()
+	it("puts the default prompt first and sorts the rest alphabetically", function()
+		local items = Util.promptMenuItems({
+			["Zoo Visit"] = "z",
+			["Default"] = "d",
+			["Family & Everyday Photos"] = "f",
+		}, "Default")
+		assert.are.same({
+			{ title = "Default", value = "Default" },
+			{ title = "Family & Everyday Photos", value = "Family & Everyday Photos" },
+			{ title = "Zoo Visit", value = "Zoo Visit" },
+		}, items)
+	end)
+
+	it("orders case-insensitively and stays deterministic for equal names", function()
+		local items = Util.promptMenuItems({ ["beach"] = "1", ["Album"] = "2", ["Beach"] = "3" }, nil)
+		assert.are.same({ "Album", "Beach", "beach" }, {
+			items[1].title,
+			items[2].title,
+			items[3].title,
+		})
+	end)
+
+	it("returns an empty list rather than failing on nil", function()
+		assert.are.same({}, Util.promptMenuItems(nil, "Default"))
+	end)
+
+	it("keeps every prompt when the pinned name is not there", function()
+		local items = Util.promptMenuItems({ ["One"] = "1", ["Two"] = "2" }, "Default")
+		assert.are.equal(2, #items)
+	end)
+end)
+
+describe("Util.seedBuiltinPrompts", function()
+	local builtins = {
+		{ name = "Default", instruction = "documentary" },
+		{ name = "Family & Everyday Photos", instruction = "album voice" },
+	}
+
+	it("seeds both prompts on a fresh install", function()
+		local prompts, seeded, changed = Util.seedBuiltinPrompts(nil, nil, builtins)
+		assert.is_true(changed)
+		assert.are.equal("documentary", prompts["Default"])
+		assert.are.equal("album voice", prompts["Family & Everyday Photos"])
+		assert.is_true(seeded["Default"])
+	end)
+
+	it("adds a newly shipped prompt to an existing install", function()
+		-- What an upgrade looks like: the old default is there, edited, and the
+		-- new preset has never been offered.
+		local prompts, _, changed = Util.seedBuiltinPrompts(
+			{ Default = "my own wording" },
+			{ Default = true },
+			builtins
+		)
+		assert.is_true(changed)
+		assert.are.equal("my own wording", prompts["Default"])
+		assert.are.equal("album voice", prompts["Family & Everyday Photos"])
+	end)
+
+	it("does not resurrect a prompt the user deleted", function()
+		local prompts, _, changed = Util.seedBuiltinPrompts(
+			{ Default = "documentary" },
+			{ ["Default"] = true, ["Family & Everyday Photos"] = true },
+			builtins
+		)
+		assert.is_nil(prompts["Family & Everyday Photos"])
+		assert.is_false(changed)
+	end)
+
+	it("leaves a user's own prompt of the same name alone", function()
+		local prompts = Util.seedBuiltinPrompts({ ["Family & Everyday Photos"] = "mine" }, {}, builtins)
+		assert.are.equal("mine", prompts["Family & Everyday Photos"])
+	end)
+
+	it("reports no change once everything has been offered", function()
+		local prompts, seeded = Util.seedBuiltinPrompts(nil, nil, builtins)
+		local _, _, changed = Util.seedBuiltinPrompts(prompts, seeded, builtins)
+		assert.is_false(changed)
+	end)
+end)

--- a/server-rs/Cargo.lock
+++ b/server-rs/Cargo.lock
@@ -520,6 +520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,7 +1876,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1994,6 +2000,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "divrem"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2031,12 @@ name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "elapsed"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4e5af126dafd0741c2ad62d47f68b28602550102e5f0dd45c8a97fc8b49c29"
 
 [[package]]
 name = "encoding_rs"
@@ -2141,7 +2165,7 @@ dependencies = [
  "document-features",
  "image",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2178,6 +2202,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
 dependencies = [
  "glob",
+]
+
+[[package]]
+name = "fixed"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "num-traits",
+ "typenum",
 ]
 
 [[package]]
@@ -2393,7 +2430,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -2944,6 +2981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "init_with"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0175f63815ce00183bf755155ad0cb48c65226c5d17a724e369c25418d2b7699"
+
+[[package]]
 name = "io-uring"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3008,16 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "isocountry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea1dc4bf0fb4904ba83ffdb98af3d9c325274e92e6e295e4151e86c96363e04"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "iter-read"
@@ -3106,7 +3159,7 @@ dependencies = [
  "jiff",
  "nom 8.0.0",
  "num-traits",
- "ordered-float",
+ "ordered-float 5.3.0",
  "rand 0.9.5",
  "serde",
  "serde_json",
@@ -3307,6 +3360,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "kiddo"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c5fcd3044b774e2c80a502b2387b75d1baa95e99b2bceeb5db00f2e2d27fe9"
+dependencies = [
+ "az",
+ "divrem",
+ "doc-comment",
+ "elapsed",
+ "fixed",
+ "generator",
+ "init_with",
+ "itertools 0.13.0",
+ "log",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "sorted-vec",
+ "tracing",
+ "tracing-subscriber",
+ "ubyte",
 ]
 
 [[package]]
@@ -4144,7 +4220,7 @@ dependencies = [
  "serde_json",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4175,7 +4251,7 @@ dependencies = [
  "enumflags2",
  "llama-cpp-sys-2",
  "llguidance",
- "thiserror",
+ "thiserror 2.0.20",
  "toktrie",
  "tracing",
  "tracing-core",
@@ -4288,7 +4364,7 @@ dependencies = [
  "rusqlite",
  "serde-pickle",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4310,11 +4386,13 @@ version = "0.1.0"
 dependencies = [
  "fast_image_resize",
  "image",
+ "isocountry",
  "kamadak-exif",
  "log",
  "rawler",
+ "reverse_geocoder",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4326,7 +4404,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "toktrie",
 ]
@@ -4343,7 +4421,7 @@ dependencies = [
  "ort",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokenizers",
 ]
 
@@ -4354,7 +4432,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "uuid",
 ]
@@ -4374,7 +4452,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -4404,7 +4482,7 @@ dependencies = [
  "lrg-chroma-reader",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -4910,7 +4988,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -5001,6 +5079,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -5395,7 +5482,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -5417,7 +5504,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5580,7 +5667,7 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde",
- "thiserror",
+ "thiserror 2.0.20",
  "toml",
  "uuid",
  "weezl",
@@ -5641,7 +5728,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5763,6 +5850,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reverse_geocoder"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c987d5006fe57c099370a219602d52da978376fa7bf3324e036ad647beafda2"
+dependencies = [
+ "csv",
+ "kiddo",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5829,7 +5928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6326,6 +6425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-vec"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238653bedf881fede50103cb7838b029e2b73d3d3d8e70d36f0a96be32a65c7b"
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6531,10 +6636,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -6543,7 +6657,18 @@ version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6682,7 +6807,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.20",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -6985,6 +7110,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
 
 [[package]]
 name = "unicase"

--- a/server-rs/crates/lrg-api/src/routes/edit.rs
+++ b/server-rs/crates/lrg-api/src/routes/edit.rs
@@ -43,6 +43,10 @@ pub(crate) struct EditOptions {
     prompt: Option<String>,
     submit_keywords: bool,
     submit_folder_names: bool,
+    /// Whether the names on the photo's faces may be sent — see
+    /// [`lrg_providers::types::MetadataGenerationRequest::submit_face_tags`].
+    /// Defaults to true for the same wire-compatibility reason.
+    submit_face_tags: bool,
     existing_keywords: Option<Vec<String>>,
     /// Face tags, kept apart from `existing_keywords` — see
     /// [`lrg_providers::types::MetadataGenerationRequest::existing_face_tags`].
@@ -94,6 +98,7 @@ impl Default for EditOptions {
             prompt: None,
             submit_keywords: false,
             submit_folder_names: false,
+            submit_face_tags: true,
             existing_keywords: None,
             existing_face_tags: None,
             folder_names: None,
@@ -169,6 +174,7 @@ pub(crate) fn parse_edit_options_form(fields: &HashMap<String, String>) -> EditO
         prompt: fields.get("prompt").cloned(),
         submit_keywords: bool_field(fields, "submit_keywords", false),
         submit_folder_names: bool_field(fields, "submit_folder_names", false),
+        submit_face_tags: bool_field(fields, "submit_face_tags", true),
         existing_keywords,
         existing_face_tags,
         folder_names: fields.get("folder_names").cloned(),
@@ -255,6 +261,7 @@ fn parse_edit_options_json(data: &Value) -> EditOptions {
         prompt: get_str("prompt"),
         submit_keywords: get_bool("submit_keywords", false),
         submit_folder_names: get_bool("submit_folder_names", false),
+        submit_face_tags: get_bool("submit_face_tags", true),
         existing_keywords,
         existing_face_tags,
         folder_names: get_str("folder_names"),
@@ -486,6 +493,7 @@ pub(crate) async fn generate_edit_recipe_for_photo(
     request.system_prompt = options.prompt.clone();
     request.submit_keywords = options.submit_keywords;
     request.submit_folder_names = options.submit_folder_names;
+    request.submit_face_tags = options.submit_face_tags;
     request.existing_keywords = options.existing_keywords.clone();
     request.existing_face_tags = options.existing_face_tags.clone();
     request.folder_names = options.folder_names.clone();

--- a/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_by_reference.rs
@@ -47,6 +47,13 @@ fn image_overrides(item: &Value) -> PhotoOverrides {
             .map(str::to_string),
         exposure_bias: item.get("exposure_bias").and_then(Value::as_f64),
         is_raw: item.get("is_raw").and_then(Value::as_bool),
+        // The coordinates arrive as JSON numbers and the place names as
+        // strings, so both are rendered back to text for the shared parser.
+        location: super::index_upload::location_from_fields(&|key| match item.get(key) {
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Number(n)) => Some(n.to_string()),
+            _ => None,
+        }),
     }
 }
 
@@ -193,5 +200,32 @@ mod tests {
     fn absent_face_tags_stay_none() {
         let overrides = image_overrides(&json!({ "existing_keywords": ["beach"] }));
         assert_eq!(overrides.existing_face_tags, None);
+    }
+
+    /// Location is per photo for the same reason capture time is: a group of
+    /// sixteen photos travels in one request, and the first photo's city is
+    /// not the others' (issue #321).
+    #[test]
+    fn per_image_location_is_read_including_numeric_coordinates() {
+        let overrides = image_overrides(&json!({
+            "location_city": "Ribadeo",
+            "location_country": "Spain",
+            "gps_latitude": 43.537,
+            "gps_longitude": -7.0409,
+        }));
+        let location = overrides.location.expect("a location");
+        assert_eq!(location.city.as_deref(), Some("Ribadeo"));
+        assert_eq!(location.country.as_deref(), Some("Spain"));
+        assert_eq!(location.gps_latitude, Some(43.537));
+        assert_eq!(location.gps_longitude, Some(-7.0409));
+    }
+
+    /// A plugin that sends no location at all leaves the backend to the file
+    /// and its sidecar, exactly as before.
+    #[test]
+    fn absent_location_stays_none() {
+        assert!(image_overrides(&json!({ "existing_keywords": ["beach"] }))
+            .location
+            .is_none());
     }
 }

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -20,6 +20,7 @@ use serde_json::{json, Map, Value};
 use lrg_analysis::face_aggregate::{aggregate_face_culling_metrics, FaceMetricsInput};
 use lrg_imaging::convert::{normalize_image_bytes, UnsupportedImageError};
 use lrg_imaging::cull_config::{FaceMetricsConfig, ImageMetricsConfig};
+use lrg_imaging::location::LocationTags;
 use lrg_imaging::metrics::{culling_metrics, perceptual_hash, RgbImage};
 use lrg_ml::faces::FacePass;
 use lrg_providers::provider::{build_provider, ProviderSelection};
@@ -113,6 +114,13 @@ pub(crate) struct PhotoOverrides {
     /// Per-photo raw flag, for `/v1/index/photos/by-path`. Falls back to the
     /// batch-level [`ParsedOptions::is_raw`] when absent.
     pub is_raw: Option<bool>,
+    /// Where the catalog says this photo was taken.
+    ///
+    /// The plugin reads Lightroom's own location fields and sends them, which
+    /// is the only source that survives everything: normalising a raw original
+    /// re-encodes it to a metadata-free JPEG, and the catalog also holds
+    /// corrections the file was never rewritten with.
+    pub location: Option<LocationTags>,
 }
 
 /// The metadata-generation-specific subset of `_extract_options`, kept
@@ -135,6 +143,9 @@ struct MetadataOptions {
     /// existed on the wire but not in behaviour. Defaults to true so existing
     /// installs keep the context they have been getting.
     submit_gps: bool,
+    /// Batch-level location, for the single-photo transports. Per-photo
+    /// [`PhotoOverrides::location`] wins when both are present.
+    location: Option<LocationTags>,
     existing_keywords: Option<Vec<String>>,
     existing_face_tags: Option<Vec<String>>,
     folder_names: Option<String>,
@@ -151,6 +162,44 @@ struct MetadataOptions {
     catalog_keywords: Option<Vec<String>>,
     ollama_base_url: Option<String>,
     lmstudio_base_url: Option<String>,
+}
+
+/// Reads the catalog's location fields out of a request.
+///
+/// Shared by every transport: the multipart form sends them flat, the by-path
+/// route sends them per image, and both arrive here as string lookups. Empty
+/// strings are dropped rather than stored, so a photo Lightroom knows no city
+/// for does not arrive with an empty one that would suppress reverse geocoding.
+pub(crate) fn location_from_fields(get: &dyn Fn(&str) -> Option<String>) -> Option<LocationTags> {
+    let text = |key: &str| {
+        get(key)
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    };
+    let coordinate = |key: &str| text(key).and_then(|v| v.parse::<f64>().ok());
+
+    let tags = LocationTags {
+        location: text("location_sublocation"),
+        city: text("location_city"),
+        state: text("location_state"),
+        country: text("location_country"),
+        country_code: text("location_country_code"),
+        gps_latitude: coordinate("gps_latitude"),
+        gps_longitude: coordinate("gps_longitude"),
+        gps_place_distance_km: None,
+    };
+    // Latitude without longitude is not a position; keep the place names and
+    // drop the half-pair rather than reverse-geocoding a guess.
+    let tags = if tags.gps_latitude.is_none() || tags.gps_longitude.is_none() {
+        LocationTags {
+            gps_latitude: None,
+            gps_longitude: None,
+            ..tags
+        }
+    } else {
+        tags
+    };
+    (!tags.is_empty()).then_some(tags)
 }
 
 /// Parses the `keyword_categories` multipart field (JSON, sent by the plugin
@@ -358,6 +407,7 @@ pub(crate) fn parse_options(fields: &HashMap<String, String>) -> ParsedOptions {
             submit_keywords: bool_field(fields, "submit_keywords", false),
             submit_folder_names: bool_field(fields, "submit_folder_names", false),
             submit_gps: bool_field(fields, "submit_gps", true),
+            location: location_from_fields(&|key| fields.get(key).cloned()),
             existing_keywords,
             existing_face_tags,
             folder_names: fields.get("folder_names").cloned(),
@@ -436,6 +486,23 @@ impl ImageSource {
     }
 }
 
+/// What normalising one photo produces: the JPEG every later stage reads, the
+/// name to report it under, and whatever the original said about where it was
+/// taken before the conversion dropped its metadata.
+type NormalizedImage = (Vec<u8>, String, Option<LocationTags>);
+
+/// One photo after normalisation, on its way into phase 1.
+struct NormalizedPhoto {
+    /// The normalised JPEG every later stage reads.
+    bytes: Arc<[u8]>,
+    photo_id: String,
+    filename: String,
+    overrides: PhotoOverrides,
+    /// What the original file said about where it was taken, read before
+    /// normalisation dropped its metadata. See [`load_and_normalize`].
+    file_location: Option<LocationTags>,
+}
+
 /// One photo's bytes, or where to find them.
 enum PendingImage {
     Loaded(UploadedImage),
@@ -506,12 +573,27 @@ async fn load_pending(pending: PendingImage) -> Result<UploadedImage, String> {
 /// The raw bytes are dropped inside the blocking task, the moment the
 /// normalised JPEG exists, so they never overlap with the next photo's read
 /// any longer than they have to.
+///
+/// Location comes out of the *original* bytes, before that happens. It has to:
+/// normalisation decodes and re-encodes anything raw or larger than
+/// [`lrg_imaging::convert::default_max_long_edge`], and the JPEG it writes
+/// carries no EXIF and no IPTC — so reading location from its output found a
+/// place name only for the small exported JPEGs that pass through untouched,
+/// and silently found nothing for every raw original and every full-size
+/// camera JPEG (issue #321). For a file on disk the XMP sidecar beside it is
+/// read too, which for a raw workflow is the only place Lightroom's place
+/// names exist outside the catalog.
 async fn load_and_normalize(
     pending: PendingImage,
     photo_id: String,
     max_edge: u32,
     quality: u8,
-) -> Result<(Vec<u8>, String), String> {
+    read_location: bool,
+) -> Result<NormalizedImage, String> {
+    let source_path = match &pending {
+        PendingImage::Path(path) => Some(path.clone()),
+        PendingImage::Loaded(_) => None,
+    };
     let img = load_pending(pending).await?;
 
     let t0 = Instant::now();
@@ -519,9 +601,27 @@ async fn load_and_normalize(
     let bytes = img.bytes;
     // `normalize_image_bytes` is hundreds of milliseconds of pure CPU for a raw
     // original; it used to run directly on a tokio worker thread.
-    let (result, filename) = tokio::task::spawn_blocking(move || {
+    let (result, filename, file_location) = tokio::task::spawn_blocking(move || {
+        let location = read_location
+            .then(|| {
+                let mut tags = lrg_imaging::location::extract_location_tags(&bytes);
+                if let Some(sidecar) = source_path
+                    .as_deref()
+                    .map(std::path::Path::new)
+                    .and_then(lrg_imaging::location::read_sidecar_location)
+                {
+                    match tags.as_mut() {
+                        // The file's own EXIF/IPTC first: a sidecar can lag
+                        // behind what was last written into the image.
+                        Some(tags) => tags.merge_missing(&sidecar),
+                        None => tags = Some(sidecar),
+                    }
+                }
+                tags
+            })
+            .flatten();
         let out = normalize_image_bytes(&bytes, Some(&filename), max_edge, quality);
-        (out, filename)
+        (out, filename, location)
     })
     .await
     .map_err(|e| format!("image conversion panicked: {e}"))?;
@@ -530,7 +630,9 @@ async fn load_and_normalize(
         "Photo {photo_id} ({filename}): decode+resize+encode took {:?}",
         t0.elapsed()
     );
-    result.map_err(|UnsupportedImageError(msg)| msg)
+    result
+        .map(|(bytes, filename)| (bytes, filename, file_location))
+        .map_err(|UnsupportedImageError(msg)| msg)
 }
 
 async fn index_batch(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
@@ -663,7 +765,7 @@ pub(crate) async fn process_batch(
     // the batch is handed to the parallel cull pass, kept in `PreparedPhoto`
     // for phase 2, and read again by face detection. Each of those used to be
     // a full copy, so a 200-photo batch held the batch three times over.
-    let mut triplets: Vec<(Arc<[u8]>, String, String, PhotoOverrides)> = Vec::new();
+    let mut normalized_photos: Vec<NormalizedPhoto> = Vec::new();
     let mut conversion_errors: Vec<String> = pre_failures;
     // A bounded number of photos in flight: read, normalise, drop the original.
     // With `ImageSource::Paths` that is what keeps a group of raw files from
@@ -672,13 +774,18 @@ pub(crate) async fn process_batch(
     // in order to retry that photo alone.
     let concurrency = decode_concurrency();
     let t_decode = Instant::now();
-    let normalized: Vec<Result<(Vec<u8>, String), String>> = futures_util::stream::iter(
+    // Only when the user asked for location context; reading it means a second
+    // pass over every original's bytes plus a sidecar stat per photo.
+    let read_location = options.compute_metadata && options.metadata_request.submit_gps;
+    let normalized: Vec<Result<NormalizedImage, String>> = futures_util::stream::iter(
         images
             .into_pending()
             .into_iter()
             .zip(photo_ids.iter().cloned()),
     )
-    .map(|(pending, photo_id)| load_and_normalize(pending, photo_id, max_edge, quality))
+    .map(|(pending, photo_id)| {
+        load_and_normalize(pending, photo_id, max_edge, quality, read_location)
+    })
     .buffered(concurrency)
     .collect()
     .await;
@@ -692,9 +799,13 @@ pub(crate) async fn process_batch(
         photo_ids.into_iter().zip(overrides).zip(normalized)
     {
         match result {
-            Ok((bytes, filename)) => {
-                triplets.push((Arc::from(bytes), photo_id, filename, photo_overrides))
-            }
+            Ok((bytes, filename, file_location)) => normalized_photos.push(NormalizedPhoto {
+                bytes: Arc::from(bytes),
+                photo_id,
+                filename,
+                overrides: photo_overrides,
+                file_location,
+            }),
             Err(msg) => {
                 log::warn!("Skipping {photo_id}: {msg}");
                 results.push(json!({
@@ -705,7 +816,7 @@ pub(crate) async fn process_batch(
         }
     }
 
-    if triplets.is_empty() {
+    if normalized_photos.is_empty() {
         if !conversion_errors.is_empty() {
             let joined = conversion_errors
                 .iter()
@@ -746,35 +857,43 @@ pub(crate) async fn process_batch(
     // parallel. Pure CPU work with no model behind it, so unlike phase 1 there
     // is nothing here that wants the whole machine to itself.
     let t_cull = Instant::now();
-    let image_blobs: Vec<Arc<[u8]>> = triplets.iter().map(|(b, _, _, _)| Arc::clone(b)).collect();
+    let image_blobs: Vec<Arc<[u8]>> = normalized_photos
+        .iter()
+        .map(|p| Arc::clone(&p.bytes))
+        .collect();
     let mut cull_signals =
         tokio::task::spawn_blocking(move || precompute_cull_signals(&image_blobs))
             .await
             .unwrap_or_else(|e| vec![Err(format!("cull metric pass panicked: {e}"))]);
-    if !triplets.is_empty() {
+    if !normalized_photos.is_empty() {
         log::debug!(
             "Cull signals for {} photo(s) took {:?}",
-            triplets.len(),
+            normalized_photos.len(),
             t_cull.elapsed()
         );
     }
     // A join failure yields a single error; widen it so the zip below still
     // lines up one entry per photo.
-    if cull_signals.len() != triplets.len() {
+    if cull_signals.len() != normalized_photos.len() {
         let msg = cull_signals
             .first()
             .and_then(|r| r.as_ref().err().cloned())
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| "cull metric pass produced no result".to_string());
-        cull_signals = triplets.iter().map(|_| Err(msg.clone())).collect();
+        cull_signals = normalized_photos.iter().map(|_| Err(msg.clone())).collect();
     }
 
     // Phase 1 — everything that does not need the LLM, still strictly
     // sequential (SigLIP2 and the face detector each want the whole machine).
-    let mut prepared: Vec<PreparedPhoto> = Vec::with_capacity(triplets.len());
-    for ((image_bytes, photo_id, filename, photo_overrides), cull) in
-        triplets.into_iter().zip(cull_signals)
-    {
+    let mut prepared: Vec<PreparedPhoto> = Vec::with_capacity(normalized_photos.len());
+    for (photo, cull) in normalized_photos.into_iter().zip(cull_signals) {
+        let NormalizedPhoto {
+            bytes: image_bytes,
+            photo_id,
+            filename,
+            overrides: photo_overrides,
+            file_location,
+        } = photo;
         let Some(store_ref) = store.as_ref() else {
             failure_count += 1;
             let msg = "database not initialized (no db_path bound)";
@@ -803,6 +922,7 @@ pub(crate) async fn process_batch(
             &image_bytes,
             &photo_id,
             &filename,
+            file_location.as_ref(),
             cull,
         )
         .await
@@ -1094,6 +1214,7 @@ async fn prepare_one(
     image_bytes: &Arc<[u8]>,
     photo_id: &str,
     filename: &str,
+    file_location: Option<&LocationTags>,
     cull: CullSignals,
 ) -> Result<PreparedPhoto, String> {
     // The cull signals arrive precomputed from the parallel pass, so the only
@@ -1304,7 +1425,14 @@ async fn prepare_one(
         // prompt.
         let detected_species = species_for_prompt(&main_metadata);
         need_metadata.then(|| {
-            build_metadata_request(options, overrides, image_bytes, photo_id, detected_species)
+            build_metadata_request(
+                options,
+                overrides,
+                image_bytes,
+                photo_id,
+                file_location,
+                detected_species,
+            )
         })
     } else {
         None
@@ -2070,6 +2198,68 @@ async fn provider_for_batch(
     })
 }
 
+/// Assembles one photo's location from every source that knows something, in
+/// order of how much each one knows about what the photographer meant.
+///
+/// 1. What the plugin read out of the Lightroom catalog for this photo. It is
+///    the most current — a city corrected in Lightroom is never written back
+///    into a raw original — and the only source a re-encoded file cannot lose.
+/// 2. What the file itself carries: its EXIF/IPTC, plus any XMP sidecar,
+///    read before normalisation ([`load_and_normalize`]).
+/// 3. Failing a place name, the nearest settlement to the coordinates.
+///
+/// Step 3 only ever runs when the first two produced no name at all. A place
+/// on the photo is a statement; the nearest town to a fix is an estimate, and
+/// mixing the two would pair a photographer's sub-location with a country
+/// looked up from somewhere else.
+fn resolve_location(
+    overrides: &PhotoOverrides,
+    mo: &MetadataOptions,
+    file_location: Option<&LocationTags>,
+    image_bytes: &[u8],
+    photo_id: &str,
+) -> Option<LocationTags> {
+    let mut location = overrides
+        .location
+        .clone()
+        .or_else(|| mo.location.clone())
+        .unwrap_or_default();
+
+    match file_location {
+        Some(from_file) => location.merge_missing(from_file),
+        // No pre-normalisation read happened (an older caller, or a test):
+        // fall back to the normalised bytes, which is all this used to do.
+        None => {
+            if let Some(from_bytes) = lrg_imaging::location::extract_location_tags(image_bytes) {
+                location.merge_missing(&from_bytes);
+            }
+        }
+    }
+
+    let geocoded = lrg_imaging::geocode::fill_place_from_gps(&mut location);
+    if location.is_empty() {
+        return None;
+    }
+    // One line per photo saying what the model will be told and where it came
+    // from. "The location is wrong" and "the location is missing" are
+    // different bugs with the same symptom in the caption, and this is what
+    // tells them apart in a support log.
+    log::debug!(
+        "Photo {photo_id}: location {:?} ({})",
+        lrg_imaging::location::format_location_for_prompt(&location),
+        match (
+            geocoded,
+            overrides.location.is_some() || mo.location.is_some()
+        ) {
+            (true, _) => "looked up from GPS",
+            (false, true) => "from the catalog",
+            (false, false) => "from the file",
+        }
+    );
+
+    Some(location)
+}
+
 /// Builds one photo's `MetadataGenerationRequest` from the parsed options.
 ///
 /// Pure and cheap on purpose: phase 1 builds these for the whole group, and
@@ -2079,20 +2269,20 @@ fn build_metadata_request(
     overrides: &PhotoOverrides,
     image_bytes: &[u8],
     photo_id: &str,
+    file_location: Option<&LocationTags>,
     detected_species: Option<lrg_providers::types::DetectedSpecies>,
 ) -> lrg_providers::types::MetadataGenerationRequest {
     let provider = provider_name(options);
     let model = options.model.clone().unwrap_or_default();
     let mo = &options.metadata_request;
 
-    // Reading the EXIF location is what turns "this photo was taken at these
-    // coordinates" into a place name in the prompt, so it is gated on the
-    // user's choice rather than done unconditionally.
-    let location_data = if mo.submit_gps {
-        lrg_imaging::location::extract_location_tags(image_bytes)
-    } else {
-        None
-    };
+    // Turning "these coordinates" into a place name is what puts the place in
+    // the title and the caption, so it is gated on the user's choice rather
+    // than done unconditionally.
+    let location_data = mo
+        .submit_gps
+        .then(|| resolve_location(overrides, mo, file_location, image_bytes, photo_id))
+        .flatten();
     lrg_providers::types::MetadataGenerationRequest {
         image_data: image_bytes.to_vec(),
         uuid: photo_id.to_string(),
@@ -2284,8 +2474,9 @@ mod keyword_option_tests {
             folder_names: Some("MyFolder".to_string()),
             exposure_bias: None,
             is_raw: None,
+            location: None,
         };
-        let req = build_metadata_request(&opts, &overrides, &[], "p1", None);
+        let req = build_metadata_request(&opts, &overrides, &[], "p1", None, None);
         assert_eq!(req.date_time.as_deref(), Some("2026-08-07 12:00:00"));
         assert_eq!(req.existing_keywords, Some(vec!["mine".to_string()]));
         assert_eq!(req.existing_face_tags, Some(vec!["Ivo".to_string()]));
@@ -2301,7 +2492,7 @@ mod keyword_option_tests {
             ("existing_keywords", r#"["batch"]"#),
             ("folder_names", "BatchFolder"),
         ]));
-        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None);
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None, None);
         assert_eq!(req.date_time.as_deref(), Some("2026-01-01 00:00:00"));
         assert_eq!(req.existing_keywords, Some(vec!["batch".to_string()]));
         assert_eq!(req.folder_names.as_deref(), Some("BatchFolder"));
@@ -2315,12 +2506,125 @@ mod keyword_option_tests {
             ("existing_keywords", r#"["beach","sunset"]"#),
             ("existing_face_tags", r#"["Ivo"]"#),
         ]));
-        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None);
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None, None);
         assert_eq!(
             req.existing_keywords,
             Some(vec!["beach".to_string(), "sunset".to_string()])
         );
         assert_eq!(req.existing_face_tags, Some(vec!["Ivo".to_string()]));
+    }
+
+    /// The catalog is the source that survives everything: a raw original is
+    /// re-encoded before anything reads it, so what Lightroom knows has to
+    /// travel as fields (issue #321).
+    #[test]
+    fn the_catalog_location_reaches_the_prompt() {
+        let opts = parse_options(&fields(&[
+            ("location_city", "Ribadeo"),
+            ("location_state", "Galicia"),
+            ("location_country", "Spain"),
+            ("location_country_code", "ES"),
+            ("gps_latitude", "43.537"),
+            ("gps_longitude", "-7.0409"),
+        ]));
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None, None);
+        let location = req.location_data.expect("a location");
+        assert_eq!(location.city.as_deref(), Some("Ribadeo"));
+        assert_eq!(location.country.as_deref(), Some("Spain"));
+        assert_eq!(location.gps_latitude, Some(43.537));
+        // Named by the catalog, so nothing was looked up.
+        assert_eq!(location.gps_place_distance_km, None);
+    }
+
+    /// Coordinates and nothing else is the case the reporter hit: Lightroom's
+    /// address suggestions were never confirmed, so no city exists anywhere.
+    /// A pair of decimals in the prompt is useless to a model — the place name
+    /// has to be looked up.
+    #[test]
+    fn coordinates_alone_are_turned_into_a_place_name() {
+        let opts = parse_options(&fields(&[
+            ("gps_latitude", "43.537"),
+            ("gps_longitude", "-7.0409"),
+        ]));
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None, None);
+        let location = req.location_data.expect("a location");
+        assert_eq!(location.city.as_deref(), Some("Ribadeo"));
+        assert_eq!(location.country.as_deref(), Some("Spain"));
+        assert!(location.gps_place_distance_km.is_some());
+    }
+
+    /// The user's own place names outrank both the file and the geocoder, and
+    /// per-photo outranks the batch — a grouped request must not hand every
+    /// photo the first one's city.
+    #[test]
+    fn per_photo_location_wins_over_batch_and_file() {
+        let opts = parse_options(&fields(&[("location_city", "BatchCity")]));
+        let overrides = PhotoOverrides {
+            location: Some(LocationTags {
+                city: Some("Ribadeo".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let file = LocationTags {
+            city: Some("FileCity".to_string()),
+            country: Some("Spain".to_string()),
+            gps_latitude: Some(48.1372),
+            gps_longitude: Some(11.5755),
+            ..Default::default()
+        };
+        let req = build_metadata_request(&opts, &overrides, &[], "p1", Some(&file), None);
+        let location = req.location_data.expect("a location");
+        assert_eq!(location.city.as_deref(), Some("Ribadeo"));
+        // Filled in from the file, because the catalog had nothing to say.
+        assert_eq!(location.country.as_deref(), Some("Spain"));
+        // A name was already known, so Munich's coordinates changed nothing.
+        assert_eq!(location.gps_place_distance_km, None);
+    }
+
+    /// The switch has to keep meaning what it says: with location context off,
+    /// nothing about where the photo was taken may reach the model.
+    #[test]
+    fn submit_gps_false_suppresses_every_source() {
+        let opts = parse_options(&fields(&[
+            ("submit_gps", "false"),
+            ("location_city", "Ribadeo"),
+            ("gps_latitude", "43.537"),
+            ("gps_longitude", "-7.0409"),
+        ]));
+        let file = LocationTags {
+            city: Some("FileCity".to_string()),
+            ..Default::default()
+        };
+        let req = build_metadata_request(
+            &opts,
+            &PhotoOverrides::default(),
+            &[],
+            "p1",
+            Some(&file),
+            None,
+        );
+        assert!(req.location_data.is_none());
+    }
+
+    /// Half a coordinate pair is not a position, and reverse geocoding one
+    /// would invent a place from a longitude alone.
+    #[test]
+    fn a_half_coordinate_pair_is_dropped() {
+        let parsed = location_from_fields(&|key| match key {
+            "gps_latitude" => Some("43.537".to_string()),
+            _ => None,
+        });
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn blank_location_fields_are_not_a_known_place() {
+        let parsed = location_from_fields(&|key| match key {
+            "location_city" => Some("   ".to_string()),
+            _ => None,
+        });
+        assert!(parsed.is_none());
     }
 
     /// Issue #326: the classifier's answer only helps if it reaches the
@@ -2368,7 +2672,7 @@ mod keyword_option_tests {
     #[test]
     fn absent_face_tags_leave_the_request_unchanged() {
         let opts = parse_options(&fields(&[("existing_keywords", r#"["beach"]"#)]));
-        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None);
+        let req = build_metadata_request(&opts, &PhotoOverrides::default(), &[], "p1", None, None);
         assert_eq!(req.existing_keywords, Some(vec!["beach".to_string()]));
         assert_eq!(req.existing_face_tags, None);
     }

--- a/server-rs/crates/lrg-api/src/routes/index_upload.rs
+++ b/server-rs/crates/lrg-api/src/routes/index_upload.rs
@@ -135,6 +135,14 @@ struct MetadataOptions {
     generate_alt_text: bool,
     submit_keywords: bool,
     submit_folder_names: bool,
+    /// Whether the names on the photo's faces may be sent to the model.
+    ///
+    /// Defaults to true, which is not the plugin's default but the right one
+    /// for the wire: a plugin old enough not to send the field only ever sends
+    /// `existing_face_tags` when its own keyword switch is on, so trusting
+    /// what arrived keeps that client's behaviour exactly as it was. A new
+    /// plugin sends the field and decides for itself.
+    submit_face_tags: bool,
     /// Whether the photo's own GPS may be turned into place names and sent to
     /// the model along with the image.
     ///
@@ -406,6 +414,7 @@ pub(crate) fn parse_options(fields: &HashMap<String, String>) -> ParsedOptions {
             generate_alt_text: bool_field(fields, "generate_alt_text", true),
             submit_keywords: bool_field(fields, "submit_keywords", false),
             submit_folder_names: bool_field(fields, "submit_folder_names", false),
+            submit_face_tags: bool_field(fields, "submit_face_tags", true),
             submit_gps: bool_field(fields, "submit_gps", true),
             location: location_from_fields(&|key| fields.get(key).cloned()),
             existing_keywords,
@@ -2300,6 +2309,7 @@ fn build_metadata_request(
         user_prompt: None,
         submit_keywords: mo.submit_keywords,
         submit_folder_names: mo.submit_folder_names,
+        submit_face_tags: mo.submit_face_tags,
         existing_keywords: overrides
             .existing_keywords
             .clone()
@@ -2566,8 +2576,10 @@ mod keyword_option_tests {
             }),
             ..Default::default()
         };
+        // The file agrees on the city, so what it knows on top of that is the
+        // same place's country and fills in.
         let file = LocationTags {
-            city: Some("FileCity".to_string()),
+            city: Some("Ribadeo".to_string()),
             country: Some("Spain".to_string()),
             gps_latitude: Some(48.1372),
             gps_longitude: Some(11.5755),
@@ -2576,10 +2588,58 @@ mod keyword_option_tests {
         let req = build_metadata_request(&opts, &overrides, &[], "p1", Some(&file), None);
         let location = req.location_data.expect("a location");
         assert_eq!(location.city.as_deref(), Some("Ribadeo"));
-        // Filled in from the file, because the catalog had nothing to say.
         assert_eq!(location.country.as_deref(), Some("Spain"));
         // A name was already known, so Munich's coordinates changed nothing.
         assert_eq!(location.gps_place_distance_km, None);
+    }
+
+    /// The same request with a file that names a *different* city: its country
+    /// is that other place's country, and pairing it with the catalog's city
+    /// would describe somewhere neither source meant.
+    #[test]
+    fn a_file_naming_another_place_contributes_no_names() {
+        let opts = parse_options(&fields(&[]));
+        let overrides = PhotoOverrides {
+            location: Some(LocationTags {
+                city: Some("Sankt Peter-Ording".to_string()),
+                country: Some("Germany".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let file = LocationTags {
+            city: Some("Ribadeo".to_string()),
+            state: Some("Galicia".to_string()),
+            country: Some("Spain".to_string()),
+            ..Default::default()
+        };
+        let req = build_metadata_request(&opts, &overrides, &[], "p1", Some(&file), None);
+        let location = req.location_data.expect("a location");
+        assert_eq!(location.city.as_deref(), Some("Sankt Peter-Ording"));
+        assert_eq!(location.country.as_deref(), Some("Germany"));
+        assert_eq!(location.state, None);
+    }
+
+    /// The people switch reaches the request on its own, and an older plugin
+    /// that never heard of it keeps sending names exactly as before: it only
+    /// puts `existing_face_tags` on the wire when its keyword switch is on, so
+    /// the absent field has to mean "use what arrived", not "drop it".
+    #[test]
+    fn people_switch_is_read_and_defaults_to_what_the_client_sent() {
+        let sent = parse_options(&fields(&[("submit_face_tags", "false")]));
+        let req = build_metadata_request(&sent, &PhotoOverrides::default(), &[], "p1", None, None);
+        assert!(!req.submit_face_tags);
+
+        let older_client = parse_options(&fields(&[("submit_keywords", "true")]));
+        let req = build_metadata_request(
+            &older_client,
+            &PhotoOverrides::default(),
+            &[],
+            "p1",
+            None,
+            None,
+        );
+        assert!(req.submit_face_tags);
     }
 
     /// The switch has to keep meaning what it says: with location context off,

--- a/server-rs/crates/lrg-imaging/Cargo.toml
+++ b/server-rs/crates/lrg-imaging/Cargo.toml
@@ -7,9 +7,11 @@ license.workspace = true
 [dependencies]
 fast_image_resize = { version = "6.1.0", features = ["image"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff", "webp", "bmp"] }
+isocountry = "0.3.2"
 kamadak-exif = "0.6"
 log.workspace = true
 rawler = { version = "0.7.2", default-features = false }
+reverse_geocoder = "4.1.1"
 thiserror = "2"
 
 [dev-dependencies]

--- a/server-rs/crates/lrg-imaging/src/geocode.rs
+++ b/server-rs/crates/lrg-imaging/src/geocode.rs
@@ -1,0 +1,210 @@
+//! Offline reverse geocoding: coordinates in, a place name out.
+//!
+//! Lightroom's own address lookup writes city/state/country into the catalog,
+//! but those fields only reach us when they survive to the file we are handed
+//! — and an unconfirmed lookup suggestion never does. What is left is a pair
+//! of coordinates, and `"43.536700, -7.040950"` in the prompt is worth nothing
+//! to a vision model: it will not name Ribadeo, it will write "a rocky beach"
+//! (issue #321). Turning the coordinates into a name is what puts the place in
+//! the title and the caption.
+//!
+//! The lookup is offline by design. This is a local-first plugin, and sending
+//! every indexed photo's position to a geocoding service is exactly the kind
+//! of thing a user who runs a local model is avoiding. The `reverse_geocoder`
+//! crate bundles GeoNames' `cities1000` (~145k places worldwide, everything
+//! down to villages of a thousand people), which is why a town of 9,000 like
+//! Ribadeo resolves at all.
+//!
+//! Data: GeoNames (<https://www.geonames.org>), CC BY 4.0.
+
+use std::sync::OnceLock;
+
+use reverse_geocoder::ReverseGeocoder;
+
+use crate::location::LocationTags;
+
+/// Beyond this the nearest known settlement says nothing useful about where
+/// the photo was taken — mid-ocean, deep desert, high mountains. Naming a town
+/// 80 km away is worse than naming nothing, because the model will happily
+/// build a caption around it.
+const MAX_PLACE_DISTANCE_KM: f64 = 50.0;
+
+/// Within this radius the photo is, for captioning purposes, *in* the place.
+/// Further out it is *near* it, and the prompt says so — a photo taken 20 km
+/// outside a town is not a photo of that town.
+pub const IN_PLACE_DISTANCE_KM: f64 = 5.0;
+
+/// The mean Earth radius, for turning the geocoder's unit-sphere distance
+/// back into kilometres.
+const EARTH_RADIUS_KM: f64 = 6371.0;
+
+/// The nearest populated place to a coordinate pair.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NearestPlace {
+    pub name: String,
+    /// First-level administrative division (state, province, region), empty
+    /// when GeoNames has none for the place.
+    pub admin1: String,
+    /// Second-level division (county, district), empty when unknown.
+    pub admin2: String,
+    pub country_code: String,
+    /// English country name for `country_code`, absent for a code that is not
+    /// ISO 3166-1 alpha-2 (GeoNames uses a handful, e.g. `XK` for Kosovo).
+    pub country: Option<String>,
+    pub distance_km: f64,
+}
+
+/// Loaded once, on the first photo of the first run that actually needs it.
+///
+/// Building it parses ~145k CSV rows into a k-d tree, so it is deliberately
+/// not part of server start-up: a catalog without GPS, or a user who switched
+/// location context off, never pays for it.
+fn geocoder() -> &'static ReverseGeocoder {
+    static GEOCODER: OnceLock<ReverseGeocoder> = OnceLock::new();
+    GEOCODER.get_or_init(|| {
+        let t0 = std::time::Instant::now();
+        let geocoder = ReverseGeocoder::new();
+        log::debug!(
+            "Loaded offline reverse-geocoding index in {:?}",
+            t0.elapsed()
+        );
+        geocoder
+    })
+}
+
+/// Squared chord length on the unit sphere (what the k-d tree returns) to
+/// great-circle kilometres.
+fn chord_squared_to_km(squared: f64) -> f64 {
+    let chord = squared.max(0.0).sqrt().min(2.0);
+    EARTH_RADIUS_KM * 2.0 * (chord / 2.0).asin()
+}
+
+/// The nearest populated place, or `None` when the coordinates are not real
+/// coordinates or nothing known is close enough to be worth naming.
+pub fn nearest_place(latitude: f64, longitude: f64) -> Option<NearestPlace> {
+    if !(-90.0..=90.0).contains(&latitude) || !(-180.0..=180.0).contains(&longitude) {
+        return None;
+    }
+    // 0,0 is Null Island: the coordinate a camera or a converter writes when
+    // it has no fix, not a photo taken in the Gulf of Guinea.
+    if latitude == 0.0 && longitude == 0.0 {
+        return None;
+    }
+
+    let result = geocoder().search((latitude, longitude));
+    let distance_km = chord_squared_to_km(result.distance);
+    if distance_km > MAX_PLACE_DISTANCE_KM {
+        return None;
+    }
+    let record = result.record;
+    Some(NearestPlace {
+        name: record.name.clone(),
+        admin1: record.admin1.clone(),
+        admin2: record.admin2.clone(),
+        country_code: record.cc.clone(),
+        country: isocountry::CountryCode::for_alpha2(&record.cc)
+            .ok()
+            .map(|c| c.name().to_string()),
+        distance_km,
+    })
+}
+
+/// Fills a photo's missing place names from its coordinates, and reports
+/// whether it did.
+///
+/// Only when there is no place name at all: a city the photographer (or
+/// Lightroom) put on the photo is a statement about where they were, and the
+/// nearest settlement to a GPS fix is a guess. The guess never overwrites the
+/// statement, and never mixes with it either — a photo tagged "Ribadeo" does
+/// not get a country filled in from a different record.
+pub fn fill_place_from_gps(tags: &mut LocationTags) -> bool {
+    if tags.has_place_name() {
+        return false;
+    }
+    let (Some(lat), Some(lon)) = (tags.gps_latitude, tags.gps_longitude) else {
+        return false;
+    };
+    let Some(place) = nearest_place(lat, lon) else {
+        return false;
+    };
+
+    tags.city = Some(place.name);
+    if !place.admin1.is_empty() {
+        tags.state = Some(place.admin1);
+    }
+    if let Some(country) = place.country {
+        tags.country = Some(country);
+    }
+    if tags.country_code.is_none() && !place.country_code.is_empty() {
+        tags.country_code = Some(place.country_code);
+    }
+    tags.gps_place_distance_km = Some(place.distance_km);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_the_town_behind_the_coordinates() {
+        // The beach in issue #321.
+        let place = nearest_place(43.5370, -7.0409).expect("Ribadeo is in cities1000");
+        assert_eq!(place.name, "Ribadeo");
+        assert_eq!(place.admin1, "Galicia");
+        assert_eq!(place.country.as_deref(), Some("Spain"));
+        assert!(place.distance_km < 1.0, "got {} km", place.distance_km);
+    }
+
+    #[test]
+    fn distance_is_in_kilometres() {
+        // ~50 km north of Munich's centre is still within the cap, but is not
+        // Munich any more.
+        let place = nearest_place(48.6, 11.5).unwrap();
+        assert!(place.distance_km < MAX_PLACE_DISTANCE_KM);
+        assert_eq!(place.country.as_deref(), Some("Germany"));
+    }
+
+    #[test]
+    fn mid_ocean_has_no_place() {
+        assert!(nearest_place(0.0, -140.0).is_none());
+    }
+
+    #[test]
+    fn null_island_and_impossible_coordinates_are_rejected() {
+        assert!(nearest_place(0.0, 0.0).is_none());
+        assert!(nearest_place(91.0, 10.0).is_none());
+        assert!(nearest_place(10.0, 200.0).is_none());
+    }
+
+    #[test]
+    fn fills_only_when_nothing_is_known() {
+        let mut tags = LocationTags {
+            gps_latitude: Some(43.5370),
+            gps_longitude: Some(-7.0409),
+            ..Default::default()
+        };
+        assert!(fill_place_from_gps(&mut tags));
+        assert_eq!(tags.city.as_deref(), Some("Ribadeo"));
+        assert_eq!(tags.country.as_deref(), Some("Spain"));
+        assert!(tags.gps_place_distance_km.is_some());
+
+        let mut tagged = LocationTags {
+            city: Some("Ribadeo".into()),
+            gps_latitude: Some(48.1372),
+            gps_longitude: Some(11.5755),
+            ..Default::default()
+        };
+        assert!(!fill_place_from_gps(&mut tagged));
+        assert_eq!(tagged.city.as_deref(), Some("Ribadeo"));
+        assert!(tagged.country.is_none());
+        assert!(tagged.gps_place_distance_km.is_none());
+    }
+
+    #[test]
+    fn without_coordinates_nothing_happens() {
+        let mut tags = LocationTags::default();
+        assert!(!fill_place_from_gps(&mut tags));
+        assert!(tags.is_empty());
+    }
+}

--- a/server-rs/crates/lrg-imaging/src/lib.rs
+++ b/server-rs/crates/lrg-imaging/src/lib.rs
@@ -1,11 +1,13 @@
 //! Image pipeline: Pillow-exact resampling, pHash, culling metrics,
 //! source-state measurement for the edit path (`scene`),
-//! RAW decoding (`raw`, via `rawler`), JPEG/PNG conversion (`convert`).
+//! RAW decoding (`raw`, via `rawler`), JPEG/PNG conversion (`convert`),
+//! location metadata (`location`) and offline reverse geocoding (`geocode`).
 //! HEIC (libheif) decoding is still not wired in.
 
 pub mod capture;
 pub mod convert;
 pub mod cull_config;
+pub mod geocode;
 pub mod location;
 pub mod metrics;
 pub mod pil_resample;

--- a/server-rs/crates/lrg-imaging/src/location.rs
+++ b/server-rs/crates/lrg-imaging/src/location.rs
@@ -2,8 +2,10 @@
 //! location tags (IPTC IIM record 2 in the JPEG APP13 segment) plus GPS
 //! coordinates from EXIF, for LLM prompt context.
 //!
-//! Note: the Python module's docstring mentions XMP but only implements
-//! IPTC + GPS; this port matches the implementation, not the docstring.
+//! The IPTC path only sees what is embedded in a JPEG. Lightroom keeps the
+//! place a photo was taken in its catalog and writes it into an XMP sidecar
+//! next to a raw original, so [`read_sidecar_location`] reads that too — for a
+//! raw workflow it is the only copy of the location that exists on disk.
 
 use std::collections::BTreeMap;
 use std::io::Cursor;
@@ -31,6 +33,15 @@ pub struct LocationTags {
     pub country_code: Option<String>,
     pub gps_latitude: Option<f64>,
     pub gps_longitude: Option<f64>,
+    /// Set when the place names above were *derived* from the coordinates by
+    /// [`crate::geocode::fill_place_from_gps`] rather than read off the photo:
+    /// how far the named place is, in kilometres.
+    ///
+    /// The prompt needs the difference. A city the photographer put on the
+    /// photo is a fact about it; the nearest town to a GPS fix is an estimate,
+    /// and a model told the estimate as fact will write a caption about a
+    /// harbour the photo does not show.
+    pub gps_place_distance_km: Option<f64>,
 }
 
 impl LocationTags {
@@ -42,6 +53,63 @@ impl LocationTags {
             && self.country_code.is_none()
             && self.gps_latitude.is_none()
             && self.gps_longitude.is_none()
+    }
+
+    /// Whether anything here names a place, as opposed to locating one.
+    /// Coordinates alone do not: they are what reverse geocoding consumes.
+    pub fn has_place_name(&self) -> bool {
+        self.location.is_some()
+            || self.city.is_some()
+            || self.state.is_some()
+            || self.country.is_some()
+    }
+
+    /// Fills empty fields from `other`, keeping everything already set.
+    ///
+    /// Used to layer the sources by how much each knows about the
+    /// photographer's intent: what the plugin read out of the catalog first,
+    /// then what the file itself carries.
+    ///
+    /// Coordinates fill in freely — a position is a position. Place *names* do
+    /// not: two sources that disagree describe two different places, and
+    /// filling the gaps between them invents a third. A catalog that says
+    /// "Sankt Peter-Ording, Germany" merged field-wise with a file that says
+    /// "Ribadeo, Galicia, Spain" yields "Sankt Peter-Ording, Galicia, Germany",
+    /// which is nowhere. So the names are only filled in when the two agree on
+    /// every name they both carry; otherwise ours stand alone.
+    pub fn merge_missing(&mut self, other: &LocationTags) {
+        if self.names_agree_with(other) {
+            fn fill(target: &mut Option<String>, source: &Option<String>) {
+                if target.is_none() {
+                    target.clone_from(source);
+                }
+            }
+            fill(&mut self.location, &other.location);
+            fill(&mut self.city, &other.city);
+            fill(&mut self.state, &other.state);
+            fill(&mut self.country, &other.country);
+            fill(&mut self.country_code, &other.country_code);
+        }
+        if self.gps_latitude.is_none() && self.gps_longitude.is_none() {
+            self.gps_latitude = other.gps_latitude;
+            self.gps_longitude = other.gps_longitude;
+        }
+    }
+
+    /// Whether two sources contradict each other on any place name they both
+    /// carry. Compared case-insensitively and ignoring surrounding space:
+    /// "spain" and "Spain " are the same claim.
+    fn names_agree_with(&self, other: &LocationTags) -> bool {
+        fn same(a: &Option<String>, b: &Option<String>) -> bool {
+            match (a, b) {
+                (Some(a), Some(b)) => a.trim().eq_ignore_ascii_case(b.trim()),
+                _ => true,
+            }
+        }
+        same(&self.location, &other.location)
+            && same(&self.city, &other.city)
+            && same(&self.state, &other.state)
+            && same(&self.country, &other.country)
     }
 }
 
@@ -197,6 +265,158 @@ pub fn extract_location_tags(image_bytes: &[u8]) -> Option<LocationTags> {
     }
 }
 
+/// The largest sidecar we will read. An XMP sidecar is a few kilobytes;
+/// anything past this is not one, and we are about to hold it in memory for
+/// every photo of a batch.
+const MAX_SIDECAR_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Unescapes the five XML predefined entities. XMP values are attribute or
+/// element text, so nothing else can appear in them.
+fn unescape_xml(value: &str) -> String {
+    value
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+}
+
+/// Reads one qualified XMP property, in either shape Lightroom may write it:
+/// an attribute on `rdf:Description`, or its own element. An `rdf:Alt`
+/// language table (which is how a localised value is stored) yields its first
+/// `rdf:li`.
+fn xmp_value(xmp: &str, qualified_name: &str) -> Option<String> {
+    if let Some(value) = xmp
+        .split_once(&format!("{qualified_name}=\""))
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(value, _)| value)
+    {
+        let value = unescape_xml(value).trim().to_string();
+        if !value.is_empty() {
+            return Some(value);
+        }
+    }
+
+    let open = format!("<{qualified_name}>");
+    let close = format!("</{qualified_name}>");
+    let inner = xmp
+        .split_once(&open)
+        .and_then(|(_, rest)| rest.split_once(&close))
+        .map(|(inner, _)| inner)?;
+    // <dc:title><rdf:Alt><rdf:li xml:lang="x-default">Text</rdf:li></rdf:Alt>
+    let inner = match inner.split_once("<rdf:li") {
+        Some((_, rest)) => rest
+            .split_once('>')
+            .and_then(|(_, text)| text.split_once("</rdf:li>"))
+            .map(|(text, _)| text)?,
+        None => inner,
+    };
+    let value = unescape_xml(inner).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// Parses an XMP GPS coordinate: `"43,32.220000N"` (degrees, decimal minutes)
+/// or `"43,32,13N"` (degrees, minutes, seconds), the two forms the XMP
+/// specification allows. A plain decimal is accepted too, because some writers
+/// emit one.
+fn parse_xmp_coordinate(raw: &str) -> Option<f64> {
+    let raw = raw.trim();
+    let (numbers, hemisphere) = match raw.chars().last() {
+        Some(c) if matches!(c.to_ascii_uppercase(), 'N' | 'S' | 'E' | 'W') => {
+            (&raw[..raw.len() - c.len_utf8()], c.to_ascii_uppercase())
+        }
+        _ => (raw, 'N'),
+    };
+
+    let mut parts = numbers.split(',');
+    let degrees: f64 = parts.next()?.trim().parse().ok()?;
+    let minutes: f64 = match parts.next() {
+        Some(m) => m.trim().parse().ok()?,
+        None => 0.0,
+    };
+    let seconds: f64 = match parts.next() {
+        Some(s) => s.trim().parse().ok()?,
+        None => 0.0,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let magnitude = degrees.abs() + minutes / 60.0 + seconds / 3600.0;
+    let negative = matches!(hemisphere, 'S' | 'W') || degrees.is_sign_negative();
+    Some(if negative { -magnitude } else { magnitude })
+}
+
+/// Pulls the location out of XMP packet text (a sidecar's contents, or an XMP
+/// block lifted from a file). Returns `None` when it holds no location.
+pub fn extract_location_from_xmp(xmp: &str) -> Option<LocationTags> {
+    let mut tags = LocationTags {
+        location: xmp_value(xmp, "Iptc4xmpCore:Location"),
+        city: xmp_value(xmp, "photoshop:City"),
+        state: xmp_value(xmp, "photoshop:State"),
+        country: xmp_value(xmp, "photoshop:Country"),
+        country_code: xmp_value(xmp, "Iptc4xmpCore:CountryCode"),
+        ..Default::default()
+    };
+
+    let latitude = xmp_value(xmp, "exif:GPSLatitude")
+        .as_deref()
+        .and_then(parse_xmp_coordinate);
+    let longitude = xmp_value(xmp, "exif:GPSLongitude")
+        .as_deref()
+        .and_then(parse_xmp_coordinate);
+    if let (Some(lat), Some(lon)) = (latitude, longitude) {
+        tags.gps_latitude = Some(round6(lat));
+        tags.gps_longitude = Some(round6(lon));
+    }
+
+    (!tags.is_empty()).then_some(tags)
+}
+
+/// Reads the location from the XMP sidecar belonging to `image_path`.
+///
+/// This is the raw shooter's copy of the location: normalising a raw original
+/// re-encodes it to a metadata-free JPEG, and a raw container never carried
+/// Lightroom's IPTC place names in the first place — they live in the catalog
+/// and, when the user has sidecars turned on, in the `.xmp` beside the file.
+///
+/// Both conventions are tried: `IMG_1234.xmp` (Lightroom's, replacing the
+/// extension) and `IMG_1234.CR2.xmp` (appended, used by several other tools).
+pub fn read_sidecar_location(image_path: &std::path::Path) -> Option<LocationTags> {
+    let mut candidates = vec![
+        image_path.with_extension("xmp"),
+        image_path.with_extension("XMP"),
+    ];
+    let appended = {
+        let mut name = image_path.file_name()?.to_os_string();
+        name.push(".xmp");
+        image_path.with_file_name(name)
+    };
+    candidates.push(appended);
+
+    for candidate in candidates {
+        if candidate == image_path {
+            continue;
+        }
+        let readable = std::fs::metadata(&candidate)
+            .map(|m| m.is_file() && m.len() <= MAX_SIDECAR_BYTES)
+            .unwrap_or(false);
+        if !readable {
+            continue;
+        }
+        match std::fs::read_to_string(&candidate) {
+            Ok(text) => {
+                if let Some(tags) = extract_location_from_xmp(&text) {
+                    log::debug!("Read location from sidecar {}", candidate.display());
+                    return Some(tags);
+                }
+            }
+            Err(e) => log::debug!("Could not read sidecar {}: {e}", candidate.display()),
+        }
+    }
+    None
+}
+
 /// Port of `format_location_for_prompt`.
 pub fn format_location_for_prompt(location: &LocationTags) -> Option<String> {
     let parts: Vec<&str> = [
@@ -286,6 +506,126 @@ mod tests {
             format_location_for_prompt(&tags).unwrap(),
             "47.855600, 12.365700"
         );
+    }
+
+    /// The shape Lightroom writes: GPS as degrees + decimal minutes with a
+    /// hemisphere letter, and — because the user never confirmed the address
+    /// suggestions — no city, state or country at all. Coordinates are the
+    /// only thing there is, which is what reverse geocoding is for.
+    #[test]
+    fn reads_gps_from_a_lightroom_sidecar_without_place_names() {
+        let xmp = r#"<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:exif="http://ns.adobe.com/exif/1.0/"
+    exif:GPSVersionID="2.3.0.0"
+    exif:GPSLatitude="48,27.5784N"
+    exif:GPSLongitude="12,5.3578E"
+    exif:GPSAltitude="50493/100"/>
+ </rdf:RDF>
+</x:xmpmeta>"#;
+        let tags = extract_location_from_xmp(xmp).unwrap();
+        assert!(!tags.has_place_name());
+        assert_eq!(tags.gps_latitude, Some(48.45964));
+        assert_eq!(tags.gps_longitude, Some(12.089297));
+    }
+
+    #[test]
+    fn reads_place_names_from_a_sidecar() {
+        let xmp = r#"<rdf:Description rdf:about=""
+    photoshop:City="Ribadeo" photoshop:State="Galicia"
+    photoshop:Country="Spain" Iptc4xmpCore:CountryCode="ES">
+    <Iptc4xmpCore:Location>Praia das Catedrais &amp; cliffs</Iptc4xmpCore:Location>
+</rdf:Description>"#;
+        let tags = extract_location_from_xmp(xmp).unwrap();
+        assert_eq!(tags.city.as_deref(), Some("Ribadeo"));
+        assert_eq!(tags.state.as_deref(), Some("Galicia"));
+        assert_eq!(tags.country.as_deref(), Some("Spain"));
+        assert_eq!(tags.country_code.as_deref(), Some("ES"));
+        assert_eq!(
+            tags.location.as_deref(),
+            Some("Praia das Catedrais & cliffs")
+        );
+        assert!(tags.has_place_name());
+    }
+
+    #[test]
+    fn xmp_without_location_is_none() {
+        assert!(extract_location_from_xmp("<rdf:Description dc:title=\"x\"/>").is_none());
+        assert!(extract_location_from_xmp("").is_none());
+    }
+
+    #[test]
+    fn coordinate_forms_and_hemispheres() {
+        assert_eq!(parse_xmp_coordinate("48,27.5784N"), Some(48.45964));
+        assert_eq!(parse_xmp_coordinate("7,2,30W"), Some(-7.041666666666667));
+        assert_eq!(parse_xmp_coordinate("43.5370"), Some(43.5370));
+        assert_eq!(parse_xmp_coordinate("-7.0409"), Some(-7.0409));
+        assert!(parse_xmp_coordinate("north-ish").is_none());
+        assert!(parse_xmp_coordinate("1,2,3,4N").is_none());
+    }
+
+    #[test]
+    fn sidecar_is_found_next_to_the_original() {
+        let dir = std::env::temp_dir().join(format!("lrg-sidecar-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = dir.join("IMG_1234.CR2");
+        std::fs::write(&raw, b"not really a raw file").unwrap();
+        assert!(read_sidecar_location(&raw).is_none());
+
+        std::fs::write(
+            dir.join("IMG_1234.xmp"),
+            r#"<rdf:Description photoshop:City="Ribadeo"/>"#,
+        )
+        .unwrap();
+        let tags = read_sidecar_location(&raw).unwrap();
+        assert_eq!(tags.city.as_deref(), Some("Ribadeo"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn merge_fills_the_gaps_when_both_sources_agree() {
+        let mut catalog = LocationTags {
+            city: Some("Ribadeo".into()),
+            ..Default::default()
+        };
+        catalog.merge_missing(&LocationTags {
+            city: Some("ribadeo ".into()),
+            state: Some("Galicia".into()),
+            country: Some("Spain".into()),
+            gps_latitude: Some(43.5),
+            gps_longitude: Some(-7.0),
+            ..Default::default()
+        });
+        assert_eq!(catalog.city.as_deref(), Some("Ribadeo"));
+        assert_eq!(catalog.state.as_deref(), Some("Galicia"));
+        assert_eq!(catalog.country.as_deref(), Some("Spain"));
+        assert_eq!(catalog.gps_latitude, Some(43.5));
+    }
+
+    /// Two sources describing different places must not be stitched into a
+    /// third that exists nowhere — caught by a live run, which produced
+    /// "Sankt Peter-Ording, Galicia, Germany".
+    #[test]
+    fn merge_never_stitches_two_different_places_together() {
+        let mut catalog = LocationTags {
+            city: Some("Sankt Peter-Ording".into()),
+            country: Some("Germany".into()),
+            ..Default::default()
+        };
+        catalog.merge_missing(&LocationTags {
+            city: Some("Ribadeo".into()),
+            state: Some("Galicia".into()),
+            country: Some("Spain".into()),
+            gps_latitude: Some(54.3),
+            gps_longitude: Some(8.6),
+            ..Default::default()
+        });
+        assert_eq!(catalog.city.as_deref(), Some("Sankt Peter-Ording"));
+        assert_eq!(catalog.state, None);
+        assert_eq!(catalog.country.as_deref(), Some("Germany"));
+        // The coordinates are not a name and still fill in.
+        assert_eq!(catalog.gps_latitude, Some(54.3));
     }
 
     #[test]

--- a/server-rs/crates/lrg-providers/src/prompts.rs
+++ b/server-rs/crates/lrg-providers/src/prompts.rs
@@ -433,8 +433,12 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
         if let Some(joined) = request.existing_keywords.as_deref().and_then(join_terms) {
             per_photo_additions.push(format!("Some keywords are: {joined}"));
         }
-        // After the keywords, not before: the contrast between the two lines is
-        // what tells the model that these particular terms are not scenery.
+    }
+
+    // After the keywords, not before: the contrast between the two lines is
+    // what tells the model that these particular terms are not scenery. Its
+    // own switch, though — see `MetadataGenerationRequest::submit_face_tags`.
+    if request.submit_face_tags {
         if let Some(line) = request
             .existing_face_tags
             .as_deref()
@@ -692,6 +696,8 @@ pub fn prepare_edit_user_prompt_split(request: &EditGenerationRequest) -> SplitP
         if let Some(joined) = request.existing_keywords.as_deref().and_then(join_terms) {
             per_photo_additions.push(format!("Existing keywords: {joined}"));
         }
+    }
+    if request.submit_face_tags {
         if let Some(line) = request
             .existing_face_tags
             .as_deref()
@@ -842,6 +848,7 @@ mod tests {
     fn face_tags_are_to_be_used_by_name() {
         let mut req = base_request();
         req.submit_keywords = true;
+        req.submit_face_tags = true;
         req.existing_face_tags = Some(vec!["Ivo".to_string(), "Myriam".to_string()]);
         let prompt = prepare_user_prompt(&req);
         assert!(prompt.contains("Refer to them by name in the title and the caption"));
@@ -870,6 +877,7 @@ mod tests {
         // "Ivo" as scenery and wrote "the rocky shore of Ivo Beach".
         let mut req = base_request();
         req.submit_keywords = true;
+        req.submit_face_tags = true;
         req.existing_keywords = Some(vec!["beach".to_string(), "sunset".to_string()]);
         req.existing_face_tags = Some(vec!["Ivo".to_string()]);
 
@@ -881,16 +889,48 @@ mod tests {
         assert!(!prompt.contains("Some keywords are: beach, sunset, Ivo"));
     }
 
+    /// The two switches are independent: naming the people in a private photo
+    /// to a cloud model is a different decision from sending "beach, sunset",
+    /// and either answer must be expressible without the other.
     #[test]
-    fn face_tags_follow_the_same_switch_as_keywords() {
-        // They are the same catalog context under a different label, so the
-        // user's "existing keywords" choice governs both.
+    fn people_have_their_own_switch_separate_from_keywords() {
         let mut req = base_request();
+        req.existing_keywords = Some(vec!["beach".to_string()]);
         req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+
         req.submit_keywords = false;
-        assert!(!prepare_user_prompt(&req).contains("People in this photo"));
+        req.submit_face_tags = false;
+        let neither = prepare_user_prompt(&req);
+        assert!(!neither.contains("People in this photo"));
+        assert!(!neither.contains("Some keywords are"));
+
+        // Keywords without the names: the scenery goes, the people stay home.
         req.submit_keywords = true;
-        assert!(prepare_user_prompt(&req).contains("People in this photo"));
+        req.submit_face_tags = false;
+        let keywords_only = prepare_user_prompt(&req);
+        assert!(keywords_only.contains("Some keywords are: beach"));
+        assert!(!keywords_only.contains("People in this photo"));
+
+        // Names without the keywords: what issue #321 wanted the title to say,
+        // for a catalog whose keywords are not worth sending.
+        req.submit_keywords = false;
+        req.submit_face_tags = true;
+        let people_only = prepare_user_prompt(&req);
+        assert!(people_only.contains("People in this photo, named by face recognition: Ivo"));
+        assert!(!people_only.contains("Some keywords are"));
+    }
+
+    /// The edit prompt asks for the names for its own reasons (skin tones, who
+    /// the subject is), but it answers to the same switch.
+    #[test]
+    fn edit_prompt_people_follow_the_people_switch() {
+        let mut req = base_edit_request();
+        req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+        req.submit_keywords = true;
+        req.submit_face_tags = false;
+        assert!(!prepare_edit_user_prompt(&req).contains("People in this photo"));
+        req.submit_face_tags = true;
+        assert!(prepare_edit_user_prompt(&req).contains("People in this photo"));
     }
 
     #[test]
@@ -898,7 +938,7 @@ mod tests {
         // Who is in the frame changes with every photo; in `stable` it would
         // cut the reusable KV-cache prefix at the first photo with a face tag.
         let mut req = base_request();
-        req.submit_keywords = true;
+        req.submit_face_tags = true;
         req.existing_face_tags = Some(vec!["Ivo".to_string()]);
         let split = prepare_user_prompt_split(&req);
         assert!(split.per_photo.contains("People in this photo"));
@@ -908,7 +948,7 @@ mod tests {
     #[test]
     fn blank_face_tags_produce_no_line() {
         let mut req = base_request();
-        req.submit_keywords = true;
+        req.submit_face_tags = true;
         req.existing_face_tags = Some(vec!["  ".to_string(), String::new()]);
         assert!(!prepare_user_prompt(&req).contains("People in this photo"));
     }
@@ -1210,6 +1250,7 @@ mod tests {
     fn edit_prompt_labels_face_tags_as_people() {
         let mut req = base_edit_request();
         req.submit_keywords = true;
+        req.submit_face_tags = true;
         req.existing_keywords = Some(vec!["beach".to_string()]);
         req.existing_face_tags = Some(vec!["Ivo".to_string()]);
         let prompt = prepare_edit_user_prompt(&req);

--- a/server-rs/crates/lrg-providers/src/prompts.rs
+++ b/server-rs/crates/lrg-providers/src/prompts.rs
@@ -11,7 +11,7 @@
 //! stable half silently truncates that prefix to nothing — add new context via
 //! the right bucket, not wherever it reads best.
 
-use lrg_imaging::location::format_location_for_prompt;
+use lrg_imaging::location::{format_location_for_prompt, LocationTags};
 
 use crate::keyword_taxonomy::{CategoryLabels, KeywordLeafEncoding};
 use crate::types::{
@@ -85,22 +85,112 @@ fn join_terms(terms: &[String]) -> Option<String> {
     }
 }
 
-/// The prompt line that tells the model a name belongs to a person.
+/// The prompt line that tells the model a name belongs to a person — and that
+/// it is there to be used.
 ///
 /// Lightroom hands face tags over as plain keywords, so without this the model
 /// sees "Ivo" next to "beach" and writes "the rocky shore of Ivo Beach"
-/// (issue #315). Naming what the terms are is the whole fix; the explicit
-/// prohibition is there because a bare list still leaves the model free to
-/// read a name as a place.
+/// (issue #315). Naming what the terms are is what fixed that.
+///
+/// The prohibition alone was not enough, though: a model that is told only
+/// what a name must not be leaves it out altogether and writes "a man and a
+/// woman stand on a beach" for a photo of two people it has been handed the
+/// names of (issue #321). The instruction to prefer the names is the other
+/// half, and it is safe to give because these names come from the user's own
+/// catalog — they were sent precisely so the photo could be described in terms
+/// of who is in it.
+///
+/// It stops short of assigning names to faces. With several people named there
+/// is nothing in the prompt that says which is which, and a guess there is
+/// worse than the generic description it replaces.
 fn face_tag_line(faces: &[String]) -> Option<String> {
     join_terms(faces).map(|joined| {
+        let together = if faces.iter().filter(|f| !f.trim().is_empty()).count() > 1 {
+            " Name them together when you cannot tell from the image which name belongs to \
+             which face; never guess that pairing."
+        } else {
+            ""
+        };
         format!(
             "People in this photo, named by face recognition: {joined}. These are names of \
-             people who appear in the photo. Use them only to refer to those people; never \
-             treat such a name as a place, landmark, event, brand or object, and never build \
-             a location name out of one."
+             people who appear in the photo. Refer to them by name in the title and the \
+             caption instead of describing them generically as a man, a woman or a couple, \
+             wherever naming them reads naturally.{together} Never treat such a name as a \
+             place, landmark, event, brand or object, and never build a location name out of \
+             one."
         )
     })
+}
+
+/// The place names a photo carries, most specific first.
+fn place_names(location: &LocationTags) -> Option<String> {
+    let parts: Vec<&str> = [
+        location.location.as_deref(),
+        location.city.as_deref(),
+        location.state.as_deref(),
+        location.country.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::trim)
+    .filter(|p| !p.is_empty())
+    .collect();
+    (!parts.is_empty()).then(|| parts.join(", "))
+}
+
+/// The prompt line that tells the model where the photo was taken.
+///
+/// A bare "This photo was taken at: X" was a statement with no instruction
+/// attached, and the model treated it as one more detail it was free to leave
+/// out — hence "A Couple on a Rocky Beach" for a photo whose metadata said
+/// Ribadeo (issue #321). Saying what to do with the place is the fix.
+///
+/// The wording splits on where the place came from, because the two are not
+/// equally true. Names read off the photo are what the photographer (or
+/// Lightroom's address lookup) put there; a name derived from coordinates is
+/// the nearest settlement to a point, which is a fine thing to say "near" about
+/// and a bad thing to build a landmark out of.
+fn location_line(location: &LocationTags) -> Option<String> {
+    if location.is_empty() {
+        return None;
+    }
+
+    if let Some(place) = place_names(location) {
+        return Some(match location.gps_place_distance_km {
+            None => format!(
+                "Where this photo was taken, from the photo's own metadata: {place}. This is \
+                 fact, not a guess: name the place in the title and the caption wherever a \
+                 place belongs, preferring the most specific name given, and use it for \
+                 location keywords. Never name a different place, and never a more precise \
+                 one than this — no street, building or landmark that this does not state."
+            ),
+            Some(km) if km <= lrg_imaging::geocode::IN_PLACE_DISTANCE_KM => format!(
+                "Where this photo was taken, looked up from its GPS coordinates: {place}. Use \
+                 this place in the title and the caption wherever a place belongs, and for \
+                 location keywords. It is the nearest known settlement to the coordinates, so \
+                 name the place, the region or the country — never a street, a building or a \
+                 landmark on this basis, and never a different place than this one."
+            ),
+            Some(km) => format!(
+                "Where this photo was taken, looked up from its GPS coordinates: near {place} \
+                 (the nearest known settlement, about {km:.0} km away). The photo was taken \
+                 close to there but not necessarily in it, so name the wider area, the region \
+                 or the country rather than that settlement itself, and never a street, a \
+                 building or a landmark on this basis."
+            ),
+        });
+    }
+
+    // No name anywhere and nothing near enough to look up — open water, desert,
+    // high mountains. The coordinates are all there is, and they are worth
+    // saying only with the warning attached: a model handed bare coordinates
+    // will otherwise invent a plausible town.
+    let (lat, lon) = (location.gps_latitude?, location.gps_longitude?);
+    Some(format!(
+        "This photo's GPS coordinates are {lat:.6}, {lon:.6}, and no known settlement is near \
+         them. Name a place only if you are certain of it from the coordinates and the image \
+         together; otherwise describe the scene without naming one."
+    ))
 }
 
 /// What the classifier's kingdom says the subject is, for the prompt's first
@@ -335,12 +425,8 @@ pub fn prepare_user_prompt_split(request: &MetadataGenerationRequest) -> SplitPr
 
     // --- per-photo context: everything below changes from photo to photo ---
 
-    if let Some(location) = &request.location_data {
-        if !location.is_empty() {
-            if let Some(location_str) = format_location_for_prompt(location) {
-                per_photo_additions.push(format!("This photo was taken at: {location_str}"));
-            }
-        }
+    if let Some(line) = request.location_data.as_ref().and_then(location_line) {
+        per_photo_additions.push(line);
     }
 
     if request.submit_keywords {
@@ -698,15 +784,73 @@ mod tests {
     }
 
     #[test]
-    fn location_context_uses_shared_format_location_for_prompt() {
+    fn location_from_metadata_is_stated_as_fact_and_asked_for() {
         let mut req = base_request();
-        req.location_data = Some(lrg_imaging::location::LocationTags {
+        req.location_data = Some(LocationTags {
             city: Some("Munich".to_string()),
             country: Some("Germany".to_string()),
             ..Default::default()
         });
         let prompt = prepare_user_prompt(&req);
-        assert!(prompt.contains("This photo was taken at: Munich, Germany"));
+        assert!(prompt.contains("from the photo's own metadata: Munich, Germany"));
+        assert!(prompt.contains("name the place in the title and the caption"));
+    }
+
+    /// The whole point of reverse geocoding: a place the photographer never
+    /// typed still has to reach the model as a name, and has to be marked as
+    /// derived so it is not turned into a landmark.
+    #[test]
+    fn location_derived_from_gps_says_so() {
+        let mut req = base_request();
+        req.location_data = Some(LocationTags {
+            city: Some("Ribadeo".to_string()),
+            state: Some("Galicia".to_string()),
+            country: Some("Spain".to_string()),
+            gps_latitude: Some(43.537),
+            gps_longitude: Some(-7.0409),
+            gps_place_distance_km: Some(1.2),
+            ..Default::default()
+        });
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("looked up from its GPS coordinates: Ribadeo, Galicia, Spain"));
+        assert!(!prompt.contains("near Ribadeo"));
+
+        // Far enough out that the photo is not of that town.
+        req.location_data.as_mut().unwrap().gps_place_distance_km = Some(23.4);
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains(
+            "near Ribadeo, Galicia, Spain (the nearest known settlement, about 23 km away)"
+        ));
+    }
+
+    #[test]
+    fn coordinates_with_no_place_warn_against_guessing() {
+        let mut req = base_request();
+        req.location_data = Some(LocationTags {
+            gps_latitude: Some(-14.5),
+            gps_longitude: Some(-140.25),
+            ..Default::default()
+        });
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("-14.500000, -140.250000"));
+        assert!(prompt.contains("Name a place only if you are certain"));
+    }
+
+    /// A name that is sent must also be used, or the caption stays at "a man
+    /// and a woman" — the other half of issue #321.
+    #[test]
+    fn face_tags_are_to_be_used_by_name() {
+        let mut req = base_request();
+        req.submit_keywords = true;
+        req.existing_face_tags = Some(vec!["Ivo".to_string(), "Myriam".to_string()]);
+        let prompt = prepare_user_prompt(&req);
+        assert!(prompt.contains("Refer to them by name in the title and the caption"));
+        assert!(prompt.contains("never guess that pairing"));
+        assert!(prompt.contains("never build a location name out of"));
+
+        // One name cannot be mixed up with another, so that clause is dropped.
+        req.existing_face_tags = Some(vec!["Ivo".to_string()]);
+        assert!(!prepare_user_prompt(&req).contains("never guess that pairing"));
     }
 
     #[test]
@@ -944,7 +1088,7 @@ mod tests {
         }
 
         for per_photo in [
-            "This photo was taken at: Reykjavik",
+            "metadata: Reykjavik",
             "Some keywords are: cat",
             "Folders: Iceland Trip",
             "Capture Time: 2026-08-07 10:00",

--- a/server-rs/crates/lrg-providers/src/types.rs
+++ b/server-rs/crates/lrg-providers/src/types.rs
@@ -29,6 +29,16 @@ pub struct MetadataGenerationRequest {
 
     pub submit_keywords: bool,
     pub submit_folder_names: bool,
+    /// Whether the people named on the photo may be sent to the model.
+    ///
+    /// Its own switch rather than a share of `submit_keywords`, because the
+    /// two ask different questions. Keywords are about how much the model has
+    /// to work with; names are about whether the people in a private photo are
+    /// named to a cloud provider at all — and a household that wants "beach,
+    /// sunset" sent may well not want "Ivo, Myriam" sent with it. Wanting the
+    /// names without the keyword clutter is just as reasonable, and neither
+    /// was expressible while one checkbox governed both.
+    pub submit_face_tags: bool,
 
     pub existing_keywords: Option<Vec<String>>,
     /// Names Lightroom's face recognition put on the photo, kept apart from
@@ -37,8 +47,7 @@ pub struct MetadataGenerationRequest {
     /// Lightroom flattens a named face into the same keyword list as
     /// everything else, and a model reading "Ivo" between "beach" and "sunset"
     /// takes it for scenery — issue #315's "the rocky shore of Ivo Beach".
-    /// Same switch as `existing_keywords` (`submit_keywords`): this splits the
-    /// context that was already being sent, it does not add more.
+    /// Gated by `submit_face_tags`.
     pub existing_face_tags: Option<Vec<String>>,
     /// What the local BioCLIP 2 classifier made of the organism in the frame,
     /// when species identification ran for this photo.
@@ -144,6 +153,12 @@ pub struct EditGenerationRequest {
 
     pub submit_keywords: bool,
     pub submit_folder_names: bool,
+    /// Whether the people named on the photo may be sent — see
+    /// [`MetadataGenerationRequest::submit_face_tags`]. The edit prompt asks
+    /// for names for a different reason (skin tones, who the subject is), but
+    /// the user's answer to "may these names leave my machine" is the same
+    /// one, so it is the same switch.
+    pub submit_face_tags: bool,
 
     pub existing_keywords: Option<Vec<String>>,
     /// Face tags, kept apart from `existing_keywords` — see
@@ -200,6 +215,7 @@ impl EditGenerationRequest {
             user_prompt: None,
             submit_keywords: false,
             submit_folder_names: false,
+            submit_face_tags: false,
             existing_keywords: None,
             existing_face_tags: None,
             location_data: None,


### PR DESCRIPTION
Closes #321.

A photo of two tagged people at a known beach came back as *"A Couple on a Rocky Beach"*, where another tool wrote *"Ivo and Myriam on Vacation at Ribadeo Beach, Spain"*. Six things stood between us and that title; all six are fixed here.

## 1. The location often never arrived

`extract_location_tags` read the bytes the backend was about to *send* — the **normalised** ones. Normalisation decodes and re-encodes every raw original and every JPEG over 2048 px, and the JPEG it writes has neither EXIF nor IPTC. So location context worked only for small exported JPEGs that pass through untouched, and vanished silently for anyone using *submit originals* or an export size above 2048 px, with the checkbox on and nothing to suggest anything was missing.

It is now read from the **original** bytes before conversion, plus the **XMP sidecar** beside a file on disk — for a raw workflow the only copy that exists outside the catalog.

## 2. Coordinates are not a place

Lightroom's address lookup only *suggests* a city until it is confirmed, and a suggestion reaches neither the exported file nor the sidecar. The reporter's own sidecar carries `exif:GPSLatitude` and no city at all, so the prompt got `48.459640, 12.089297` — which no vision model turns into a place name.

Coordinates with no name on them anywhere are now **reverse geocoded offline** against GeoNames `cities1000` (bundled with the `reverse_geocoder` crate — nothing is asked of the network), and the prompt says the name was looked up and how far away it is, so the model names the area instead of inventing a landmark. `cities1000` rather than `cities15000` because Ribadeo has 9,000 inhabitants.

## 3. The catalog's own fields were never sent

The plugin now sends Lightroom's location fields per photo (per *photo*, not per request — sixteen photos travel in one grouped request and the first one's city is not the others'). It is the only source that survives re-encoding and the only one that carries a place corrected after import.

The three sources are layered, and their place names are **never mixed**: two sources that disagree describe two different places, and filling the gaps between them invents a third. A live run produced exactly that — *"Sankt Peter-Ording, Galicia, Germany"* — before the merge was made all-or-nothing per source.

## 4. Nothing in the prompt asked for any of it

*"This photo was taken at: X"* was a statement with no instruction, and the face-tag line only said what a name must **not** be used for (#315), so the model left the names out. Both lines now say what to do: name the place where a place belongs, refer to tagged people by name instead of "a man and a woman", and — with several people named and no way to tell which face is which — name them together rather than guessing the pairing.

## 5. People's names had no switch of their own

They rode on **Existing Keywords**, which asks a different question. Sending "beach, sunset" to a cloud model is about how much the model has to work with; sending "Ivo, Myriam" is about whether the people in a private photo are named to a third party at all. Neither "keywords but not the names" nor "the names but not the keyword clutter" was expressible.

Now each is: a **People's names from face recognition** checkbox, its own `submit_face_tags` field, and its own gate in the metadata *and* the edit prompt — the edit request never had a checkbox of its own and follows this one.

Two compatibility details: the wire field defaults to **true** (a client old enough not to send it only puts `existing_face_tags` on the wire when its keyword switch is on, so trusting what arrived changes nothing for it), and the plugin preference is **seeded from the keyword switch**, so no upgrade starts sending names that were not being sent before. Unticking it also keeps the names out of `existing_keywords`, where they would otherwise ride along.

## 6. Only the stock-photo voice was on offer

The shipped prompt asks for species, landmarks and vehicle makes, and describes people as "a man and a woman" because that is what it was told to do — right for a stock library, wrong for a shoebox of family photos. Hence a second built-in template, **Family & Everyday Photos**: who, what, where, what the occasion appears to be, using the names the catalog already has, and explicitly forbidden to invent a relationship, a birthday or a landmark it was not given. The default is untouched, so no existing catalog's output changes.

Each built-in is offered exactly once (recorded in `seededPrompts`): "add when missing" would resurrect a deleted preset on every launch, "add on fresh installs" would never reach the people who already have the plugin — who are exactly the ones the new preset is for.

Two bugs a second preset exposed, both invisible while the menu had one entry: the three prompt pickers built their lists with `pairs`, so the order changed between launches, and deleting a prompt nil'd one slot of an array, truncating the menu at the hole and hiding every prompt after it. Both now go through `Util.promptMenuItems`.

## Verification

Live against the running binary, not just unit tests.

All three location sources, one request:

```
p_catalog2 → "Sankt Peter-Ording, Germany"   (from the catalog)
p_file2    → "Ribadeo, Galicia, Spain"       (from the file)
p_gps2     → "Vilsheim, Bavaria, Germany"    (looked up from GPS)
```

`p_file2` is a 3000 px JPEG whose IPTC used to be lost to normalisation; `p_gps2` is a sidecar carrying only coordinates, the shape of the file in the issue. A debug line per photo now names the place and its source, because "location wrong" and "location missing" are otherwise indistinguishable in a support log.

The two switches, captured from a stub provider that records what the model was actually sent: with **People's names** off the keyword line survives and the "People in this photo" line is gone; with **Family & Everyday Photos** selected it arrives as the system message alongside the location and people lines.

Test suites: `cargo test --workspace` green, `cargo clippy --workspace --all-targets` zero warnings, `cargo fmt --check` clean, `busted` 294/294 (12 new specs), `stylua --check` and `luacheck` clean, `scripts/check-docs.py` with no new warnings.

## Worth knowing before merging

- The binary grows by the ~7.5 MB bundled city list (`include_str!`, parsed lazily — a catalog without GPS pays nothing at runtime), and `isocountry` comes in as a small second dependency for country names.
- The second commit also fixes a test the first left asserting the old merge behaviour. It never failed visibly: the run that should have caught it died at the linker on a full disk, and the failure looked like silence.

---
_Generated by [Claude Code](https://claude.ai/code/session_013svryWwTdZ7JCMssbgvzQ3)_