### PR TITLE
Investigate a Capture One port, and keep what it produced

### DIFF
--- a/capture-one/.gitignore
+++ b/capture-one/.gitignore
@@ -1,0 +1,9 @@
+# Build output.
+build/
+dist/
+
+# `scripts/build.sh` stages a copy of Capture One's own CaptureOnePlugins.framework
+# under build/ so the compiler has something to link against. That binary is Phase
+# One's property and is taken out of the locally installed app — it must never be
+# committed or redistributed. It is covered by the build/ rule above; this comment
+# exists so nobody "fixes" that rule without knowing why it is there.

--- a/capture-one/README.md
+++ b/capture-one/README.md
@@ -1,0 +1,72 @@
+# Capture One — abandoned experiment
+
+**Status: not a product, not built, not shipped.** This directory is a partial
+snapshot of an attempt to port the plugin to Capture One, stopped on 2026-09-10
+part-way through the first implementation pass. It is kept as a record, because
+the research behind it was expensive and the reconstructed SDK header below is
+not trivially reproducible.
+
+Read [`docs/wiki/Dev-Capture-One-Port-Plan.md`](../docs/wiki/Dev-Capture-One-Port-Plan.md)
+first. It has the findings, the feasibility matrix for macOS vs. Windows, the
+architecture this code was heading towards, and the open questions. This file
+only describes what is actually on disk.
+
+## Why it stopped
+
+Two reasons, in order of weight:
+
+1. Capture One's plugin SDK cannot write keywords, metadata, or anything else
+   into the catalog. It hands a plugin a list of file paths and takes back a
+   status. The core of `Analyze & Index` is outside its contract, so a
+   Capture One "plugin" would really have been a companion application with its
+   own window, plus a shim to launch it.
+2. macOS and Windows would have been two different products. On macOS
+   AppleScript covers nearly the whole Lightroom feature surface; on Windows
+   there is no automation interface at all and the only way back into the
+   catalog is an XMP sidecar the user has to tell Capture One to read.
+
+Then the project decided not to pursue Capture One. That decision is the actual
+reason this stopped where it did.
+
+## What is here
+
+| Path | State |
+|---|---|
+| `coplugin-macos/Headers/CaptureOnePlugins.h` | **The interesting part.** A reconstructed interface for the SDK, recovered from Objective-C runtime metadata in the shipped `CaptureOnePlugins.framework` and in a real third-party plugin. Selector names and type encodings are exact; what could not be recovered from metadata (enum names and values leave no trace in a binary) is marked `SDK-UNVERIFIED`. Verified against Capture One 16.8.5.30. |
+| `coplugin-macos/Sources/LrGeniusAIPlugin.swift` | The `.coplugin` shim: collect the selected paths, hand them to the backend, mirror progress, surface errors. Compiles against the reconstructed header. |
+| `coplugin-macos/Info.plist` | `CFBundlePackageType=BNDL`, `NSPrincipalClass`, the `COPlugin*` keys — mirrors what a real installed plugin declares. |
+| `coplugin-macos/scripts/build.sh`, `notarize.sh` | Build and the manual notarisation dance (Xcode cannot notarise a bundle; `stapler staple` goes on the bundle, not the ZIP). |
+| `coplugin-windows/LrGeniusAI.Plugin/Core/*.cs` | Eight support classes — HTTP handoff, fallback launcher, hand-rolled JSON (net472 has no `System.Text.Json`), photo id, sidecar naming rules, run report. |
+| `scripts-macos/analyze_selection.applescript` | Scripts-menu entry point. Compiles cleanly with `osacompile`. |
+
+## What is missing
+
+The run was stopped mid-flight, so this is genuinely incomplete:
+
+- `bridge/c1_bridge.js` — the JXA bridge, the piece that would have done all the
+  actual catalog work on macOS. Never written.
+- `cli/` — `lrgenius-c1`, the companion process with the `CatalogHost` trait,
+  the `OsaHost`/`XmpHost` implementations and the XMP sidecar writer. Never written.
+- `coplugin-windows/` — no `Plugin.cs` entry class, no `.csproj`, no
+  `manifest.xml`, no packaging scripts. Only the support classes exist.
+- `scripts-macos/` — only one of the three entry points, and no installer.
+- Per-directory READMEs.
+
+## Two caveats before anyone picks this up
+
+**Nothing here has run against Capture One.** The macOS binaries built, and the
+AppleScript compiles, but no write path was ever executed — the catalog open on
+the development machine was empty. Every Windows statement is derived from
+documentation and two public plugin repositories, never reproduced on Windows.
+
+**`build/` and `dist/` are gitignored, and one reason is legal.** `build.sh`
+stages a copy of Capture One's own `CaptureOnePlugins.framework` so the compiler
+has something to link against. That binary is Phase One's property, taken out of
+the locally installed app. It must not be committed or redistributed. The
+reconstructed header in `Headers/` is our own work and is fine; the framework
+binary is not.
+
+The official SDK is behind a developer-portal signup at captureone.com, was last
+released as 1.0.1 in March 2022, and has no public repository. Getting hold of
+it legitimately is the first step for anyone continuing this, and the only way
+to get a Windows build at all.

--- a/capture-one/coplugin-macos/Headers/CaptureOnePlugins.h
+++ b/capture-one/coplugin-macos/Headers/CaptureOnePlugins.h
@@ -1,0 +1,312 @@
+//
+//  CaptureOnePlugins.h
+//
+//  RECONSTRUCTED interface for Capture One's plugin SDK.
+//
+//  This file is NOT from Phase One. It was reconstructed by reading the Objective-C
+//  runtime metadata that ships inside two binaries already present on this machine:
+//
+//    1. /Applications/Capture One.app/Contents/Frameworks/CaptureOnePlugins.framework
+//       (the framework binary — exported classes, properties and their type encodings)
+//    2. ~/Library/Application Support/Capture One/Plug-ins/COHeliconFocusPlugin.coplugin
+//       (a real third-party plugin — Objective-C protocols are emitted into whichever
+//        binary *uses* them, so this plugin's binary still carries the full text of
+//        COOpenWithPlugin, COEditingPlugin, COSettings, COFileHandling,
+//        COVariantProcessing and COActionSettings, including method type encodings)
+//
+//  Everything below that is marked "verified" was read out of those binaries with
+//  `nm`, `otool -oV` and `strings`; the selector names and the ObjC type encodings
+//  are exact. Everything marked SDK-UNVERIFIED could not be recovered from metadata
+//  (enum *values* and *names* are compile-time constants and leave no trace in a
+//  binary) and is a documented guess.
+//
+//  Replace this file with the official headers as soon as the real SDK is available.
+//  See Headers/README.md for the symbol-by-symbol comparison checklist.
+//
+//  Verified against Capture One 16.8.5.30.
+//
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class COPluginTask;
+@class COPluginAction;
+@class COSettingsItem;
+
+#pragma mark - Constants (verified: exported symbols of CaptureOnePlugins)
+
+/// Keys found inside COPluginTask.environment.
+extern NSString *const COPluginTaskDestinationFolder;
+extern NSString *const COPluginTaskTemporaryFolder;
+extern NSString *const COPluginTaskExecutingDocumentType;
+
+/// Values for COPluginTaskExecutingDocumentType.
+extern NSString *const COPluginTaskDocumentTypeCatalog;
+extern NSString *const COPluginTaskDocumentTypeSession;
+
+/// Declares which file formats an action accepts.
+extern NSString *const COSupportedFileFormatsKey;
+
+extern NSString *const COPluginActionDisplayNameKey;
+extern NSString *const COPluginActionIdentifierKey;
+extern NSString *const COFileHandlingPluginTaskFilesKey;
+
+#pragma mark - Enums (SDK-UNVERIFIED: values reconstructed by inference)
+
+/// SDK-UNVERIFIED: the real type name and its cases are unknown.
+///
+/// Evidence for the numbering: COHeliconFocusPlugin's implementation of
+/// -openWithActionsWithFileInfo:pluginRole:error: begins with
+/// `testq %r14,%r14 ; jne <return nil>` — i.e. it returns no actions unless
+/// pluginRole == 0. Helicon Focus is an "Open With" plugin, so 0 is the
+/// Open-With role. The framework also ships COPluginActionPublishResult and
+/// COPluginActionColorProfilingResult, which strongly implies that the same
+/// callback is reused to enumerate publish and colour-profiling actions under
+/// other role values. The 1 and 2 assignments below are ordering guesses.
+typedef NS_ENUM(NSUInteger, COPluginRole) {
+    COPluginRoleOpenWith        = 0,
+    COPluginRolePublish         = 1,  // SDK-UNVERIFIED
+    COPluginRoleColorProfiling  = 2,  // SDK-UNVERIFIED
+};
+
+/// SDK-UNVERIFIED: opaque event code delivered to -handleEvent:forSettingsItem:error:callback:.
+/// Only the parameter's ObjC type (NSUInteger) is verified.
+typedef NSUInteger COSettingsEvent;
+
+/// SDK-UNVERIFIED: opaque code handed *back* through the settings callback block to tell
+/// Capture One what to do next (e.g. re-read the settings tree). Only its type is verified.
+typedef NSUInteger COSettingsCallbackAction;
+
+#pragma mark - Progress (verified encoding, SDK-UNVERIFIED typedef name)
+
+/// Verified from the type encoding of -startOpenWithTask:error:progress: :
+///   @?<v@?@"COPluginTask"QQ@"NSString">
+/// i.e. void (^)(COPluginTask *, NSUInteger, NSUInteger, NSString *).
+///
+/// SDK-UNVERIFIED: the argument *meaning*. The (NSUInteger, NSUInteger) pair is
+/// assumed to be (completedUnits, totalUnits) — that ordering matches Capture One's
+/// own AppleScript properties "progress completed units" / "progress total units".
+typedef void (^COPluginTaskProgress)(COPluginTask *task,
+                                     NSUInteger completedUnits,
+                                     NSUInteger totalUnits,
+                                     NSString *_Nullable message);
+
+#pragma mark - Actions and results (verified)
+
+@interface COPluginAction : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic, copy) NSString *displayName;
+@property (nonatomic, copy, nullable) NSString *identifier;
+@property (nonatomic, strong, nullable) NSImage *image;
+- (instancetype)initWithDisplayName:(NSString *)displayName;
+- (instancetype)initWithDisplayName:(NSString *)displayName image:(nullable NSImage *)image;
++ (instancetype)pluginActionWithDisplayName:(NSString *)displayName;
+- (BOOL)isEqualToPluginAction:(COPluginAction *)other;
+@end
+
+@interface COPluginActionResult : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic) BOOL suppressNotification;
+@end
+
+/// Verified: `status` is a BOOL (property attribute string "TB,N,V_status").
+@interface COPluginActionOpenWithResult : COPluginActionResult
+@property (nonatomic) BOOL status;
+- (instancetype)initWithStatus:(BOOL)status;
+@end
+
+@interface COPluginActionImageResult : COPluginActionResult
+@property (nonatomic, copy) NSArray<NSString *> *images;
+- (instancetype)initWithImages:(NSArray<NSString *> *)images;
+@end
+
+@interface COPluginActionPublishResult : COPluginActionResult
+@property (nonatomic, copy, nullable) NSString *URL;
+@property (nonatomic, copy, nullable) NSString *message;
+- (instancetype)initWithURL:(nullable NSString *)url message:(nullable NSString *)message;
+@end
+
+@interface COPluginActionColorProfilingResult : COPluginActionResult
+@property (nonatomic, copy) NSArray<NSString *> *colorProfiles;
+- (instancetype)initWithColorProfiles:(NSArray<NSString *> *)colorProfiles;
+@end
+
+#pragma mark - Tasks (verified)
+
+@interface COPluginTask : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic, readonly) NSUUID *uuid;
+@property (nonatomic, readonly) COPluginAction *action;
+@property (nonatomic) BOOL cancelled;
+@property (nonatomic, copy, nullable) NSDictionary *settings;
+@property (nonatomic, copy, nullable) NSDictionary *environment;
+- (instancetype)initWithAction:(COPluginAction *)action;
+- (instancetype)initWithAction:(COPluginAction *)action settings:(nullable NSDictionary *)settings;
+@end
+
+@interface COFileHandlingPluginTask : COPluginTask
+@property (nonatomic, copy) NSArray<NSString *> *files;
+- (instancetype)initWithAction:(COPluginAction *)action files:(NSArray<NSString *> *)files;
+@end
+
+#pragma mark - Settings model (verified)
+
+@interface COSettingsBase : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic, copy, nullable) NSString *identifier;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) NSString *informativeText;
+- (instancetype)initWithIdentifier:(nullable NSString *)identifier title:(nullable NSString *)title;
+@end
+
+@interface COSettingsElement : COSettingsBase
+@end
+
+@interface COSettingsItem : COSettingsElement
+@end
+
+/// A titled group of *elements* (the top level of a settings tree).
+@interface COSettingsElementsGroup : COSettingsElement
+@property (nonatomic, copy) NSArray<COSettingsElement *> *elements;
+@end
+
+/// A titled group of *items* (one row cluster inside a group).
+@interface COSettingsItemsGroup : COSettingsElement
+@property (nonatomic, copy) NSArray<COSettingsItem *> *items;
+@end
+
+@interface COSettingsLabelItem : COSettingsItem
+@property (nonatomic, copy, nullable) NSString *value;
+@end
+
+@interface COSettingsBoolItem : COSettingsItem
+@property (nonatomic) BOOL value;
+@end
+
+@interface COSettingsTextItem : COSettingsItem
+@property (nonatomic, copy, nullable) NSString *value;
+@property (nonatomic) BOOL secure;
+@end
+
+/// Verified: `context` is id<NSSecureCoding>. It is echoed back to
+/// -handleEvent:forSettingsItem:error:callback: so a button can identify itself
+/// without the plugin storing any state.
+@interface COSettingsButtonItem : COSettingsItem
+@property (nonatomic, strong, nullable) id<NSSecureCoding> context;
+@end
+
+@interface COSettingsFileItem : COSettingsItem
+@property (nonatomic, copy, nullable) NSString *value;
+@property (nonatomic) BOOL canChooseFiles;
+@property (nonatomic) BOOL canChooseDirectories;
+@property (nonatomic) BOOL allowsMultipleSelection;
+@property (nonatomic, copy, nullable) NSArray<NSString *> *allowedFileTypes;
+@property (nonatomic, copy, nullable) NSString *directoryURL;
+@property (nonatomic, copy, nullable) NSString *placeholder;
+@end
+
+@interface COSettingsListOption : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic, strong, nullable) id<NSSecureCoding> value;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, strong, nullable) NSImage *image;
++ (instancetype)settingsListOptionWithValue:(nullable id<NSSecureCoding>)value title:(nullable NSString *)title;
++ (instancetype)separator;
+@end
+
+@interface COSettingsListItem : COSettingsItem
+@property (nonatomic, strong, nullable) id<NSSecureCoding> value;
+@property (nonatomic, copy, nullable) NSArray<COSettingsListOption *> *options;
+@end
+
+@interface COSettingsMultipleListItem : COSettingsItem
+@property (nonatomic, copy, nullable) NSArray *value;
+@property (nonatomic, copy, nullable) NSArray<COSettingsListOption *> *options;
+@property (nonatomic) BOOL allowsFiltering;
+@property (nonatomic, copy, nullable) NSString *filteringTextPlaceholder;
+@property (nonatomic) NSUInteger visibleRows;
+@property (nonatomic) BOOL showsSelectDeselectAll;
+@end
+
+#pragma mark - Protocols (verified: recovered from COHeliconFocusPlugin's protocol refs)
+
+/// Turns a chosen action plus a concrete file list into one or more units of work.
+@protocol COFileHandling <NSObject>
+- (nullable NSArray<COPluginTask *> *)tasksForAction:(COPluginAction *)action
+                                            forFiles:(NSArray<NSString *> *)files
+                                               error:(NSError **)error;
+@end
+
+/// Implementing this protocol is what makes Capture One hand a plugin *processed*
+/// variants instead of the original files on disk. Do not adopt it if you want RAWs.
+@protocol COVariantProcessing <NSObject>
+- (nullable NSDictionary *)processingSettingsForAction:(COPluginAction *)action error:(NSError **)error;
+- (NSUInteger)processingSettingsVisibilityForAction:(COPluginAction *)action;
+@end
+
+@protocol COActionSettings <NSObject>
+- (nullable NSArray<COSettingsElement *> *)settingsForAction:(COPluginAction *)action
+                                                    settings:(nullable NSDictionary *)settings
+                                                       error:(NSError **)error;
+- (BOOL)didUpdateValue:(nullable id<NSSecureCoding>)value
+            forSetting:(NSString *)settingIdentifier
+                action:(COPluginAction *)action
+              settings:(nullable NSDictionary *)settings
+        callbackAction:(COSettingsCallbackAction *)callbackAction
+                 error:(NSError **)error;
+- (BOOL)validateSettings:(nullable NSDictionary *)settings
+              forAction:(COPluginAction *)action
+                  error:(NSError **)error;
+@end
+
+@protocol COOpenWithPlugin <COFileHandling>
+- (nullable NSArray<COPluginAction *> *)openWithActionsWithFileInfo:(nullable NSDictionary *)fileInfo
+                                                        pluginRole:(COPluginRole)pluginRole
+                                                             error:(NSError **)error;
+- (nullable COPluginActionOpenWithResult *)startOpenWithTask:(COFileHandlingPluginTask *)task
+                                                       error:(NSError **)error
+                                                    progress:(nullable COPluginTaskProgress)progress;
+@end
+
+@protocol COEditingPlugin <COFileHandling, COVariantProcessing, COActionSettings>
+- (nullable NSArray<COPluginAction *> *)editingActionsWithFileInfo:(nullable NSDictionary *)fileInfo
+                                                             error:(NSError **)error;
+- (nullable COPluginActionImageResult *)startEditingTask:(COFileHandlingPluginTask *)task
+                                                    error:(NSError **)error
+                                                 progress:(nullable COPluginTaskProgress)progress;
+@end
+
+/// The plugin-wide (not per-action) preferences pane.
+@protocol COSettings <NSObject>
+- (nullable NSArray<COSettingsElement *> *)settingsWithError:(NSError **)error;
+- (BOOL)didUpdateValue:(nullable id<NSSecureCoding>)value
+            forSetting:(NSString *)settingIdentifier
+                 error:(NSError **)error
+              callback:(nullable void (^)(COSettingsCallbackAction action,
+                                          id<NSCopying, NSSecureCoding> _Nullable value))callback;
+- (BOOL)handleEvent:(COSettingsEvent)event
+    forSettingsItem:(COSettingsItem *)item
+              error:(NSError **)error
+           callback:(nullable void (^)(COSettingsCallbackAction action,
+                                       id<NSCopying, NSSecureCoding> _Nullable value))callback;
+@end
+
+#pragma mark - Base class (verified: exported, and carries no methods of its own)
+
+/// COPluginBase exports no instance methods in 16.8.5.30 — the host discovers what a
+/// plugin can do purely through protocol conformance / -respondsToSelector:.
+///
+/// The two selectors below are NOT on COPluginBase in the framework's metadata, yet
+/// COHeliconFocusPlugin implements both, so they are host-invoked hooks declared in
+/// the official header. Signatures are verified from Helicon's own type encodings
+/// (`@24@0:8@16` and `c32@0:8@16@24`); the *semantics* are inferred.
+@interface COPluginBase : NSObject
+
+/// SDK-UNVERIFIED semantics. Helicon uses the returned string as a defaults-key prefix
+/// for per-action persisted settings.
+- (nullable NSString *)keepSettingsForActionKey:(COPluginAction *)action;
+
+/// SDK-UNVERIFIED semantics. Only meaningful for COVariantProcessing plugins: whether the
+/// processed files Capture One rendered should be kept after the task finishes.
+- (BOOL)keepProcessedFilesForAction:(COPluginAction *)action settings:(nullable NSDictionary *)settings;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/capture-one/coplugin-macos/Headers/module.modulemap
+++ b/capture-one/coplugin-macos/Headers/module.modulemap
@@ -1,0 +1,14 @@
+// Consumed by scripts/build.sh, which assembles a *shim* framework:
+//
+//   build/CaptureOnePlugins.framework/
+//     Headers/CaptureOnePlugins.h   <- copied from ../Headers
+//     Modules/module.modulemap      <- copied from this file
+//     CaptureOnePlugins             <- the real binary, from Capture One.app
+//
+// That gives Swift a module to import and the linker real symbols to bind against,
+// without writing anything into /Applications.
+framework module CaptureOnePlugins {
+    umbrella header "CaptureOnePlugins.h"
+    export *
+    module * { export * }
+}

--- a/capture-one/coplugin-macos/Info.plist
+++ b/capture-one/coplugin-macos/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Key set mirrors the shipping COHeliconFocusPlugin.coplugin, which is the only
+	     verified example of a working Capture One plugin available to this project. -->
+
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+
+	<!-- Capture One instantiates this class by name. It must match the @objc(...) name
+	     on the Swift class, NOT the mangled Swift symbol. -->
+	<key>NSPrincipalClass</key>
+	<string>LrGeniusAIPlugin</string>
+
+	<key>CFBundleExecutable</key>
+	<string>LrGeniusAIPlugin</string>
+
+	<key>CFBundleIdentifier</key>
+	<string>cloud.machek.lrgeniusai.coplugin</string>
+
+	<key>CFBundleName</key>
+	<string>LrGeniusAI</string>
+
+	<key>CFBundleDisplayName</key>
+	<string>LrGeniusAI</string>
+
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+
+	<key>CFBundleVersion</key>
+	<string>1</string>
+
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+
+	<!-- Shown by Capture One in the Plug-ins preference pane. -->
+	<key>CFBundleGetInfoString</key>
+	<string>Send the selected originals to LrGeniusAI for AI tagging, description and search.</string>
+
+	<key>COPluginAuthor</key>
+	<string>Bastian Machek</string>
+
+	<key>COPluginAuthorURL</key>
+	<string>https://github.com/LrGenius/LrGeniusAI</string>
+
+	<!-- Capture One 16.8.5 itself declares LSMinimumSystemVersion 14.0, and
+	     CaptureOnePlugins.framework is built for macOS 14.0. Anything lower produces a
+	     linker warning and could not be loaded by this host anyway. -->
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © Bastian Machek. All rights reserved.</string>
+
+	<!-- Uncomment once Resources/LrGeniusAI.icns exists; menuIcon() looks it up by this name.
+	<key>CFBundleIconFile</key>
+	<string>LrGeniusAI</string>
+	-->
+</dict>
+</plist>

--- a/capture-one/coplugin-macos/Sources/LrGeniusAIPlugin.swift
+++ b/capture-one/coplugin-macos/Sources/LrGeniusAIPlugin.swift
@@ -1,0 +1,540 @@
+//
+//  LrGeniusAIPlugin.swift
+//
+//  Capture One "Open With" plugin that hands the *original* files of the current
+//  selection to the LrGeniusAI backend (127.0.0.1:19819), falling back to launching
+//  the `lrgenius-c1` helper when the backend is not answering.
+//
+//  Scope, deliberately: this is a shim. It collects paths and hands them off. It does
+//  not read metadata, does not write keywords, does not talk to the catalog — the
+//  Capture One plugin API exposes none of that (see ../README.md). Anything richer
+//  runs through the AppleScript entry point in ../scripts-macos/.
+//
+//  Statelessness is a hard requirement, not a style choice: Capture One hosts plugins
+//  out-of-process in COPluginHostApple.xpc, calls these methods in arbitrary order,
+//  and may relaunch the host between calls. Every method below is a pure function of
+//  its arguments plus the on-disk environment. There are no stored properties.
+//
+
+import AppKit
+import CaptureOnePlugins
+import Foundation
+import os.log
+
+// MARK: - Configuration
+
+private enum Config {
+    /// Reverse-DNS prefix shared by the action and every settings identifier, matching
+    /// the convention the shipping third-party plugins use.
+    static let bundleID = "cloud.machek.lrgeniusai.coplugin"
+
+    static let openWithActionID = bundleID + ".openwith"
+    static let settingsGroupID = bundleID + ".group"
+    static let settingsInfoID = bundleID + ".info"
+    static let settingsOpenButtonID = bundleID + ".openapp"
+    static let settingsStatusID = bundleID + ".status"
+
+    /// Echoed back to us through -handleEvent:forSettingsItem:error:callback: so the
+    /// button identifies itself without the plugin holding any state.
+    static let openButtonContext = bundleID + ".openapp.context"
+
+    static let backendHost = "127.0.0.1"
+    static let backendPort = 19819
+
+    static var backendBase: URL {
+        // Fixed host/port, so this cannot fail; a force-unwrap here is honest.
+        URL(string: "http://\(backendHost):\(backendPort)")!
+    }
+
+    /// Liveness probe. Plain-text "pong".
+    static var pingURL: URL { backendBase.appendingPathComponent("ping") }
+
+    /// NOTE: this endpoint does NOT exist in the backend yet. `server-rs` currently has
+    /// no /v1/host/handoff route — adding it is a separate, deliberate piece of work and
+    /// is explicitly out of scope for this change (no backend edits). Until it lands the
+    /// POST below will return 404, which this plugin treats exactly like "backend not
+    /// usable" and resolves through the `lrgenius-c1` fallback path. That is why the
+    /// fallback is not an afterthought here: today it is the *only* working path.
+    static var handoffURL: URL { backendBase.appendingPathComponent("v1/host/handoff") }
+
+    static let pingTimeout: TimeInterval = 1.5
+    static let handoffTimeout: TimeInterval = 30.0
+
+    /// Environment override for the helper binary, mostly for development.
+    static let helperEnvVar = "LRGENIUS_C1"
+
+    static let helperCandidates = [
+        "/Applications/LrGeniusAI/Server/lrgenius-c1",
+        "/Applications/LrGeniusAI/lrgenius-c1",
+        "/usr/local/bin/lrgenius-c1",
+        "/opt/homebrew/bin/lrgenius-c1",
+        NSHomeDirectory() + "/.local/bin/lrgenius-c1",
+    ]
+
+    static let log = OSLog(subsystem: bundleID, category: "plugin")
+}
+
+// MARK: - Errors that reach the user
+
+/// Capture One surfaces a thrown NSError's `localizedDescription` to the user, and that
+/// string is the plugin's ONLY user-visible channel — there is no warning channel and no
+/// window of our own. So every case here says what to DO, not what happened internally.
+private enum HandoffError: LocalizedError {
+    case noFiles
+    case noReadableFiles(tried: Int, reasons: [String])
+    case cancelled
+    case backendRejected(status: Int, body: String)
+    case helperMissing(underlying: String)
+    case helperFailed(status: Int32, output: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noFiles:
+            return "Capture One passed no files to LrGeniusAI. Select one or more images in the Browser, then try again."
+
+        case let .noReadableFiles(tried, reasons):
+            let detail = Summary.render(reasons, limit: 3)
+            return """
+            None of the \(tried) selected file\(tried == 1 ? "" : "s") could be read from disk. \
+            Reconnect the drive holding these images, or locate them in Capture One \
+            (Image menu > Locate), then try again.
+            \(detail)
+            """
+
+        case .cancelled:
+            return "The LrGeniusAI hand-off was cancelled."
+
+        case let .backendRejected(status, body):
+            if status == 404 {
+                return """
+                This copy of the LrGeniusAI backend does not support hand-off from Capture One yet. \
+                Update LrGeniusAI to a build that provides /v1/host/handoff, or install the \
+                lrgenius-c1 helper so the plugin can fall back to it.
+                """
+            }
+            let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines).prefix(300)
+            return """
+            The LrGeniusAI backend refused the hand-off (HTTP \(status)). \
+            Open the LrGeniusAI app and check its log, then try again.
+            \(trimmed.isEmpty ? "" : "Backend said: \(trimmed)")
+            """
+
+        case let .helperMissing(underlying):
+            return """
+            LrGeniusAI is not running and the lrgenius-c1 helper could not be found. \
+            Start the LrGeniusAI app once so its backend is listening on port \(Config.backendPort), \
+            or install lrgenius-c1 into /usr/local/bin.
+            (\(underlying))
+            """
+
+        case let .helperFailed(status, output):
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines).prefix(300)
+            return """
+            The lrgenius-c1 helper exited with code \(status). \
+            Run it once from Terminal to see the full message, then try again.
+            \(trimmed.isEmpty ? "" : "It printed: \(trimmed)")
+            """
+        }
+    }
+}
+
+// MARK: - Warning summarisation
+
+private enum Summary {
+    /// Deduplicates preserving order, shows a handful, counts the rest. A run-wide cause
+    /// (a whole volume offline) collapses to one line instead of one line per photo.
+    static func render(_ messages: [String], limit: Int) -> String {
+        var seen = Set<String>()
+        var unique: [String] = []
+        for m in messages where !seen.contains(m) {
+            seen.insert(m)
+            unique.append(m)
+        }
+        guard !unique.isEmpty else { return "" }
+        let shown = unique.prefix(limit).map { "- \($0)" }.joined(separator: "\n")
+        let rest = unique.count - min(limit, unique.count)
+        return rest > 0 ? "\(shown)\n- ... and \(rest) more" : shown
+    }
+}
+
+// MARK: - Plugin
+
+@objc(LrGeniusAIPlugin)
+public final class LrGeniusAIPlugin: COPluginBase, COOpenWithPlugin, COSettings {
+
+    // MARK: COOpenWithPlugin — action enumeration
+    //
+    // This runs synchronously while Capture One is building the context menu. It must
+    // not touch the network: a 1.5 s ping against a dead port would stall the menu for
+    // every right-click. Whether the backend is up is decided later, inside the task.
+
+    public func openWithActions(
+        withFileInfo fileInfo: [AnyHashable: Any]?,
+        pluginRole: COPluginRole
+    ) throws -> [COPluginAction] {
+        // Only the Open With role. Publish and colour-profiling reuse this callback and
+        // expect COPluginActionPublishResult / ...ColorProfilingResult respectively, which
+        // this plugin does not produce.
+        guard pluginRole == .openWith else { return [] }
+
+        // fileInfo maps a file-kind key to an NSNumber count. Verified from the shipping
+        // Helicon plugin, which gates on [[fileInfo allValues] valueForKeyPath:@"@sum.intValue"].
+        // A nil fileInfo means "no filtering information", so we stay available.
+        if let info = fileInfo, !info.isEmpty {
+            let total = (info.values.compactMap { ($0 as? NSNumber)?.intValue }).reduce(0, +)
+            guard total > 0 else { return [] }
+        }
+
+        let action = COPluginAction(displayName: "Send to LrGeniusAI")
+        action.identifier = Config.openWithActionID
+        action.image = Self.menuIcon()
+        return [action]
+    }
+
+    // MARK: COFileHandling — one task for the whole selection
+    //
+    // Returning one task per file would produce one hand-off per image. The backend wants
+    // the selection as a batch, so this deliberately returns exactly one task.
+
+    public func tasks(for action: COPluginAction, forFiles files: [String]) throws -> [COPluginTask] {
+        guard !files.isEmpty else { throw HandoffError.noFiles }
+        return [COFileHandlingPluginTask(action: action, files: files)]
+    }
+
+    // MARK: COOpenWithPlugin — the actual work
+
+    public func startOpen(
+        with task: COFileHandlingPluginTask,
+        progress: COPluginTaskProgress?
+    ) throws -> COPluginActionOpenWithResult {
+        let files = task.files
+        guard !files.isEmpty else { throw HandoffError.noFiles }
+
+        // +1 unit for the hand-off itself, after the per-file validation units.
+        let total = UInt(files.count + 1)
+        var completed: UInt = 0
+        progress?(task, completed, total, "Checking files...")
+
+        var usable: [String] = []
+        var problems: [String] = []
+
+        for path in files {
+            if task.cancelled { throw HandoffError.cancelled }
+
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+            if !exists {
+                problems.append("missing from disk: \((path as NSString).lastPathComponent)")
+            } else if isDirectory.boolValue {
+                problems.append("is a folder, not an image: \((path as NSString).lastPathComponent)")
+            } else if !FileManager.default.isReadableFile(atPath: path) {
+                problems.append("not readable (check permissions): \((path as NSString).lastPathComponent)")
+            } else {
+                usable.append(path)
+            }
+
+            completed += 1
+            progress?(task, completed, total, "Checking files...")
+        }
+
+        guard !usable.isEmpty else {
+            throw HandoffError.noReadableFiles(tried: files.count, reasons: problems)
+        }
+
+        if task.cancelled { throw HandoffError.cancelled }
+
+        let documentType = Self.documentType(from: task.environment)
+
+        // A degraded success still has to reach the user. The plugin API gives us no
+        // warning channel of its own, so the skipped files travel *in the payload*:
+        // LrGeniusAI is responsible for showing them, which keeps the report chain intact
+        // rather than ending it in a log line here.
+        let skipped = Array(Set(problems)).sorted()
+
+        progress?(task, completed, total, "Handing \(usable.count) file\(usable.count == 1 ? "" : "s") to LrGeniusAI...")
+
+        do {
+            try Self.handOff(
+                paths: usable,
+                documentType: documentType,
+                skipped: skipped,
+                temporaryFolder: Self.temporaryFolder(from: task.environment),
+                isCancelled: { task.cancelled }
+            )
+        } catch let error as HandoffError {
+            os_log("hand-off failed: %{public}@", log: Config.log, type: .error, error.errorDescription ?? "unknown")
+            throw error
+        }
+
+        progress?(task, total, total, "Handed off to LrGeniusAI.")
+
+        let result = COPluginActionOpenWithResult(status: true)
+        // We open our own UI; Capture One's "done" notification would be noise on top.
+        result.suppressNotification = true
+        return result
+    }
+
+    // MARK: COSettings — a minimal, declarative form
+    //
+    // The settings tree is pure data; there is no view code and no way to draw a custom
+    // window. One informative label plus one button is the whole surface.
+
+    public func settings() throws -> [COSettingsElement] {
+        let info = COSettingsLabelItem(identifier: Config.settingsInfoID, title: "About")
+        info.value = """
+        Select images in Capture One and choose "Send to LrGeniusAI" from the \
+        Open With menu. LrGeniusAI reads the original files directly — Capture One \
+        does not need to process or export them first.
+        """
+
+        let status = COSettingsLabelItem(identifier: Config.settingsStatusID, title: "Backend")
+        status.value = "Expected at http://\(Config.backendHost):\(Config.backendPort)"
+        status.informativeText = "Start the LrGeniusAI app if hand-off reports that the backend is unavailable."
+
+        let button = COSettingsButtonItem(identifier: Config.settingsOpenButtonID, title: "Open LrGeniusAI")
+        button.context = Config.openButtonContext as NSString
+        button.informativeText = "Opens the LrGeniusAI interface in your browser."
+
+        let items = COSettingsItemsGroup(identifier: Config.settingsGroupID + ".items", title: nil)
+        items.items = [info, status, button]
+
+        let group = COSettingsElementsGroup(identifier: Config.settingsGroupID, title: "LrGeniusAI")
+        group.elements = [items]
+
+        return [group]
+    }
+
+    public func didUpdateValue(
+        _ value: (any NSSecureCoding)?,
+        forSetting settingIdentifier: String,
+        callback: ((COSettingsCallbackAction, (any NSCopying & NSSecureCoding)?) -> Void)?
+    ) throws {
+        // Nothing in this form is editable, so there is no value to persist. Declared
+        // because COSettings requires it.
+        os_log("ignoring value change for %{public}@", log: Config.log, type: .debug, settingIdentifier)
+    }
+
+    public func handleEvent(
+        _ event: COSettingsEvent,
+        for item: COSettingsItem,
+        callback: ((COSettingsCallbackAction, (any NSCopying & NSSecureCoding)?) -> Void)?
+    ) throws {
+        // Identify the button by identifier, and by the context it carries, rather than
+        // by the opaque event code, whose values are not documented.
+        let contextMatches = (item as? COSettingsButtonItem)
+            .flatMap { $0.context as? NSString }
+            .map { $0 as String } == Config.openButtonContext
+
+        guard item.identifier == Config.settingsOpenButtonID || contextMatches else { return }
+
+        if Self.backendIsUp() {
+            NSWorkspace.shared.open(Config.backendBase)
+            return
+        }
+
+        // Backend down: start the helper with no files, which brings the app up.
+        do {
+            _ = try Self.runHelper(arguments: ["open"])
+        } catch let error as HandoffError {
+            throw error
+        }
+    }
+
+    // MARK: - Hand-off
+
+    private static func handOff(
+        paths: [String],
+        documentType: String,
+        skipped: [String],
+        temporaryFolder: String,
+        isCancelled: () -> Bool
+    ) throws {
+        var payload: [String: Any] = [
+            "host": "captureone",
+            "document_type": documentType,
+            "paths": paths,
+        ]
+        if !skipped.isEmpty {
+            payload["skipped"] = skipped
+        }
+
+        // Try HTTP first, but only if something is actually listening — a short ping keeps
+        // the failure fast when LrGeniusAI simply is not running.
+        if backendIsUp() {
+            let body = try JSONSerialization.data(withJSONObject: payload, options: [])
+            var request = URLRequest(url: Config.handoffURL)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+            request.timeoutInterval = Config.handoffTimeout
+
+            let (status, data) = try send(request, timeout: Config.handoffTimeout, isCancelled: isCancelled)
+
+            if (200..<300).contains(status) {
+                return
+            }
+
+            // 404 means this backend predates /v1/host/handoff. Everything else is a real
+            // refusal and should be reported rather than silently retried through the helper.
+            guard status == 404 else {
+                throw HandoffError.backendRejected(status: status, body: String(decoding: data, as: UTF8.self))
+            }
+            os_log("backend has no /v1/host/handoff (404); using lrgenius-c1", log: Config.log, type: .info)
+        }
+
+        if isCancelled() { throw HandoffError.cancelled }
+
+        // Fallback. Paths go through a list file rather than argv: a Capture One selection
+        // can run to thousands of images and blow past ARG_MAX. (The shipping Helicon plugin
+        // uses the same list-file technique.)
+        let listPath = (temporaryFolder as NSString)
+            .appendingPathComponent("lrgeniusai-handoff-\(UUID().uuidString).txt")
+        let listBody = paths.joined(separator: "\n") + "\n"
+        do {
+            try listBody.write(toFile: listPath, atomically: true, encoding: .utf8)
+        } catch {
+            throw HandoffError.helperMissing(underlying: "could not write the file list to \(temporaryFolder): \(error.localizedDescription)")
+        }
+        defer { try? FileManager.default.removeItem(atPath: listPath) }
+
+        var arguments = [
+            "handoff",
+            "--host", "captureone",
+            "--document-type", documentType,
+            "--paths-from", listPath,
+        ]
+        if !skipped.isEmpty {
+            arguments.append(contentsOf: ["--skipped-count", String(skipped.count)])
+        }
+
+        _ = try runHelper(arguments: arguments)
+    }
+
+    /// Synchronous POST that stays responsive to Capture One's cancel button.
+    ///
+    /// `startOpenWithTask:error:progress:` is a synchronous call on a host-owned worker
+    /// thread, so blocking here is expected — but blocking on a bare semaphore would make
+    /// Cancel do nothing for the whole timeout. Polling in short slices fixes that.
+    private static func send(
+        _ request: URLRequest,
+        timeout: TimeInterval,
+        isCancelled: () -> Bool
+    ) throws -> (Int, Data) {
+        let semaphore = DispatchSemaphore(value: 0)
+        var responseStatus = 0
+        var responseData = Data()
+        var transportError: Error?
+
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let http = response as? HTTPURLResponse { responseStatus = http.statusCode }
+            if let data { responseData = data }
+            transportError = error
+            semaphore.signal()
+        }
+        dataTask.resume()
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            if semaphore.wait(timeout: .now() + 0.1) == .success { break }
+            if isCancelled() {
+                dataTask.cancel()
+                throw HandoffError.cancelled
+            }
+            if Date() >= deadline {
+                dataTask.cancel()
+                transportError = URLError(.timedOut)
+                break
+            }
+        }
+
+        if let transportError {
+            // Reaching the backend failed outright. Report it as "not usable" so the caller
+            // moves on to the helper instead of surfacing a URLError the user cannot act on.
+            os_log("transport error: %{public}@", log: Config.log, type: .info, transportError.localizedDescription)
+            return (0, Data())
+        }
+        return (responseStatus, responseData)
+    }
+
+    private static func backendIsUp() -> Bool {
+        var request = URLRequest(url: Config.pingURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = Config.pingTimeout
+        let (status, body) = (try? send(request, timeout: Config.pingTimeout, isCancelled: { false })) ?? (0, Data())
+        guard (200..<300).contains(status) else { return false }
+        return String(decoding: body, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix("pong")
+    }
+
+    // MARK: - Helper process
+
+    @discardableResult
+    private static func runHelper(arguments: [String]) throws -> String {
+        guard let helper = helperPath() else {
+            throw HandoffError.helperMissing(
+                underlying: "looked in " + Config.helperCandidates.joined(separator: ", ")
+            )
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: helper)
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        do {
+            try process.run()
+        } catch {
+            throw HandoffError.helperMissing(underlying: "\(helper) could not be started: \(error.localizedDescription)")
+        }
+
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw HandoffError.helperFailed(status: process.terminationStatus, output: output)
+        }
+        return output
+    }
+
+    private static func helperPath() -> String? {
+        if let override = ProcessInfo.processInfo.environment[Config.helperEnvVar],
+           FileManager.default.isExecutableFile(atPath: override) {
+            return override
+        }
+        return Config.helperCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    // MARK: - Environment helpers
+
+    private static func documentType(from environment: [AnyHashable: Any]?) -> String {
+        guard let raw = environment?[COPluginTaskExecutingDocumentType] as? String else {
+            return "unknown"
+        }
+        // Normalise the SDK's opaque constants to the plain words the backend expects.
+        switch raw {
+        case COPluginTaskDocumentTypeCatalog: return "catalog"
+        case COPluginTaskDocumentTypeSession: return "session"
+        default: return raw
+        }
+    }
+
+    private static func temporaryFolder(from environment: [AnyHashable: Any]?) -> String {
+        if let folder = environment?[COPluginTaskTemporaryFolder] as? String, !folder.isEmpty {
+            return folder
+        }
+        return NSTemporaryDirectory()
+    }
+
+    private static func menuIcon() -> NSImage? {
+        // Bundle(for:) resolves inside the XPC host, where the plugin bundle is loaded.
+        guard let url = Bundle(for: LrGeniusAIPlugin.self).url(forResource: "LrGeniusAI", withExtension: "icns") else {
+            return nil
+        }
+        return NSImage(contentsOf: url)
+    }
+}

--- a/capture-one/coplugin-macos/scripts/build.sh
+++ b/capture-one/coplugin-macos/scripts/build.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Builds LrGeniusAI.coplugin — the Capture One "Open With" shim.
+#
+# Two supported modes:
+#
+#   1. OFFICIAL SDK (preferred).  Set CAPTURE_ONE_SDK to the directory that contains
+#      CaptureOnePlugins.framework as shipped by Phase One's developer portal. Its real
+#      headers are used and the reconstructed ones are ignored.
+#
+#   2. RECONSTRUCTED (fallback, and what you get out of the box).  No SDK required: the
+#      framework binary already ships inside Capture One.app, and ../Headers holds an
+#      interface reconstructed from that binary's Objective-C metadata. The build is
+#      byte-for-byte a normal plugin bundle, but the header is an educated reconstruction
+#      — see ../Headers/README.md for what is verified and what is guessed.
+#
+# Either way nothing is written into /Applications: a shim framework is assembled in
+# build/ from a *copy* of the binary plus whichever headers are in play.
+#
+# Environment:
+#   CAPTURE_ONE_SDK    dir containing CaptureOnePlugins.framework (optional)
+#   CAPTURE_ONE_APP    path to Capture One.app (default: /Applications/Capture One.app)
+#   ARCHS              space-separated (default: "arm64 x86_64")
+#   CODESIGN_IDENTITY  Developer ID Application: ... (optional; required for notarizing)
+#   MACOS_MIN          deployment target (default: 14.0)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+BUILD="$ROOT/build"
+DIST="$ROOT/dist"
+
+PLUGIN_NAME="LrGeniusAI"
+EXECUTABLE="LrGeniusAIPlugin"
+BUNDLE="$DIST/$PLUGIN_NAME.coplugin"
+
+CAPTURE_ONE_APP="${CAPTURE_ONE_APP:-/Applications/Capture One.app}"
+ARCHS="${ARCHS:-arm64 x86_64}"
+MACOS_MIN="${MACOS_MIN:-14.0}"
+
+die() { printf '\nerror: %s\n\n' "$1" >&2; exit 1; }
+
+command -v swiftc >/dev/null 2>&1 || die \
+"swiftc not found. Install the Xcode command line tools:
+    xcode-select --install"
+
+# --- Resolve the framework and headers -------------------------------------------------
+
+FRAMEWORK_BIN=""
+HEADER_DIR=""
+MODE=""
+
+if [[ -n "${CAPTURE_ONE_SDK:-}" ]]; then
+    SDK_FW="$CAPTURE_ONE_SDK/CaptureOnePlugins.framework"
+    [[ -d "$SDK_FW" ]] || die \
+"CAPTURE_ONE_SDK is set to '$CAPTURE_ONE_SDK', but there is no
+CaptureOnePlugins.framework inside it.
+
+Point CAPTURE_ONE_SDK at the directory that *contains* the framework, e.g.
+    export CAPTURE_ONE_SDK=\"\$HOME/CaptureOneSDK\"
+so that \"\$CAPTURE_ONE_SDK/CaptureOnePlugins.framework\" exists.
+
+Or unset CAPTURE_ONE_SDK to build against the reconstructed headers in
+$ROOT/Headers instead."
+
+    for candidate in "$SDK_FW/Versions/A/CaptureOnePlugins" "$SDK_FW/CaptureOnePlugins"; do
+        [[ -f "$candidate" ]] && { FRAMEWORK_BIN="$candidate"; break; }
+    done
+    [[ -n "$FRAMEWORK_BIN" ]] || die "no CaptureOnePlugins binary inside '$SDK_FW'."
+
+    for candidate in "$SDK_FW/Versions/A/Headers" "$SDK_FW/Headers"; do
+        [[ -d "$candidate" ]] && { HEADER_DIR="$candidate"; break; }
+    done
+    [[ -n "$HEADER_DIR" ]] || die \
+"'$SDK_FW' has no Headers directory, so it cannot be the official SDK.
+The copy bundled inside Capture One.app has no headers either — that is expected.
+Unset CAPTURE_ONE_SDK to build with the reconstructed headers."
+
+    MODE="official SDK ($CAPTURE_ONE_SDK)"
+else
+    APP_FW="$CAPTURE_ONE_APP/Contents/Frameworks/CaptureOnePlugins.framework/Versions/A/CaptureOnePlugins"
+    [[ -f "$APP_FW" ]] || die \
+"Cannot find CaptureOnePlugins.framework.
+
+Looked for the copy inside Capture One:
+    $APP_FW
+
+Fix by doing ONE of these:
+  * install Capture One (the framework ships inside the app), or
+  * point CAPTURE_ONE_APP at it if it lives elsewhere:
+        CAPTURE_ONE_APP=/path/to/Capture\\ One.app $0
+  * or get the official SDK from the Capture One developer portal
+    (https://www.captureone.com — Developer / Plugin SDK, account signup required)
+    and set:
+        export CAPTURE_ONE_SDK=/path/to/sdk"
+
+    FRAMEWORK_BIN="$APP_FW"
+    HEADER_DIR="$ROOT/Headers"
+    [[ -f "$HEADER_DIR/CaptureOnePlugins.h" ]] || die "missing $HEADER_DIR/CaptureOnePlugins.h"
+    MODE="reconstructed headers ($HEADER_DIR)"
+fi
+
+# --- Assemble the shim framework -------------------------------------------------------
+
+rm -rf "$BUILD" "$BUNDLE"
+mkdir -p "$BUILD"
+
+SHIM="$BUILD/CaptureOnePlugins.framework"
+mkdir -p "$SHIM/Headers" "$SHIM/Modules"
+cp "$FRAMEWORK_BIN" "$SHIM/CaptureOnePlugins"
+cp "$HEADER_DIR"/*.h "$SHIM/Headers/"
+if [[ -f "$ROOT/Headers/module.modulemap" ]]; then
+    cp "$ROOT/Headers/module.modulemap" "$SHIM/Modules/module.modulemap"
+else
+    cat > "$SHIM/Modules/module.modulemap" <<'MODMAP'
+framework module CaptureOnePlugins {
+    umbrella header "CaptureOnePlugins.h"
+    export *
+    module * { export * }
+}
+MODMAP
+fi
+
+echo "==> building $PLUGIN_NAME.coplugin"
+echo "    interface : $MODE"
+echo "    framework : $FRAMEWORK_BIN"
+echo "    archs     : $ARCHS"
+echo "    min macOS : $MACOS_MIN"
+
+# --- Compile one slice per arch, then lipo ---------------------------------------------
+
+SLICES=()
+for arch in $ARCHS; do
+    slice="$BUILD/$EXECUTABLE-$arch"
+    echo "==> swiftc ($arch)"
+    swiftc \
+        -target "${arch}-apple-macos${MACOS_MIN}" \
+        -swift-version 5 \
+        -O \
+        -F "$BUILD" -framework CaptureOnePlugins \
+        -module-name "$EXECUTABLE" \
+        -emit-library -Xlinker -bundle \
+        -o "$slice" \
+        "$ROOT/Sources"/*.swift
+    SLICES+=("$slice")
+done
+
+mkdir -p "$BUNDLE/Contents/MacOS" "$BUNDLE/Contents/Resources"
+
+if [[ ${#SLICES[@]} -gt 1 ]]; then
+    lipo -create "${SLICES[@]}" -output "$BUNDLE/Contents/MacOS/$EXECUTABLE"
+else
+    cp "${SLICES[0]}" "$BUNDLE/Contents/MacOS/$EXECUTABLE"
+fi
+
+cp "$ROOT/Info.plist" "$BUNDLE/Contents/Info.plist"
+[[ -d "$ROOT/Resources" ]] && cp -R "$ROOT/Resources/." "$BUNDLE/Contents/Resources/" || true
+
+# The plugin must NOT carry an rpath to Capture One's Frameworks directory: the XPC host
+# (COPluginHostApple.xpc) supplies it at load time. The shipping Helicon plugin has no
+# LC_RPATH at all, and neither does this one — swiftc adds none for a -bundle link.
+
+# --- Sign ------------------------------------------------------------------------------
+
+if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
+    echo "==> codesign ($CODESIGN_IDENTITY)"
+    # Hardened runtime is mandatory for notarization.
+    codesign --force --timestamp --options runtime \
+        --sign "$CODESIGN_IDENTITY" "$BUNDLE"
+    codesign --verify --strict --verbose=2 "$BUNDLE"
+else
+    echo "==> not signed (set CODESIGN_IDENTITY to sign; required before notarizing)"
+fi
+
+echo
+echo "built: $BUNDLE"
+echo
+echo "install with:"
+echo "    rm -rf ~/Library/Application\\ Support/Capture\\ One/Plug-ins/$PLUGIN_NAME.coplugin"
+echo "    cp -R '$BUNDLE' ~/Library/Application\\ Support/Capture\\ One/Plug-ins/"
+echo "then restart Capture One."

--- a/capture-one/coplugin-macos/scripts/notarize.sh
+++ b/capture-one/coplugin-macos/scripts/notarize.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Notarizes LrGeniusAI.coplugin and produces the distributable archive.
+#
+# WHY THIS IS A SCRIPT AND NOT AN XCODE BUTTON
+# --------------------------------------------
+# Xcode's Organizer can only notarize what it can archive: apps, and packages it builds
+# through a scheme's Archive action. A loadable bundle (CFBundlePackageType BNDL) that is
+# not embedded in an app never appears there, so "Product > Archive > Distribute" is not
+# an option for a .coplugin. The notarization service itself has no such limitation — it
+# just needs a signed payload uploaded by notarytool. Hence the CLI.
+#
+# ORDER OF OPERATIONS (this part is easy to get wrong)
+# ----------------------------------------------------
+#   1. sign the bundle (hardened runtime, secure timestamp)   <- scripts/build.sh does this
+#   2. zip it, because notarytool cannot accept a bare directory
+#   3. submit that zip and wait for acceptance
+#   4. staple the ticket to THE BUNDLE, not to the zip
+#      A zip cannot hold a stapled ticket. Stapling the zip either fails outright or
+#      staples nothing useful; the ticket has to live inside the bundle so that it
+#      survives being expanded on the user's machine.
+#   5. re-archive the now-stapled bundle for distribution
+#
+# Step 4 is the reason the upload zip and the distribution zip are two different files:
+# the first is a throwaway, the second contains the ticket.
+#
+# Credentials — use ONE of:
+#   NOTARY_PROFILE   name of a profile stored with:
+#                        xcrun notarytool store-credentials <name> \
+#                            --apple-id <id> --team-id <team> --password <app-specific-pw>
+#   or APPLE_ID + TEAM_ID + APP_PASSWORD  (app-specific password, not your Apple ID password)
+#
+# Optional:
+#   BUNDLE           path to the .coplugin (default: ../dist/LrGeniusAI.coplugin)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+
+BUNDLE="${BUNDLE:-$ROOT/dist/LrGeniusAI.coplugin}"
+NAME="$(basename "$BUNDLE" .coplugin)"
+WORK="$ROOT/build/notarize"
+UPLOAD_ZIP="$WORK/$NAME-upload.zip"
+DIST_ARCHIVE="$ROOT/dist/$NAME.coplugin.zip"
+
+die() { printf '\nerror: %s\n\n' "$1" >&2; exit 1; }
+
+[[ -d "$BUNDLE" ]] || die \
+"no bundle at '$BUNDLE'.
+Build it first:
+    scripts/build.sh
+or point BUNDLE at an existing one:
+    BUNDLE=/path/to/LrGeniusAI.coplugin $0"
+
+command -v xcrun >/dev/null 2>&1 || die "xcrun not found. Install the Xcode command line tools."
+
+# --- Credentials -----------------------------------------------------------------------
+
+NOTARY_AUTH=()
+if [[ -n "${NOTARY_PROFILE:-}" ]]; then
+    NOTARY_AUTH=(--keychain-profile "$NOTARY_PROFILE")
+elif [[ -n "${APPLE_ID:-}" && -n "${TEAM_ID:-}" && -n "${APP_PASSWORD:-}" ]]; then
+    NOTARY_AUTH=(--apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$APP_PASSWORD")
+else
+    die \
+"no notarization credentials.
+
+Store a reusable profile once:
+    xcrun notarytool store-credentials LrGeniusAI \\
+        --apple-id you@example.com --team-id ABCDE12345 --password <app-specific-password>
+    export NOTARY_PROFILE=LrGeniusAI
+
+or export APPLE_ID, TEAM_ID and APP_PASSWORD for a one-off run.
+APP_PASSWORD must be an app-specific password from appleid.apple.com, not your
+Apple ID password."
+fi
+
+# --- 1. The bundle must already be signed with the hardened runtime ---------------------
+
+echo "==> verifying signature"
+codesign --verify --strict --verbose=2 "$BUNDLE" 2>&1 || die \
+"'$BUNDLE' is not validly signed.
+Rebuild with a Developer ID identity:
+    CODESIGN_IDENTITY='Developer ID Application: Your Name (TEAMID)' scripts/build.sh
+Ad-hoc and unsigned bundles are rejected by the notary service."
+
+if ! codesign --display --verbose=2 "$BUNDLE" 2>&1 | grep -q 'flags=.*runtime'; then
+    die \
+"'$BUNDLE' is signed without the hardened runtime, which notarization requires.
+scripts/build.sh passes --options runtime; re-run it with CODESIGN_IDENTITY set."
+fi
+
+# --- 2. Zip for upload -----------------------------------------------------------------
+
+rm -rf "$WORK"; mkdir -p "$WORK"
+echo "==> packing for upload"
+# ditto --keepParent preserves the .coplugin directory as the archive's top-level entry
+# and keeps resource forks / extended attributes that codesign relies on. Plain `zip`
+# does not and can invalidate the signature.
+ditto -c -k --keepParent "$BUNDLE" "$UPLOAD_ZIP"
+
+# --- 3. Submit and wait ----------------------------------------------------------------
+
+echo "==> submitting to the notary service (this can take a few minutes)"
+if ! xcrun notarytool submit "$UPLOAD_ZIP" "${NOTARY_AUTH[@]}" --wait; then
+    echo
+    echo "Submission was not accepted. Get the details with:"
+    echo "    xcrun notarytool history ${NOTARY_AUTH[*]}"
+    echo "    xcrun notarytool log <submission-id> ${NOTARY_AUTH[*]}"
+    die "notarization failed."
+fi
+
+# --- 4. Staple the BUNDLE (never the zip) ----------------------------------------------
+
+echo "==> stapling ticket to the bundle"
+xcrun stapler staple "$BUNDLE" || die \
+"stapling failed. The notary service accepted the upload, but the ticket could not be
+attached. Re-run this script; tickets become available a short while after acceptance."
+
+xcrun stapler validate "$BUNDLE" || die "the stapled ticket did not validate."
+
+# --- 5. Re-archive the stapled bundle for distribution ----------------------------------
+
+echo "==> packing the stapled bundle for distribution"
+rm -f "$DIST_ARCHIVE"
+ditto -c -k --keepParent "$BUNDLE" "$DIST_ARCHIVE"
+
+# Capture One distributes plugins as a zip archive that carries the .coplugin extension;
+# the app expands it on install. Ship BOTH names from the same bytes so a download works
+# whether the user double-clicks it or drops the expanded bundle into Plug-ins/ by hand.
+cp "$DIST_ARCHIVE" "$ROOT/dist/$NAME-installer.coplugin"
+
+echo
+echo "notarized and stapled: $BUNDLE"
+echo "distributable archive: $DIST_ARCHIVE"
+echo "installer (same bytes, Capture One extension): $ROOT/dist/$NAME-installer.coplugin"
+echo
+echo "sanity check on another Mac:"
+echo "    spctl -a -vvv -t install '$BUNDLE'"

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/FallbackLauncher.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/FallbackLauncher.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>Result of trying to start the helper application.</summary>
+    internal sealed class LaunchOutcome
+    {
+        /// <summary>True when the helper is running, or ran and exited cleanly.</summary>
+        public bool Started { get; private set; }
+
+        /// <summary>Actionable failure text, or null on success.</summary>
+        public string Failure { get; private set; }
+
+        public static LaunchOutcome Ok()
+        {
+            return new LaunchOutcome { Started = true };
+        }
+
+        public static LaunchOutcome Failed(string failure)
+        {
+            return new LaunchOutcome { Started = false, Failure = failure };
+        }
+    }
+
+    /// <summary>
+    /// Starts <c>lrgenius-c1.exe</c> when the backend cannot take the hand-off
+    /// directly.
+    /// </summary>
+    /// <remarks>
+    /// This is the path that actually works today, since the backend has no
+    /// <c>/v1/host/handoff</c> route yet. The helper owns the run from the moment
+    /// it starts: it shows its own progress, and it is responsible for deleting the
+    /// request file it was handed.
+    /// </remarks>
+    internal static class FallbackLauncher
+    {
+        /// <summary>File name of the helper application.</summary>
+        public const string ExecutableName = "lrgenius-c1.exe";
+
+        /// <summary>
+        /// How long to watch a freshly started helper before assuming it is fine.
+        /// </summary>
+        /// <remarks>
+        /// A helper that dies immediately - missing runtime, broken install - would
+        /// otherwise be reported to the user as a successful hand-off, and they
+        /// would sit waiting for results that are never coming.
+        /// </remarks>
+        private const int StartupWatchMs = 1500;
+
+        /// <summary>
+        /// Every location searched for the helper, in order, for use both in the
+        /// search itself and in the message shown when it is not found.
+        /// </summary>
+        public static IList<string> CandidatePaths(string configuredPath)
+        {
+            var candidates = new List<string>();
+
+            if (!string.IsNullOrEmpty(configuredPath))
+            {
+                candidates.Add(configuredPath);
+            }
+
+            foreach (string directory in CandidateDirectories())
+            {
+                candidates.Add(Path.Combine(directory, ExecutableName));
+            }
+
+            return candidates;
+        }
+
+        private static IEnumerable<string> CandidateDirectories()
+        {
+            var directories = new List<string>();
+
+            // Next to the plug-in itself, for a self-contained install.
+            string pluginDirectory = TryGetPluginDirectory();
+            if (!string.IsNullOrEmpty(pluginDirectory))
+            {
+                directories.Add(pluginDirectory);
+                directories.Add(Path.Combine(pluginDirectory, "Server"));
+            }
+
+            foreach (string root in new[]
+                     {
+                         SafeFolder(Environment.SpecialFolder.LocalApplicationData),
+                         SafeFolder(Environment.SpecialFolder.ProgramFiles),
+                         SafeFolder(Environment.SpecialFolder.ProgramFilesX86),
+                     })
+            {
+                if (string.IsNullOrEmpty(root))
+                {
+                    continue;
+                }
+
+                string installed = Path.Combine(root, "LrGeniusAI");
+                directories.Add(installed);
+                directories.Add(Path.Combine(installed, "Server"));
+
+                // Per-user installers commonly land under Programs\.
+                string programs = Path.Combine(Path.Combine(root, "Programs"), "LrGeniusAI");
+                directories.Add(programs);
+                directories.Add(Path.Combine(programs, "Server"));
+            }
+
+            return directories;
+        }
+
+        /// <summary>
+        /// Returns the first candidate that exists, or null when the helper is not
+        /// installed anywhere this plug-in knows to look.
+        /// </summary>
+        public static string Locate(string configuredPath)
+        {
+            foreach (string candidate in CandidatePaths(configuredPath))
+            {
+                try
+                {
+                    if (File.Exists(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    // An unreadable candidate is simply not a match.
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Writes the hand-off request to a temporary file the helper will read.
+        /// </summary>
+        /// <returns>The file path.</returns>
+        /// <remarks>
+        /// The request travels as a file rather than on the command line because a
+        /// Windows command line tops out near 32767 characters, and a few hundred
+        /// full image paths pass that comfortably. Truncation there would be silent
+        /// and would drop photos without anyone noticing.
+        /// </remarks>
+        public static string WriteRequestFile(string requestJson)
+        {
+            string path = Path.Combine(
+                Path.GetTempPath(),
+                "lrgenius-c1-handoff-" + Guid.NewGuid().ToString("N") + ".json");
+            File.WriteAllText(path, requestJson, new UTF8Encoding(false));
+            return path;
+        }
+
+        /// <summary>Starts the helper against a request file.</summary>
+        public static LaunchOutcome Launch(string executablePath, string requestFilePath)
+        {
+            var startInfo = new ProcessStartInfo(executablePath)
+            {
+                Arguments = "--request " + QuoteArgument(requestFilePath),
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = Path.GetDirectoryName(executablePath) ?? string.Empty,
+            };
+
+            try
+            {
+                using (Process process = Process.Start(startInfo))
+                {
+                    if (process == null)
+                    {
+                        return LaunchOutcome.Failed(
+                            "Windows did not start " + ExecutableName
+                            + ". Reinstall LrGeniusAI, then run this again.");
+                    }
+
+                    if (process.WaitForExit(StartupWatchMs) && process.ExitCode != 0)
+                    {
+                        return LaunchOutcome.Failed(
+                            ExecutableName + " stopped immediately with exit code " + process.ExitCode
+                            + ". Run it once by hand to see what it reports, then run this again.");
+                    }
+
+                    return LaunchOutcome.Ok();
+                }
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                return LaunchOutcome.Failed(
+                    "Windows refused to start " + executablePath + " (" + ex.Message
+                    + "). Check that the file is not blocked by SmartScreen or removed by "
+                    + "virus scanning, then run this again.");
+            }
+            catch (Exception ex) when (ex is InvalidOperationException || ex is IOException)
+            {
+                return LaunchOutcome.Failed(
+                    "LrGeniusAI could not be started from " + executablePath + " (" + ex.Message
+                    + "). Reinstall LrGeniusAI, then run this again.");
+            }
+        }
+
+        /// <summary>
+        /// Quotes one argument the way the Windows C runtime parses it back.
+        /// </summary>
+        /// <remarks>
+        /// A temporary path is unlikely to contain a quote, but "unlikely" is not a
+        /// reason to hand-roll a version that breaks when it does.
+        /// </remarks>
+        internal static string QuoteArgument(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return "\"\"";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append('"');
+
+            int pendingBackslashes = 0;
+            foreach (char c in value)
+            {
+                if (c == '\\')
+                {
+                    pendingBackslashes++;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    // Backslashes before a quote must be doubled, and the quote
+                    // itself escaped.
+                    sb.Append('\\', (pendingBackslashes * 2) + 1);
+                    sb.Append('"');
+                    pendingBackslashes = 0;
+                    continue;
+                }
+
+                if (pendingBackslashes > 0)
+                {
+                    sb.Append('\\', pendingBackslashes);
+                    pendingBackslashes = 0;
+                }
+
+                sb.Append(c);
+            }
+
+            // Backslashes before the closing quote must be doubled too.
+            sb.Append('\\', pendingBackslashes * 2);
+            sb.Append('"');
+            return sb.ToString();
+        }
+
+        private static string TryGetPluginDirectory()
+        {
+            try
+            {
+                string location = Assembly.GetExecutingAssembly().Location;
+                return string.IsNullOrEmpty(location) ? null : Path.GetDirectoryName(location);
+            }
+            catch (Exception ex) when (ex is NotSupportedException || ex is IOException)
+            {
+                return null;
+            }
+        }
+
+        private static string SafeFolder(Environment.SpecialFolder folder)
+        {
+            try
+            {
+                return Environment.GetFolderPath(folder);
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is PlatformNotSupportedException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/HandoffClient.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/HandoffClient.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>The outcome of one HTTP round trip.</summary>
+    /// <remarks>
+    /// A transport failure and an HTTP error are different things to the user - one
+    /// says "start the backend", the other says "the backend refused this" - so
+    /// they are kept apart rather than flattened into one exception.
+    /// </remarks>
+    internal sealed class HttpOutcome
+    {
+        /// <summary>HTTP status, or 0 when the request never reached the server.</summary>
+        public int StatusCode { get; private set; }
+
+        /// <summary>Response body, or null after a transport failure.</summary>
+        public string Body { get; private set; }
+
+        /// <summary>
+        /// Plain-language reason the connection failed, or null when it did not.
+        /// Phrased to slot into a sentence, e.g. "nothing is listening there".
+        /// </summary>
+        public string TransportError { get; private set; }
+
+        /// <summary>True for 2xx.</summary>
+        public bool IsSuccess
+        {
+            get { return StatusCode >= 200 && StatusCode < 300; }
+        }
+
+        /// <summary>True when the server was never reached.</summary>
+        public bool IsTransportFailure
+        {
+            get { return TransportError != null; }
+        }
+
+        public static HttpOutcome Http(int statusCode, string body)
+        {
+            return new HttpOutcome { StatusCode = statusCode, Body = body };
+        }
+
+        public static HttpOutcome Transport(string reason)
+        {
+            return new HttpOutcome { StatusCode = 0, TransportError = reason };
+        }
+    }
+
+    /// <summary>
+    /// Talks to the local LrGeniusAI backend.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Deliberately synchronous, and deliberately <see cref="HttpWebRequest"/>.</b>
+    /// Capture One hosts plug-ins out of process and we do not know what - if
+    /// anything - it installs as a synchronization context on the thread that calls
+    /// us. Blocking on a Task in that situation is the classic way to deadlock a
+    /// plug-in host, and going async all the way would mean guessing at the SDK's
+    /// threading contract as well as its signatures. Straight-line blocking calls
+    /// with explicit timeouts have neither problem.
+    /// </para>
+    /// <para>
+    /// Cancellation is therefore cooperative: the caller checks between requests,
+    /// and the timeouts below bound how long any single request can delay that
+    /// check.
+    /// </para>
+    /// </remarks>
+    internal sealed class HandoffClient
+    {
+        /// <summary>Where the backend listens unless configured otherwise.</summary>
+        public const string DefaultBaseUrl = "http://127.0.0.1:19819";
+
+        /// <summary>
+        /// The hand-off endpoint.
+        /// </summary>
+        /// <remarks>
+        /// <b>This endpoint does not exist yet.</b> As of this writing the backend
+        /// exposes no <c>/v1/host/handoff</c> route - the shape below is this
+        /// plug-in's proposal, documented in README.md, and a 404 from it is an
+        /// expected answer today rather than a malfunction. The caller treats 404
+        /// as "this backend predates the endpoint" and falls back to the helper
+        /// executable, so the plug-in is useful before the backend catches up.
+        /// No backend change is made by this component.
+        /// </remarks>
+        public const string HandoffPath = "/v1/host/handoff";
+
+        private const int PingTimeoutMs = 2000;
+        private const int HandoffTimeoutMs = 30000;
+        private const int PollTimeoutMs = 15000;
+
+        private readonly string _baseUrl;
+
+        public HandoffClient(string baseUrl)
+        {
+            _baseUrl = string.IsNullOrEmpty(baseUrl)
+                ? DefaultBaseUrl
+                : baseUrl.TrimEnd('/');
+        }
+
+        /// <summary>The base URL actually in use, for messages.</summary>
+        public string BaseUrl
+        {
+            get { return _baseUrl; }
+        }
+
+        /// <summary>
+        /// Cheap liveness probe against <c>GET /ping</c>, which answers with the
+        /// plain text "pong".
+        /// </summary>
+        /// <remarks>
+        /// Worth its round trip: hashing a few hundred RAW files takes real time,
+        /// and finding out only afterwards that neither the backend nor the helper
+        /// is available would waste all of it.
+        /// </remarks>
+        public bool IsBackendAlive()
+        {
+            HttpOutcome outcome = Send("GET", "/ping", null, PingTimeoutMs);
+            return outcome.IsSuccess
+                   && outcome.Body != null
+                   && outcome.Body.IndexOf("pong", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        /// <summary>Posts the hand-off request.</summary>
+        public HttpOutcome PostHandoff(string requestJson)
+        {
+            return Send("POST", HandoffPath, requestJson, HandoffTimeoutMs);
+        }
+
+        /// <summary>
+        /// Reads a job's status once.
+        /// </summary>
+        /// <remarks>
+        /// <b>This read is destructive.</b> The backend hands a finished job's
+        /// result back exactly once and then drops it, and an untouched job expires
+        /// after 600 seconds. So a caller must consume everything it needs from the
+        /// response that first reports <c>done</c> or <c>error</c> - there is no
+        /// second chance - and two pollers must never share a job id.
+        /// </remarks>
+        public HttpOutcome PollJob(string jobId)
+        {
+            return Send("GET", "/v1/jobs/" + Uri.EscapeDataString(jobId), null, PollTimeoutMs);
+        }
+
+        private HttpOutcome Send(string method, string path, string jsonBody, int timeoutMs)
+        {
+            HttpWebRequest request;
+            try
+            {
+                request = (HttpWebRequest)WebRequest.Create(_baseUrl + path);
+            }
+            catch (Exception ex) when (ex is UriFormatException
+                                       || ex is NotSupportedException
+                                       || ex is InvalidCastException
+                                       || ex is ArgumentException)
+            {
+                return HttpOutcome.Transport(
+                    "\"" + _baseUrl + "\" is not a usable http:// address (" + ex.Message + ")");
+            }
+
+            request.Method = method;
+            request.Timeout = timeoutMs;
+            request.ReadWriteTimeout = timeoutMs;
+            request.KeepAlive = false;
+            request.Accept = "application/json";
+            request.UserAgent = PluginInfo.UserAgent;
+
+            // A configured system or corporate proxy must never be consulted for
+            // 127.0.0.1. Leaving this at the default is a well-known way to make a
+            // localhost call fail on a managed Windows machine.
+            request.Proxy = null;
+
+            try
+            {
+                if (jsonBody != null)
+                {
+                    byte[] payload = new UTF8Encoding(false).GetBytes(jsonBody);
+                    request.ContentType = "application/json; charset=utf-8";
+                    request.ContentLength = payload.Length;
+                    using (Stream body = request.GetRequestStream())
+                    {
+                        body.Write(payload, 0, payload.Length);
+                    }
+                }
+
+                using (var response = (HttpWebResponse)request.GetResponse())
+                {
+                    return HttpOutcome.Http((int)response.StatusCode, ReadBody(response));
+                }
+            }
+            catch (WebException ex)
+            {
+                // A 4xx/5xx arrives here as an exception carrying the response.
+                // That is an answer from the server, not a transport failure.
+                var response = ex.Response as HttpWebResponse;
+                if (response != null)
+                {
+                    using (response)
+                    {
+                        return HttpOutcome.Http((int)response.StatusCode, ReadBody(response));
+                    }
+                }
+
+                return HttpOutcome.Transport(DescribeTransportFailure(ex, timeoutMs));
+            }
+            catch (IOException ex)
+            {
+                return HttpOutcome.Transport("the connection dropped (" + ex.Message + ")");
+            }
+        }
+
+        private static string ReadBody(HttpWebResponse response)
+        {
+            try
+            {
+                using (Stream stream = response.GetResponseStream())
+                {
+                    if (stream == null)
+                    {
+                        return string.Empty;
+                    }
+
+                    using (var reader = new StreamReader(stream, Encoding.UTF8))
+                    {
+                        return reader.ReadToEnd();
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                // The status code is the useful part; a truncated body is not worth
+                // turning a real answer into a transport failure.
+                return string.Empty;
+            }
+        }
+
+        private static string DescribeTransportFailure(WebException ex, int timeoutMs)
+        {
+            switch (ex.Status)
+            {
+                case WebExceptionStatus.ConnectFailure:
+                case WebExceptionStatus.NameResolutionFailure:
+                case WebExceptionStatus.ProxyNameResolutionFailure:
+                    return "nothing is listening there";
+                case WebExceptionStatus.Timeout:
+                    return "it did not answer within "
+                           + (timeoutMs / 1000).ToString(CultureInfo.InvariantCulture)
+                           + " seconds";
+                case WebExceptionStatus.ConnectionClosed:
+                case WebExceptionStatus.KeepAliveFailure:
+                    return "the connection was closed mid-request";
+                default:
+                    return ex.Message;
+            }
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/Json.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/Json.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>
+    /// A minimal, dependency-free JSON writer and reader.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Why this exists instead of a framework serializer:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <c>System.Text.Json</c> does not exist in .NET Framework 4.7.2, and taking
+    /// it from NuGet would mean shipping several assemblies into a plug-in host we
+    /// do not control the load context of.
+    /// </description></item>
+    /// <item><description>
+    /// <c>DataContractJsonSerializer</c> needs one CLR type per JSON shape. The
+    /// backend's job envelope is <c>{status, result, error, progress}</c> where
+    /// <c>result</c> and <c>progress</c> are free-form (<c>serde_json::Value</c> on
+    /// the Rust side, deliberately job-specific). There is no contract type to
+    /// write, and any type we invented would start silently dropping fields the
+    /// first time the backend added one.
+    /// </description></item>
+    /// <item><description>
+    /// <c>JavaScriptSerializer</c> could do it, but it lives in
+    /// System.Web.Extensions, and dragging the ASP.NET assembly into a photo
+    /// editor's plug-in host to parse a 200-byte reply is a poor trade.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// So: about 200 lines, no dependencies, and it throws <see cref="FormatException"/>
+    /// on malformed input rather than quietly handing back a default-constructed
+    /// object that the caller would report as a successful empty result.
+    /// </para>
+    /// <para>
+    /// Parsed values are plain CLR objects: <see cref="Dictionary{TKey,TValue}"/> of
+    /// <c>string</c> to <c>object</c>, <see cref="List{T}"/> of <c>object</c>,
+    /// <c>string</c>, <c>double</c>, <c>bool</c>, or <c>null</c>.
+    /// </para>
+    /// </remarks>
+    internal static class Json
+    {
+        // ---------------------------------------------------------------- writing
+
+        /// <summary>
+        /// Renders a string as a JSON string literal, including the surrounding
+        /// quotes. Returns the literal <c>null</c> for a null input.
+        /// </summary>
+        public static string Quote(string value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            var sb = new StringBuilder(value.Length + 2);
+            sb.Append('"');
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '"':
+                        sb.Append("\\\"");
+                        break;
+                    case '\\':
+                        sb.Append("\\\\");
+                        break;
+                    case '\b':
+                        sb.Append("\\b");
+                        break;
+                    case '\f':
+                        sb.Append("\\f");
+                        break;
+                    case '\n':
+                        sb.Append("\\n");
+                        break;
+                    case '\r':
+                        sb.Append("\\r");
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    default:
+                        if (c < ' ')
+                        {
+                            sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+
+                        break;
+                }
+            }
+
+            sb.Append('"');
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// True when <paramref name="value"/> can survive a round trip through UTF-8
+        /// JSON.
+        /// </summary>
+        /// <remarks>
+        /// Windows file names are UTF-16 code-unit sequences and are not required to
+        /// be well-formed Unicode: a file copied off damaged media can carry an
+        /// unpaired surrogate. Encoding one as UTF-8 produces bytes the backend's
+        /// JSON parser rejects, which would fail the whole batch instead of the one
+        /// bad file. Callers use this to skip such a path and warn about it by name.
+        /// </remarks>
+        public static bool IsRepresentable(string value)
+        {
+            if (value == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                if (char.IsHighSurrogate(c))
+                {
+                    if (i + 1 >= value.Length || !char.IsLowSurrogate(value[i + 1]))
+                    {
+                        return false;
+                    }
+
+                    i++;
+                    continue;
+                }
+
+                if (char.IsLowSurrogate(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // ---------------------------------------------------------------- reading
+
+        /// <summary>Parses a complete JSON document.</summary>
+        /// <exception cref="FormatException">The text is not valid JSON.</exception>
+        public static object Parse(string text)
+        {
+            if (text == null)
+            {
+                throw new FormatException("empty response body");
+            }
+
+            int index = 0;
+            object value = ParseValue(text, ref index);
+            SkipWhitespace(text, ref index);
+            if (index != text.Length)
+            {
+                throw new FormatException("unexpected trailing content at offset " + index.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return value;
+        }
+
+        private static void SkipWhitespace(string s, ref int i)
+        {
+            while (i < s.Length)
+            {
+                char c = s[i];
+                if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+                {
+                    i++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        private static object ParseValue(string s, ref int i)
+        {
+            SkipWhitespace(s, ref i);
+            if (i >= s.Length)
+            {
+                throw new FormatException("unexpected end of input");
+            }
+
+            switch (s[i])
+            {
+                case '{':
+                    return ParseObject(s, ref i);
+                case '[':
+                    return ParseArray(s, ref i);
+                case '"':
+                    return ParseString(s, ref i);
+                case 't':
+                    ExpectLiteral(s, ref i, "true");
+                    return true;
+                case 'f':
+                    ExpectLiteral(s, ref i, "false");
+                    return false;
+                case 'n':
+                    ExpectLiteral(s, ref i, "null");
+                    return null;
+                default:
+                    return ParseNumber(s, ref i);
+            }
+        }
+
+        private static void ExpectLiteral(string s, ref int i, string literal)
+        {
+            if (i + literal.Length > s.Length
+                || string.CompareOrdinal(s, i, literal, 0, literal.Length) != 0)
+            {
+                throw new FormatException("invalid literal at offset " + i.ToString(CultureInfo.InvariantCulture));
+            }
+
+            i += literal.Length;
+        }
+
+        private static Dictionary<string, object> ParseObject(string s, ref int i)
+        {
+            var result = new Dictionary<string, object>(StringComparer.Ordinal);
+            i++; // consume '{'
+            SkipWhitespace(s, ref i);
+            if (i < s.Length && s[i] == '}')
+            {
+                i++;
+                return result;
+            }
+
+            while (true)
+            {
+                SkipWhitespace(s, ref i);
+                if (i >= s.Length || s[i] != '"')
+                {
+                    throw new FormatException("expected an object key at offset " + i.ToString(CultureInfo.InvariantCulture));
+                }
+
+                string key = ParseString(s, ref i);
+                SkipWhitespace(s, ref i);
+                if (i >= s.Length || s[i] != ':')
+                {
+                    throw new FormatException("expected ':' at offset " + i.ToString(CultureInfo.InvariantCulture));
+                }
+
+                i++;
+                result[key] = ParseValue(s, ref i);
+                SkipWhitespace(s, ref i);
+                if (i >= s.Length)
+                {
+                    throw new FormatException("unterminated object");
+                }
+
+                if (s[i] == ',')
+                {
+                    i++;
+                    continue;
+                }
+
+                if (s[i] == '}')
+                {
+                    i++;
+                    return result;
+                }
+
+                throw new FormatException("expected ',' or '}' at offset " + i.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        private static List<object> ParseArray(string s, ref int i)
+        {
+            var result = new List<object>();
+            i++; // consume '['
+            SkipWhitespace(s, ref i);
+            if (i < s.Length && s[i] == ']')
+            {
+                i++;
+                return result;
+            }
+
+            while (true)
+            {
+                result.Add(ParseValue(s, ref i));
+                SkipWhitespace(s, ref i);
+                if (i >= s.Length)
+                {
+                    throw new FormatException("unterminated array");
+                }
+
+                if (s[i] == ',')
+                {
+                    i++;
+                    continue;
+                }
+
+                if (s[i] == ']')
+                {
+                    i++;
+                    return result;
+                }
+
+                throw new FormatException("expected ',' or ']' at offset " + i.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        private static string ParseString(string s, ref int i)
+        {
+            // The caller has already checked that s[i] is the opening quote.
+            i++;
+            var sb = new StringBuilder();
+            while (true)
+            {
+                if (i >= s.Length)
+                {
+                    throw new FormatException("unterminated string");
+                }
+
+                char c = s[i++];
+                if (c == '"')
+                {
+                    return sb.ToString();
+                }
+
+                if (c != '\\')
+                {
+                    sb.Append(c);
+                    continue;
+                }
+
+                if (i >= s.Length)
+                {
+                    throw new FormatException("unterminated escape sequence");
+                }
+
+                char escape = s[i++];
+                switch (escape)
+                {
+                    case '"':
+                        sb.Append('"');
+                        break;
+                    case '\\':
+                        sb.Append('\\');
+                        break;
+                    case '/':
+                        sb.Append('/');
+                        break;
+                    case 'b':
+                        sb.Append('\b');
+                        break;
+                    case 'f':
+                        sb.Append('\f');
+                        break;
+                    case 'n':
+                        sb.Append('\n');
+                        break;
+                    case 'r':
+                        sb.Append('\r');
+                        break;
+                    case 't':
+                        sb.Append('\t');
+                        break;
+                    case 'u':
+                        if (i + 4 > s.Length)
+                        {
+                            throw new FormatException("truncated \\u escape at offset " + i.ToString(CultureInfo.InvariantCulture));
+                        }
+
+                        ushort unit;
+                        if (!ushort.TryParse(
+                                s.Substring(i, 4),
+                                NumberStyles.HexNumber,
+                                CultureInfo.InvariantCulture,
+                                out unit))
+                        {
+                            throw new FormatException("invalid \\u escape at offset " + i.ToString(CultureInfo.InvariantCulture));
+                        }
+
+                        // Appending the raw UTF-16 code unit lets a surrogate pair
+                        // written as two \u escapes reassemble on its own.
+                        sb.Append((char)unit);
+                        i += 4;
+                        break;
+                    default:
+                        throw new FormatException("invalid escape '\\" + escape + "' at offset " + i.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+        }
+
+        private static double ParseNumber(string s, ref int i)
+        {
+            int start = i;
+            while (i < s.Length)
+            {
+                char c = s[i];
+                bool isNumeric = (c >= '0' && c <= '9')
+                                 || c == '-' || c == '+' || c == '.'
+                                 || c == 'e' || c == 'E';
+                if (!isNumeric)
+                {
+                    break;
+                }
+
+                i++;
+            }
+
+            if (i == start)
+            {
+                throw new FormatException("expected a value at offset " + start.ToString(CultureInfo.InvariantCulture));
+            }
+
+            double value;
+            if (!double.TryParse(
+                    s.Substring(start, i - start),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out value))
+            {
+                throw new FormatException("invalid number at offset " + start.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return value;
+        }
+
+        // -------------------------------------------------------------- accessors
+        // Deliberately tolerant: a missing or differently-typed member yields null
+        // or an empty list. The response's shape is the backend's business, and a
+        // reply that merely gained a field must not fail the run. Genuinely broken
+        // JSON is caught by Parse instead.
+
+        /// <summary>Returns a member of a JSON object, or null when absent.</summary>
+        public static object Member(object node, string key)
+        {
+            var map = node as Dictionary<string, object>;
+            object value;
+            if (map != null && map.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+
+        /// <summary>Returns a string member, or null when absent or not a string.</summary>
+        public static string GetString(object node, string key)
+        {
+            return Member(node, key) as string;
+        }
+
+        /// <summary>Returns a numeric member, or null when absent or not a number.</summary>
+        public static double? GetNumber(object node, string key)
+        {
+            object value = Member(node, key);
+            if (value is double)
+            {
+                return (double)value;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the non-empty strings of an array member. Never null; an absent
+        /// member yields an empty list.
+        /// </summary>
+        public static IList<string> GetStringArray(object node, string key)
+        {
+            var result = new List<string>();
+            var list = Member(node, key) as List<object>;
+            if (list == null)
+            {
+                return result;
+            }
+
+            foreach (object item in list)
+            {
+                var text = item as string;
+                if (!string.IsNullOrEmpty(text))
+                {
+                    result.Add(text);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/PhotoId.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/PhotoId.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>
+    /// Computes the host-neutral <c>file1:</c> photo identifier.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The identifier is <c>"file1:" + MD5(&lt;size&gt; ":" &lt;head&gt; ":" &lt;tail&gt;)</c>, where
+    /// <c>&lt;size&gt;</c> is the file length in bytes as ASCII decimal digits,
+    /// <c>&lt;head&gt;</c> is the first 4 MiB of the file and <c>&lt;tail&gt;</c> the last 4 MiB.
+    /// Files shorter than 4 MiB are covered twice, once as head and once as tail;
+    /// that is intentional and deterministic, not a bug to "fix" later.
+    /// </para>
+    /// <para>
+    /// The backend treats <c>photo_id</c> as an opaque string and derives nothing
+    /// from it, so the only requirement is that the same file always produces the
+    /// same id on every host.
+    /// </para>
+    /// <para>
+    /// <b>Deliberately no modification time.</b> The Lightroom plug-in's fallback
+    /// scheme (<c>md5p:&lt;size&gt;:&lt;mtime&gt;:...</c>) mixes mtime in, which makes the id
+    /// change when a file is copied to another volume or restored from a backup.
+    /// Content plus length is stable across all of that.
+    /// </para>
+    /// <para>
+    /// <b>Open decision, deliberately not implemented here.</b> Lightroom's primary
+    /// scheme is <c>meta1:</c>, an MD5 over eleven values that include four
+    /// *formatted* Lightroom display strings ("1/125 s", "f/2.8", "70 mm",
+    /// "ISO 400"). Capture One cannot reproduce those strings character for
+    /// character, so a <c>file1:</c> id will never collide with an existing
+    /// Lightroom index entry for the same photo. Whether the two namespaces should
+    /// later be reconciled - and if so, in which direction - is an open product
+    /// decision. This plug-in does not attempt it: it only ever emits
+    /// <c>file1:</c> ids, and never rewrites or matches against <c>meta1:</c> ones.
+    /// </para>
+    /// <para>
+    /// Two distinct files sharing a length, a first 4 MiB and a last 4 MiB would
+    /// collide. For camera originals that does not happen; for synthetic test files
+    /// padded in the middle it can.
+    /// </para>
+    /// </remarks>
+    internal static class PhotoId
+    {
+        /// <summary>Namespace prefix identifying the algorithm.</summary>
+        public const string Prefix = "file1:";
+
+        /// <summary>Name of the algorithm, as sent to the backend.</summary>
+        public const string AlgorithmName = "file1";
+
+        private const int ChunkBytes = 4 * 1024 * 1024;
+        private const int CopyBufferBytes = 64 * 1024;
+
+        /// <summary>
+        /// Checks once, up front, whether MD5 can be used at all.
+        /// </summary>
+        /// <returns>
+        /// Null when MD5 is available, otherwise the platform's reason.
+        /// </returns>
+        /// <remarks>
+        /// Windows machines with the "System cryptography: Use FIPS compliant
+        /// algorithms" policy enabled refuse to hand out MD5. That would otherwise
+        /// fail on the very first photo and again on every one after it, so the
+        /// caller probes once and reports a single actionable message instead of
+        /// one failure per file.
+        /// </remarks>
+        public static string ProbeUnavailableReason()
+        {
+            try
+            {
+                using (MD5.Create())
+                {
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Intentionally broad: this is a capability probe, and every
+                // failure mode here means the same thing to the caller.
+                return ex.Message;
+            }
+        }
+
+        /// <summary>Computes the <c>file1:</c> identifier for a file on disk.</summary>
+        /// <exception cref="IOException">The file could not be read in full.</exception>
+        /// <exception cref="UnauthorizedAccessException">Access was denied.</exception>
+        public static string Compute(string path)
+        {
+            // FileShare.ReadWrite | FileShare.Delete: Capture One very likely has
+            // the file open already, and a plug-in must not be the reason a read
+            // fails. We only ever read.
+            using (var md5 = MD5.Create())
+            using (var stream = new FileStream(
+                       path,
+                       FileMode.Open,
+                       FileAccess.Read,
+                       FileShare.ReadWrite | FileShare.Delete,
+                       CopyBufferBytes,
+                       FileOptions.SequentialScan))
+            {
+                long size = stream.Length;
+
+                AbsorbAscii(md5, size.ToString(CultureInfo.InvariantCulture));
+                AbsorbAscii(md5, ":");
+
+                int headLength = (int)Math.Min(ChunkBytes, size);
+                AbsorbRange(stream, md5, 0, headLength, path);
+
+                AbsorbAscii(md5, ":");
+
+                long tailStart = Math.Max(0, size - ChunkBytes);
+                int tailLength = (int)Math.Min(ChunkBytes, size);
+                AbsorbRange(stream, md5, tailStart, tailLength, path);
+
+                md5.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                return Prefix + ToHex(md5.Hash);
+            }
+        }
+
+        private static void AbsorbAscii(HashAlgorithm hash, string text)
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes(text);
+            hash.TransformBlock(bytes, 0, bytes.Length, null, 0);
+        }
+
+        private static void AbsorbRange(FileStream stream, HashAlgorithm hash, long offset, int count, string path)
+        {
+            if (count <= 0)
+            {
+                return;
+            }
+
+            stream.Seek(offset, SeekOrigin.Begin);
+            var buffer = new byte[CopyBufferBytes];
+            int remaining = count;
+            while (remaining > 0)
+            {
+                int wanted = Math.Min(buffer.Length, remaining);
+                int read = stream.Read(buffer, 0, wanted);
+                if (read <= 0)
+                {
+                    // The file shrank while we were reading it. Hashing the short
+                    // read would mint an id that never reproduces, so refuse
+                    // instead and let the caller skip this one photo by name.
+                    throw new IOException(
+                        "the file ended earlier than its own length promised - it is probably still being written");
+                }
+
+                hash.TransformBlock(buffer, 0, read, null, 0);
+                remaining -= read;
+            }
+        }
+
+        private static string ToHex(byte[] bytes)
+        {
+            var sb = new StringBuilder(bytes.Length * 2);
+            foreach (byte b in bytes)
+            {
+                sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/PluginConfig.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/PluginConfig.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>
+    /// The two things a user may need to override, read fresh on every run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The plug-in class holds no fields of its own. Capture One may construct it
+    /// per invocation, may keep it alive across many, and hosts it in a separate
+    /// process that can be restarted at any time - so anything cached in memory is
+    /// either pointless or stale. Settings therefore live in a small file that the
+    /// settings UI writes and every run re-reads.
+    /// </para>
+    /// <para>
+    /// Precedence is environment variable, then file, then default. The environment
+    /// variables exist so a developer can point the plug-in at a debug build
+    /// without touching the user's saved settings.
+    /// </para>
+    /// </remarks>
+    internal sealed class PluginConfig
+    {
+        /// <summary>Overrides the backend address for one process.</summary>
+        public const string BackendUrlEnvironmentVariable = "LRGENIUS_BACKEND_URL";
+
+        /// <summary>Overrides the helper executable path for one process.</summary>
+        public const string HelperPathEnvironmentVariable = "LRGENIUS_C1_EXE";
+
+        /// <summary>Base URL of the local backend.</summary>
+        public string BackendBaseUrl { get; set; }
+
+        /// <summary>
+        /// Full path to the helper executable, or null to search the usual places.
+        /// </summary>
+        public string HelperExecutablePath { get; set; }
+
+        /// <summary>Settings as shipped.</summary>
+        public static PluginConfig Defaults()
+        {
+            return new PluginConfig
+            {
+                BackendBaseUrl = HandoffClient.DefaultBaseUrl,
+                HelperExecutablePath = null,
+            };
+        }
+
+        /// <summary>
+        /// Reads the settings file, falling back to defaults for anything missing
+        /// or unreadable.
+        /// </summary>
+        /// <remarks>
+        /// Never throws. A corrupt settings file must not stop a photographer from
+        /// running the plug-in; it just means the defaults apply. The corruption is
+        /// reported through <paramref name="report"/> so it is not silent either.
+        /// </remarks>
+        public static PluginConfig Load(RunReport report)
+        {
+            PluginConfig config = Defaults();
+            string path = PluginInfo.ConfigFilePath;
+
+            try
+            {
+                if (File.Exists(path))
+                {
+                    object root = Json.Parse(File.ReadAllText(path, Encoding.UTF8));
+                    string url = Json.GetString(root, "backend_base_url");
+                    if (!string.IsNullOrEmpty(url))
+                    {
+                        config.BackendBaseUrl = url;
+                    }
+
+                    string helper = Json.GetString(root, "helper_executable_path");
+                    if (!string.IsNullOrEmpty(helper))
+                    {
+                        config.HelperExecutablePath = helper;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException
+                                       || ex is UnauthorizedAccessException
+                                       || ex is FormatException)
+            {
+                if (report != null)
+                {
+                    report.AddWarning(
+                        "Your LrGeniusAI plug-in settings could not be read (" + ex.Message
+                        + "), so the built-in defaults were used. Open the plug-in settings and "
+                        + "save them again to repair the file at " + path + ".");
+                }
+            }
+
+            string urlOverride = SafeGetEnvironmentVariable(BackendUrlEnvironmentVariable);
+            if (!string.IsNullOrEmpty(urlOverride))
+            {
+                config.BackendBaseUrl = urlOverride;
+            }
+
+            string helperOverride = SafeGetEnvironmentVariable(HelperPathEnvironmentVariable);
+            if (!string.IsNullOrEmpty(helperOverride))
+            {
+                config.HelperExecutablePath = helperOverride;
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Writes the settings file.
+        /// </summary>
+        /// <returns>Null on success, otherwise an actionable message.</returns>
+        public string Save()
+        {
+            string path = PluginInfo.ConfigFilePath;
+            try
+            {
+                string directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                var sb = new StringBuilder();
+                sb.Append("{")
+                  .Append("\"backend_base_url\":").Append(Json.Quote(BackendBaseUrl)).Append(",")
+                  .Append("\"helper_executable_path\":").Append(Json.Quote(HelperExecutablePath))
+                  .Append("}");
+
+                File.WriteAllText(path, sb.ToString(), new UTF8Encoding(false));
+                return null;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return "Your LrGeniusAI settings could not be saved to " + path + " (" + ex.Message
+                       + "). Check that the folder exists and is writable, then save again.";
+            }
+        }
+
+        private static string SafeGetEnvironmentVariable(string name)
+        {
+            try
+            {
+                return Environment.GetEnvironmentVariable(name);
+            }
+            catch (System.Security.SecurityException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/PluginInfo.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/PluginInfo.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>
+    /// Constants that identify this plug-in. Everything here is a compile-time
+    /// constant on purpose: Capture One asks for the name and identifier while it
+    /// is building a menu, and that path must never touch the network, the disk,
+    /// or any cached state.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Version"/> is duplicated in <c>manifest.xml</c> and in the
+    /// csproj. <c>scripts/package.ps1</c> fails the build when the three drift
+    /// apart, so change all three together.
+    /// </remarks>
+    internal static class PluginInfo
+    {
+        /// <summary>Reverse-DNS plug-in identifier. Also the install folder name.</summary>
+        public const string Identifier = "cloud.machek.lrgeniusai";
+
+        /// <summary>Name shown in Capture One's menus.</summary>
+        public const string DisplayName = "LrGeniusAI";
+
+        /// <summary>Keep in sync with manifest.xml and LrGeniusAI.Plugin.csproj.</summary>
+        public const string Version = "0.1.0";
+
+        /// <summary>Label for the single "Open With" action this plug-in contributes.</summary>
+        public const string AnalyzeActionName = "Analyze with LrGeniusAI";
+
+        /// <summary>Stable action id sent to the backend so it knows what was asked for.</summary>
+        public const string AnalyzeActionId = "analyze";
+
+        /// <summary>Sent as the User-Agent so backend logs can tell hosts apart.</summary>
+        public static readonly string UserAgent = "LrGeniusAI-CaptureOne-Windows/" + Version;
+
+        /// <summary>
+        /// Where per-user settings live. The plug-in object itself holds no state,
+        /// so every run re-reads this file; the settings UI writes it.
+        /// </summary>
+        public static string ConfigFilePath
+        {
+            get
+            {
+                string root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                return System.IO.Path.Combine(
+                    System.IO.Path.Combine(root, "LrGeniusAI"),
+                    "capture-one-plugin.json");
+            }
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/RunReport.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/RunReport.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>
+    /// Collects everything that went wrong, or went less than fully right, during
+    /// one run and renders it into the single string Capture One will show.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists because the plug-in host gives us exactly one message per action
+    /// result. A log line is not a report: if a problem does not end up in the text
+    /// this class produces, the user never learns about it.
+    /// </para>
+    /// <para>
+    /// The rules it implements:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// Warnings accumulate in a list, never in a single field - one slot means the
+    /// second problem erases the first.
+    /// </description></item>
+    /// <item><description>
+    /// A run-wide cause is reported once with a count and a few example file names,
+    /// not once per photo and not silently dropped.
+    /// </description></item>
+    /// <item><description>
+    /// A degraded success is not a success: the caller reports warnings even when
+    /// the run as a whole worked.
+    /// </description></item>
+    /// </list>
+    /// </remarks>
+    internal sealed class RunReport
+    {
+        /// <summary>How many distinct problems or warnings are spelled out.</summary>
+        public const int MaxItemsShown = 5;
+
+        /// <summary>How many example file names accompany a grouped warning.</summary>
+        public const int MaxExamplesPerWarning = 3;
+
+        private static readonly string NL = Environment.NewLine;
+
+        private readonly List<string> _errors = new List<string>();
+        private readonly List<string> _warningOrder = new List<string>();
+        private readonly Dictionary<string, WarningGroup> _warnings =
+            new Dictionary<string, WarningGroup>(StringComparer.Ordinal);
+
+        /// <summary>True when at least one hard failure was recorded.</summary>
+        public bool HasErrors
+        {
+            get { return _errors.Count > 0; }
+        }
+
+        /// <summary>True when at least one degradation was recorded.</summary>
+        public bool HasWarnings
+        {
+            get { return _warningOrder.Count > 0; }
+        }
+
+        /// <summary>
+        /// Records a hard failure. Phrase it as what the user should do, not as
+        /// what the code observed.
+        /// </summary>
+        public void AddError(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+
+            if (!_errors.Contains(message))
+            {
+                _errors.Add(message);
+            }
+        }
+
+        /// <summary>Records a degradation with no particular file attached.</summary>
+        public void AddWarning(string reason)
+        {
+            AddWarning(reason, null);
+        }
+
+        /// <summary>
+        /// Records a degradation caused by one file. Identical reasons are folded
+        /// into a single line carrying a count and up to
+        /// <see cref="MaxExamplesPerWarning"/> example names.
+        /// </summary>
+        public void AddWarning(string reason, string exampleFileName)
+        {
+            if (string.IsNullOrEmpty(reason))
+            {
+                return;
+            }
+
+            WarningGroup group;
+            if (!_warnings.TryGetValue(reason, out group))
+            {
+                group = new WarningGroup(reason);
+                _warnings.Add(reason, group);
+                _warningOrder.Add(reason);
+            }
+
+            group.Add(exampleFileName);
+        }
+
+        /// <summary>
+        /// Renders the message shown in Capture One.
+        /// </summary>
+        /// <param name="headline">One sentence saying how the run ended.</param>
+        /// <param name="footer">
+        /// Optional closing instruction, e.g. how to load the sidecars back in.
+        /// </param>
+        public string Compose(string headline, string footer = null)
+        {
+            var sb = new StringBuilder();
+            sb.Append(headline);
+
+            if (_errors.Count > 0)
+            {
+                sb.Append(NL).Append(NL).Append("What went wrong:");
+                AppendCapped(sb, _errors, _errors.Count, "problem");
+            }
+
+            if (_warningOrder.Count > 0)
+            {
+                var rendered = new List<string>(_warningOrder.Count);
+                foreach (string reason in _warningOrder)
+                {
+                    rendered.Add(_warnings[reason].Render());
+                }
+
+                sb.Append(NL).Append(NL).Append("Worth knowing:");
+                AppendCapped(sb, rendered, rendered.Count, "warning");
+            }
+
+            if (!string.IsNullOrEmpty(footer))
+            {
+                sb.Append(NL).Append(NL).Append(footer);
+            }
+
+            return sb.ToString();
+        }
+
+        private static void AppendCapped(StringBuilder sb, IList<string> items, int total, string noun)
+        {
+            int shown = 0;
+            foreach (string item in items)
+            {
+                if (shown == MaxItemsShown)
+                {
+                    break;
+                }
+
+                sb.Append(NL).Append("  - ").Append(item);
+                shown++;
+            }
+
+            int hidden = total - shown;
+            if (hidden > 0)
+            {
+                sb.Append(NL)
+                  .Append("  - and ")
+                  .Append(hidden.ToString(CultureInfo.InvariantCulture))
+                  .Append(" more ")
+                  .Append(noun)
+                  .Append(hidden == 1 ? "." : "s.");
+            }
+        }
+
+        private sealed class WarningGroup
+        {
+            private readonly string _reason;
+            private readonly List<string> _examples = new List<string>();
+            private int _count;
+
+            public WarningGroup(string reason)
+            {
+                _reason = reason;
+            }
+
+            public void Add(string exampleFileName)
+            {
+                _count++;
+                if (!string.IsNullOrEmpty(exampleFileName) && _examples.Count < MaxExamplesPerWarning)
+                {
+                    _examples.Add(exampleFileName);
+                }
+            }
+
+            public string Render()
+            {
+                if (_examples.Count == 0)
+                {
+                    return _count > 1
+                        ? _reason + " (" + _count.ToString(CultureInfo.InvariantCulture) + " times)"
+                        : _reason;
+                }
+
+                var sb = new StringBuilder(_reason);
+                sb.Append(" (");
+                if (_count > 1)
+                {
+                    sb.Append(_count.ToString(CultureInfo.InvariantCulture)).Append(" files: ");
+                }
+
+                sb.Append(string.Join(", ", _examples.ToArray()));
+                if (_count > _examples.Count)
+                {
+                    sb.Append(", ...");
+                }
+
+                sb.Append(")");
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/SidecarRules.cs
+++ b/capture-one/coplugin-windows/LrGeniusAI.Plugin/Core/SidecarRules.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace LrGeniusAI.CaptureOne.Core
+{
+    /// <summary>
+    /// Everything this plug-in knows about XMP sidecar files.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Windows has no Capture One scripting bridge - no AppleScript equivalent, no
+    /// COM server, no command line. The only way anything computed by LrGeniusAI
+    /// can get back into Capture One on Windows is an XMP sidecar that the user
+    /// then loads. That carries keywords (<c>dc:subject</c>), keyword hierarchy
+    /// (<c>lr:hierarchicalSubject</c>), rating, colour label, title, description and
+    /// the IPTC core fields - and nothing else. Albums, selections and develop
+    /// adjustments cannot travel this way at all.
+    /// </para>
+    /// <para>
+    /// Since the round trip depends on a preference the user has probably never
+    /// touched, every successful run says so explicitly.
+    /// </para>
+    /// </remarks>
+    internal static class SidecarRules
+    {
+        /// <summary>
+        /// Closing instruction appended to every run that wrote, or will write,
+        /// sidecars. Menu names are the English Capture One ones.
+        /// </summary>
+        public const string LoadMetadataInstruction =
+            "Results are written to XMP sidecar files next to your images. Capture One does not "
+            + "pick them up on its own: switch on Edit > Preferences > Image > \"Auto Sync Sidecar XMP\" "
+            + "and set it to \"Load\", or select the images and run Image > \"Load Metadata\" after "
+            + "each run. Keywords, rating, colour tag, title, description and the IPTC fields come "
+            + "back this way; albums and develop adjustments do not.";
+
+        /// <summary>
+        /// The sidecar path for an image, following the Adobe convention Capture
+        /// One expects: the original extension is replaced by <c>.XMP</c> rather
+        /// than appended to it.
+        /// </summary>
+        public static string SidecarPathFor(string imagePath)
+        {
+            if (string.IsNullOrEmpty(imagePath))
+            {
+                return null;
+            }
+
+            string directory = Path.GetDirectoryName(imagePath);
+            string stem = Path.GetFileNameWithoutExtension(imagePath);
+            if (string.IsNullOrEmpty(stem))
+            {
+                return null;
+            }
+
+            return string.IsNullOrEmpty(directory)
+                ? stem + ".XMP"
+                : Path.Combine(directory, stem + ".XMP");
+        }
+
+        /// <summary>
+        /// Finds selections in which several images would share one sidecar file.
+        /// </summary>
+        /// <returns>One ready-to-show message per colliding group; empty when clean.</returns>
+        /// <remarks>
+        /// Because the extension is replaced rather than appended, a RAW+JPEG pair
+        /// shot by the same camera - <c>IMG_0001.CR2</c> and <c>IMG_0001.JPG</c> -
+        /// maps onto the single file <c>IMG_0001.XMP</c>. Whatever is written last
+        /// wins, and the user would silently get one variant's keywords on both.
+        /// Detecting this is cheap and entirely local, so it happens before
+        /// anything is sent anywhere.
+        /// </remarks>
+        public static IList<string> DescribeCollisions(IEnumerable<string> imagePaths)
+        {
+            var groups = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            var order = new List<string>();
+
+            foreach (string path in imagePaths)
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                string directory = Path.GetDirectoryName(path) ?? string.Empty;
+                string stem = Path.GetFileNameWithoutExtension(path) ?? string.Empty;
+
+                // NUL cannot occur in a Windows path, so it is a safe separator
+                // between the two halves of the key.
+                string key = directory + "\0" + stem;
+
+                List<string> bucket;
+                if (!groups.TryGetValue(key, out bucket))
+                {
+                    bucket = new List<string>();
+                    groups.Add(key, bucket);
+                    order.Add(key);
+                }
+
+                bucket.Add(path);
+            }
+
+            var messages = new List<string>();
+            foreach (string key in order)
+            {
+                List<string> bucket = groups[key];
+                if (bucket.Count < 2)
+                {
+                    continue;
+                }
+
+                var names = new List<string>(bucket.Count);
+                foreach (string path in bucket)
+                {
+                    names.Add(Path.GetFileName(path));
+                }
+
+                names.Sort(StringComparer.OrdinalIgnoreCase);
+                string stem = Path.GetFileNameWithoutExtension(bucket[0]);
+
+                messages.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} all map onto the single sidecar file {1}.XMP, so only the last one written "
+                    + "would survive. Take all but one of them out of the selection, or run them in "
+                    + "separate batches.",
+                    string.Join(", ", names.ToArray()),
+                    stem));
+            }
+
+            return messages;
+        }
+    }
+}

--- a/capture-one/scripts-macos/analyze_selection.applescript
+++ b/capture-one/scripts-macos/analyze_selection.applescript
@@ -1,0 +1,240 @@
+-- Analyze Selection with LrGeniusAI
+--
+-- Installed into ~/Library/Scripts/Capture One Scripts/LrGeniusAI/ by
+-- install.sh, where Capture One picks it up and shows it in its Scripts menu.
+--
+-- This script is deliberately thin. It does not read the selection, does not
+-- talk to the backend and does not decide anything: it starts the companion
+-- program (lrgenius-c1) and gets out of the way. Everything else -- reading
+-- the selected variants over AppleScript, indexing, writing results back --
+-- happens in the companion. The only job left here is to start it and to tell
+-- the user, in a dialog, when that did not work.
+--
+-- If you do not know AppleScript: "on run" is what Capture One calls when the
+-- menu item is chosen, "on <name>(...)" declares a function ("handler"),
+-- "do shell script" runs a shell command, and "display dialog" shows a
+-- message box.
+
+-- What to run. Changing these two lines is what makes the three scripts in
+-- this folder different from each other.
+property companionArguments : {"analyze", "--source", "selection"}
+property actionTitle : "Analyze Selection"
+
+on run
+	launchCompanion(companionArguments, actionTitle)
+end run
+
+
+-- ===================================================================
+-- Shared launcher block.
+--
+-- Every script in this folder carries its own copy on purpose: a script in the
+-- Scripts menu has to keep working when it is the only file someone copied
+-- over, so it may not depend on a script library being installed as well.
+-- When you change one copy, change all three.
+-- ===================================================================
+
+-- Starts the companion, or explains to the user why it could not start.
+on launchCompanion(companionArguments, actionTitle)
+	try
+		do shell script shellProgramFor(companionArguments)
+	on error errorText number errorNumber
+		reportProblem(errorNumber, errorText, actionTitle)
+	end try
+end launchCompanion
+
+
+-- Builds the small shell program that finds the companion binary, starts it
+-- detached, and reports back through its exit status:
+--
+--   0   the companion is running (or finished successfully within a moment)
+--   65  LRGENIUS_C1_BIN is set but does not point at an executable file
+--   66  no companion binary on any of the known paths
+--   70  the companion started but exited immediately -- stderr carries the
+--       exit status and the tail of its log
+--
+-- Detaching matters: "do shell script" waits for the command to finish, and
+-- Capture One waits for the script, so a companion started in the foreground
+-- would freeze the whole application for as long as the analysis runs.
+-- "nohup ... &" plus redirected input and output is what lets the shell return
+-- straight away while the companion keeps running.
+on shellProgramFor(companionArguments)
+	-- Turn {"analyze", "--source", "selection"} into one shell-safe string:
+	--  'analyze' '--source' 'selection'
+	set argumentText to ""
+	repeat with anArgument in companionArguments
+		set argumentText to argumentText & " " & quoted form of (anArgument as text)
+	end repeat
+
+	set programLines to {}
+
+	-- Fail on unset variables rather than on an empty path silently.
+	set end of programLines to "set -u"
+
+	-- Where the companion's start-up output goes. Same place the rest of
+	-- LrGeniusAI logs on macOS. /dev/null if that is somehow not writable --
+	-- losing the log is better than failing to start.
+	set end of programLines to "lrg_log_dir=\"$HOME/Library/Logs/LrGeniusAI\""
+	set end of programLines to "mkdir -p \"$lrg_log_dir\" 2>/dev/null || true"
+	set end of programLines to "lrg_log=\"$lrg_log_dir/lrgenius-c1-launch.log\""
+	set end of programLines to "[ -w \"$lrg_log_dir\" ] || lrg_log=/dev/null"
+
+	-- Keep the log from growing forever: one rotation at 1 MiB.
+	set end of programLines to "if [ -f \"$lrg_log\" ] && [ \"$(stat -f%z \"$lrg_log\" 2>/dev/null || echo 0)\" -gt 1048576 ]; then"
+	set end of programLines to "  mv -f \"$lrg_log\" \"$lrg_log.1\" 2>/dev/null || true"
+	set end of programLines to "fi"
+
+	-- Find the companion. LRGENIUS_C1_BIN wins when it is set, so a developer
+	-- can point Capture One at a local build; it is an error, not a fallback,
+	-- when it is set to something unusable, because silently running a
+	-- different binary than the one asked for is worse than refusing.
+	set end of programLines to "lrg_bin=\"\""
+	set end of programLines to "if [ -n \"${LRGENIUS_C1_BIN:-}\" ]; then"
+	set end of programLines to "  if [ -f \"$LRGENIUS_C1_BIN\" ] && [ -x \"$LRGENIUS_C1_BIN\" ]; then"
+	set end of programLines to "    lrg_bin=\"$LRGENIUS_C1_BIN\""
+	set end of programLines to "  else"
+	set end of programLines to "    echo \"LRGENIUS_C1_BIN is set to:\" >&2"
+	set end of programLines to "    echo \"$LRGENIUS_C1_BIN\" >&2"
+	set end of programLines to "    echo \"There is no executable file at that path.\" >&2"
+	set end of programLines to "    exit 65"
+	set end of programLines to "  fi"
+	set end of programLines to "fi"
+	set end of programLines to "if [ -z \"$lrg_bin\" ]; then"
+	set end of programLines to "  for lrg_candidate in \\"
+	set end of programLines to "    \"/Applications/LrGeniusAI/Server/lrgenius-c1\" \\"
+	set end of programLines to "    \"$HOME/Applications/LrGeniusAI/lrgenius-c1\" \\"
+	set end of programLines to "    \"/usr/local/bin/lrgenius-c1\" \\"
+	set end of programLines to "    \"/opt/homebrew/bin/lrgenius-c1\""
+	set end of programLines to "  do"
+	set end of programLines to "    if [ -f \"$lrg_candidate\" ] && [ -x \"$lrg_candidate\" ]; then"
+	set end of programLines to "      lrg_bin=\"$lrg_candidate\""
+	set end of programLines to "      break"
+	set end of programLines to "    fi"
+	set end of programLines to "  done"
+	set end of programLines to "fi"
+	set end of programLines to "if [ -z \"$lrg_bin\" ]; then"
+	set end of programLines to "  echo \"No lrgenius-c1 on any known path.\" >&2"
+	set end of programLines to "  exit 66"
+	set end of programLines to "fi"
+
+	-- Start it, detached, with a dated header in the log so an old crash is
+	-- not mistaken for the current one.
+	set end of programLines to "{"
+	set end of programLines to "  echo \"\""
+	set end of programLines to "  echo \"=== $(date '+%Y-%m-%d %H:%M:%S') launching: $lrg_bin" & argumentText & "\""
+	set end of programLines to "} >>\"$lrg_log\" 2>/dev/null || true"
+	set end of programLines to "nohup \"$lrg_bin\"" & argumentText & " >>\"$lrg_log\" 2>&1 </dev/null &"
+	set end of programLines to "lrg_pid=$!"
+
+	-- Backgrounding always \"succeeds\", so the exit status of the launch says
+	-- nothing on its own. Wait a moment and look again: a companion that was
+	-- killed by Gatekeeper, is missing a library or choked on its arguments is
+	-- already gone by now, and that is exactly the failure a user would
+	-- otherwise experience as the menu item doing nothing at all.
+	set end of programLines to "sleep 0.4"
+
+	-- A process that exited but has not been reaped yet still answers to
+	-- kill -0, so ask ps for the state instead: empty means gone, Z means
+	-- zombie, anything else means it is running.
+	set end of programLines to "lrg_state=\"$(ps -o state= -p \"$lrg_pid\" 2>/dev/null | tr -d '[:space:]')\""
+	set end of programLines to "case \"$lrg_state\" in"
+	set end of programLines to "  \"\" | Z*) ;;"
+	set end of programLines to "  *) exit 0 ;;"
+	set end of programLines to "esac"
+
+	-- It is gone. Collect its exit status; 0 just means it was a short job
+	-- that finished before we looked, which is a perfectly good outcome.
+	set end of programLines to "wait \"$lrg_pid\" 2>/dev/null"
+	set end of programLines to "lrg_rc=$?"
+	set end of programLines to "if [ \"$lrg_rc\" -eq 0 ]; then"
+	set end of programLines to "  exit 0"
+	set end of programLines to "fi"
+	set end of programLines to "{"
+	set end of programLines to "  echo \"The companion exited immediately with status $lrg_rc.\""
+	set end of programLines to "  echo \"\""
+	set end of programLines to "  echo \"Program: $lrg_bin\""
+	set end of programLines to "  echo \"Log: $lrg_log\""
+	set end of programLines to "  echo \"\""
+	set end of programLines to "  echo \"Last lines of the log:\""
+	set end of programLines to "  tail -n 10 \"$lrg_log\" 2>/dev/null || true"
+	set end of programLines to "} >&2"
+	set end of programLines to "exit 70"
+
+	set programText to ""
+	repeat with aLine in programLines
+		set programText to programText & (aLine as text) & linefeed
+	end repeat
+	return programText
+end shellProgramFor
+
+
+-- Turns an exit status into something the user can act on. Every branch ends
+-- in a dialog: a menu item that quietly does nothing is the one outcome this
+-- whole handler exists to prevent.
+on reportProblem(errorNumber, errorText, actionTitle)
+	if errorNumber is 66 then
+		set messageText to "LrGeniusAI is not installed, so \"" & actionTitle & "\" cannot run." & return & return & ¬
+			"Install LrGeniusAI and choose Scripts > Update Scripts Menu in Capture One, then try again." & return & return & ¬
+			"The companion program lrgenius-c1 was looked for at:" & return & ¬
+			"    /Applications/LrGeniusAI/Server/lrgenius-c1" & return & ¬
+			"    ~/Applications/LrGeniusAI/lrgenius-c1" & return & ¬
+			"    /usr/local/bin/lrgenius-c1" & return & ¬
+			"    /opt/homebrew/bin/lrgenius-c1" & return & return & ¬
+			"If it is installed elsewhere, quit Capture One and start it from Terminal with LRGENIUS_C1_BIN set to the full path of lrgenius-c1."
+		showMessage(messageText, false)
+
+	else if errorNumber is 65 then
+		set messageText to "LrGeniusAI cannot run \"" & actionTitle & "\": the LRGENIUS_C1_BIN override does not point at a program." & return & return & ¬
+			errorText & return & return & ¬
+			"Correct LRGENIUS_C1_BIN and restart Capture One, or unset it to use the installed copy of lrgenius-c1."
+		showMessage(messageText, false)
+
+	else if errorNumber is 70 then
+		set messageText to "LrGeniusAI started and stopped again right away, so \"" & actionTitle & "\" did not run." & return & return & ¬
+			errorText & return & return & ¬
+			"Try running the same command in Terminal to see the full error, then report it with the log if it is not obvious."
+		showMessage(messageText, true)
+
+	else
+		set messageText to "LrGeniusAI could not start \"" & actionTitle & "\"." & return & return & ¬
+			errorText & " (error " & (errorNumber as text) & ")" & return & return & ¬
+			"Check that LrGeniusAI is installed, then try again."
+		showMessage(messageText, false)
+	end if
+end reportProblem
+
+
+-- Shows the message. Falls back to System Events if the host application
+-- refuses the dialog, so the report cannot end up nowhere.
+on showMessage(messageText, offerLog)
+	if offerLog then
+		set buttonList to {"Reveal Log", "OK"}
+	else
+		set buttonList to {"OK"}
+	end if
+	set chosenButton to "OK"
+	try
+		set chosenButton to button returned of (display dialog messageText with title "LrGeniusAI" buttons buttonList default button "OK" with icon caution)
+	on error
+		try
+			tell application "System Events"
+				activate
+				set chosenButton to button returned of (display dialog messageText with title "LrGeniusAI" buttons buttonList default button "OK" with icon caution)
+			end tell
+		on error
+			return
+		end try
+	end try
+	if chosenButton is "Reveal Log" then revealLog()
+end showMessage
+
+
+-- Opens the log in the Finder, or its folder when the file is not there yet.
+on revealLog()
+	try
+		do shell script "lrg_log=\"$HOME/Library/Logs/LrGeniusAI/lrgenius-c1-launch.log\"; if [ -f \"$lrg_log\" ]; then open -R \"$lrg_log\"; else open \"$HOME/Library/Logs\"; fi"
+	on error errorText
+		showMessage("LrGeniusAI could not open the log folder." & return & return & errorText & return & return & ¬
+			"Open it yourself at ~/Library/Logs/LrGeniusAI.", false)
+	end try
+end revealLog

--- a/docs/wiki/Dev-Capture-One-Port-Plan.md
+++ b/docs/wiki/Dev-Capture-One-Port-Plan.md
@@ -1,0 +1,319 @@
+# Capture One Port — Findings and Plan
+
+> **Status: not being pursued. Decision taken 2026-09-10.** The page is kept
+> because the expensive part of this work was finding out what Capture One can
+> and cannot do, and that answer does not change often. If the question comes
+> back, start here rather than re-running the investigation.
+>
+> A partial implementation snapshot was kept as well, under
+> [`capture-one/`](../../capture-one/README.md) — most usefully a **reconstructed
+> SDK header** recovered from Objective-C runtime metadata, since the official
+> SDK is not publicly available. See that README for what exists and what does
+> not; nothing in it has ever run against Capture One.
+
+## Why this exists
+
+The question was: build a Capture One plugin for Windows and macOS equivalent
+to the Lightroom plugin, reusing the existing Rust backend.
+
+The short answer is that Capture One has no mechanism equivalent to a Lightroom
+plugin, and that macOS and Capture One on Windows are so far apart in what they
+allow that they would have been two different products sharing a backend.
+
+## Key finding
+
+**The official Capture One Plugin SDK cannot do the one thing the product
+needs.** It is a file-in/file-out interface: a plugin receives file paths, does
+something, and reports a status. It has no access to the catalog, to metadata,
+to keywords, to the selection, or to a window of its own. Writing an AI-generated
+keyword back onto a photo — the core of `Analyze & Index` — is outside its
+contract entirely.
+
+What replaces "plugin" is **"companion process with its own UI"**, and the
+control direction inverts: today Lightroom calls the backend; here the backend
+would hold the UI and call the host.
+
+The second finding is that **macOS and Windows are not the same product**:
+
+| | macOS | Windows |
+|---|---|---|
+| Automation interface | AppleScript/JXA, deep and actively maintained | none — no scripting, no COM, no CLI |
+| Write keywords, rating, IPTC | native | XMP sidecar + a user-triggered sync step |
+| Develop settings | native, ~90 scriptable parameters | `.costyle` file the user applies by hand |
+| Albums, selection, variants | native | not reachable |
+| Menu entry without the SDK | yes, via the Scripts menu | no |
+
+## Verified first-hand
+
+Capture One 16.8.5.30 ("Capture One Studio (Trial)") is installed on the
+development Mac and was running during this investigation. Everything in this
+section was checked against the installed application, not taken from
+documentation.
+
+| Fact | How it was verified |
+|---|---|
+| Version 16.8.5.30, bundle id `com.captureone.captureone16` | `Info.plist` |
+| AppleScript is enabled and answers | `osascript -e 'tell application "Capture One" to return {app version, name of current document, kind of current document, count of (get selected variants)}'` → `Capture One Studio (Trial) 16.8.5, Capture One Catalog, catalog, 0` |
+| Scripting dictionary is large: 2212 lines, 2 suites, ~48 classes | `Contents/Resources/CaptureOne.sdef`, parsed with ElementTree |
+| `.coplugin` is a **ZIP** containing a macOS bundle — `Contents/{Info.plist, MacOS/<exe>, Resources/, _CodeSignature/}` | unpacked the installed `COHeliconFocusPlugin.coplugin` |
+| Plugin binaries link `@rpath/Frameworks/CaptureOnePlugins.framework` and declare `NSPrincipalClass` | `otool -L` + `plutil -p` on that plugin |
+| Plugins are hosted **out-of-process over XPC** | `COPluginHostApple.xpc` / `COPluginHostIntel.xpc` in the app bundle |
+| A 2022-era SDK 1.0 plugin still loads under 16.8.5 | file date on the installed Helicon plugin |
+| The Scripts menu folder exists: `~/Library/Scripts/Capture One Scripts/` with `Background Scripts/` and `Disabled Scripts/` | filesystem |
+
+### What the plugin API actually exposes
+
+Extracted from the symbols in `CaptureOnePlugins.framework`:
+
+```
+COPluginBase, COPluginAction, COPluginTask, COFileHandlingPluginTask
+COPluginActionResult
+  COPluginActionOpenWithResult      (+ ...Status)
+  COPluginActionPublishResult       (+ ...URL, ...Message)
+  COPluginActionImageResult         (+ ...Images)
+  COPluginActionColorProfilingResult(+ ...ColorProfiles)
+COPluginTaskExecutingDocumentType   (Catalog | Session)
+COSupportedFileFormats, COTaskDestinationFolder, COTaskTemporaryFolder
+Settings UI, declarative only:
+  COSettingsBase, COSettingsElement, COSettingsElementsGroup, COSettingsItemsGroup,
+  COSettingsBoolItem, COSettingsButtonItem, COSettingsFileItem, COSettingsLabelItem,
+  COSettingsListItem, COSettingsListOption, COSettingsMultipleListItem, COSettingsTextItem
+Keys: COPluginActionDisplayNameKey, COPluginActionIdentifierKey,
+      COFileHandlingPluginTaskFilesKey
+```
+
+There is no keyword, metadata, catalog, selection, or window API. The settings
+form has no number field, no slider, no image, no table and no web view.
+
+### What AppleScript exposes (macOS only)
+
+This is the part that makes macOS viable. From the `.sdef`:
+
+- `application` — `selected variants`, `primary variant`, `current document`
+  (**PRO only**), `progress total units` / `progress completed units` /
+  `progress text` (drives Capture One's own progress window), `available styles`,
+  `edit all selected variants`, and event hooks including
+  `selection changed script` and `processing done script`
+- `variant` — writable `rating`, `color tag`, `pick`, `adjustments`, `styles`,
+  `crop`, and the full IPTC set (`status title`, `content description`,
+  `content headline`, `image city/state/country`, …); `keyword` and `layer` as
+  elements. Note `selected` is **read-only** — but see `select` below.
+- `image` — `path`, `dimensions`, `EXIF capture date` (writable), camera model,
+  ISO, shutter speed, aperture, focal length
+- `adjustment settings` — **90 properties**: `exposure`, `contrast`,
+  `saturation`, `temperature`, `tint`, `clarity amount`, `dehaze amount`,
+  `highlight recovery`, `shadow recovery`, `white recovery`, `black recovery`,
+  `vignetting amount`, `sharpening amount`, `noise reduction luminance`,
+  `black and white`, `rgb curve`, `color balance *`, …
+- commands — `apply keyword`, `sync metadata`, `reload metadata`, `apply style`,
+  `apply adjustments` / `copy adjustments`, **`select` / `deselect`** (so the
+  selection *can* be set, just not via the `selected` property), `make` (albums),
+  `add inside`, `process` (**PRO only**), `create people mask`, `autoadjust`,
+  `clone variant`
+
+Roughly: on macOS, AppleScript covers nearly the whole Lightroom feature surface.
+
+## Feasibility matrix
+
+**N** = native · **W** = workaround, with the named cost · **X** = impossible
+
+| Capability the LR plugin relies on | C1 macOS | C1 Windows |
+|---|---|---|
+| Register a menu entry | **N** — Scripts menu (no SDK needed, supports keyboard shortcuts) *or* `.coplugin` | **W** — `.coplugin` only |
+| Read the current selection | **N** | **W** — only the paths handed over when the plugin action fires |
+| Read the active collection | **N** | **X** |
+| Enumerate the whole catalog | **W** — AppleScript (slow) or read-only SQLite | **W** — read-only SQLite, or the user picks a folder |
+| Read EXIF | **N** — or better, the backend decodes the original itself (`lrg-imaging`/`rawler`) | **N** — same |
+| Write title / caption | **N** | **W** — XMP + user sync step |
+| Assign keywords | **N** | **W** — XMP `dc:subject` + sync |
+| Hierarchical keywords | **W** — unverified; C1 forbids `,` and `\|` in keyword names, so LR's `A\|B\|C` convention is out | **W** — `lr:hierarchicalSubject` in the sidecar |
+| Rating / color tag | **N** | **W** — XMP `xmp:Rating` / `xmp:Label` |
+| Custom per-photo fields (the 40 in `MetadataProvider.lua`) | **X** | **X** |
+| Create and fill an album | **N** | **X** |
+| Set the selection / jump the view | **N** | **X** |
+| Read develop settings | **N** | **W** — parse `.cos` XML or the DB |
+| Write develop settings | **N** | **W** — drop a `.costyle`, user applies it |
+| AI masks | **W** — `create people mask` is real; subject/background unverified | **X** |
+| Virtual copies | **N** — `clone variant` | **X** |
+| Own dialog UI | **X** | **X** |
+| Progress + cancel | **W** — can drive C1's own progress window | **W** — only while the plugin action runs |
+| Undo | **X** | **X** |
+
+## Mechanism ranking
+
+Ordered by how far each one carries, not by elegance.
+
+1. **Companion process with a browser UI (the Rust server itself)** — carries all
+   analysis, all UI, all persistence, all provider/model management. Roughly
+   80–90 % of the product, identical on both platforms. The pattern already
+   exists and ships: `/v1/ui/people` + `ui_bridge.rs`.
+2. **AppleScript/JXA via `osascript`** (macOS) — the entire catalog write-back.
+   Caveats that matter: it needs TCC Apple-Events permission, which in practice
+   forces the companion to be a signed `.app` rather than a bare CLI binary;
+   `current document` and `process` are **PRO-gated**; Apple Events are expensive
+   per call, so it must be one call per *batch*, never per photo; Capture One
+   must be running with a document open.
+3. **XMP sidecar + Capture One sync** — the only vendor-sanctioned metadata
+   inbound path, and on Windows the only one at all. Carries keywords, rating,
+   color label, IPTC core. Three sharp edges: Adobe naming (`IMG_0001.XMP`
+   without the original extension) means a RAW+JPEG pair **shares one sidecar**
+   and would silently merge; the "Auto Sync Sidecar XMP" preference defaults to
+   `None`, so nothing happens until the user changes it to `Load`; `Full Sync`
+   makes Capture One write the same file, so concurrent writes lose.
+4. **The official `.coplugin` SDK** — carries exactly one thing: the entry point.
+   Still unavoidable on Windows. It is effectively frozen: last release 1.0.1 on
+   2022-03-14, developer forum inactive since 09/2024, **no public repository and
+   no online documentation** — the download is behind a developer-portal signup.
+   That signup is the single hard blocker for both `.coplugin` targets.
+5. **Reading the catalog/session SQLite** — the full DDL (23 tables) ships as
+   plain-text migration scripts inside `DataCore.framework`, so no reverse
+   engineering is needed. But the schema migrates on nearly every point release,
+   and the widely cited OSS examples describe the retired `ZSTACK` mechanism and
+   no longer work on 16.8.
+6. **Writing `.costyle`** — officially supported (drop the file in the styles
+   folder, no import needed), trivial XML. On Windows the only route to AI Edit.
+7. **Writing `.cos` sidecars** (sessions only) — the documented carrier for
+   adjustments *and* metadata, but the folder name changes per release
+   (`Settings1680` on 16.8.5, verified locally) and each variant has three layer
+   rows where writing the wrong one gets overwritten on reload. Not a default path.
+8. **Watch folder / export recipe hook** — a trigger only, no way back into the
+   catalog. Of little use since we want to analyse originals, not derivatives.
+9. **Reading the preview cache** (`.cop`/JPEG-XL, `.cot`/JPEG) — undocumented
+   internal format. An optimisation at best; `lrg-imaging` already decodes RAW.
+10. **UI automation (AutoHotkey and similar)** — carries nothing reliable.
+    Explicitly: do not build this.
+
+Not available: Capture One "Actions" (16.8) are cloud connectors, centrally
+administered, Studio-for-Teams/Enterprise only, with no public connector API.
+
+## The architecture that was going to be built
+
+```
+User selects in Capture One  →  right-click → Edit With → LrGeniusAI
+   → .coplugin (Swift / C#) collects the file paths
+   → POST 127.0.0.1:19819/v1/host/handoff  {paths, document_type, host}
+   → companion window comes forward, user picks the tasks
+   → backend indexes via /v1/index/photos/by-path (reads the originals itself)
+   → write-back:
+        macOS : osascript -l JavaScript bridge.js   (one call per batch)
+        Win   : <basename>.XMP  →  user runs "Load Metadata"
+```
+
+Planned artefacts — `✓` exists in `capture-one/`, `✗` never written:
+
+```
+capture-one/
+  coplugin-macos/Headers/      ✓ reconstructed SDK interface (see below)
+  coplugin-macos/Sources/      ✓ Swift shim + Info.plist + build/notarize scripts
+  coplugin-windows/…/Core/     ~ eight support classes only; no entry class,
+                                 no .csproj, no manifest, no packaging
+  scripts-macos/               ~ one of three entry points, no installer
+  bridge/c1_bridge.js          ✗ JXA bridge — the piece that would have done all
+                                 the real catalog work on macOS
+  cli/                         ✗ lrgenius-c1: CatalogHost trait, OsaHost, XmpHost,
+                                 XMP sidecar writer
+```
+
+### The reconstructed SDK header
+
+Worth knowing about even if Capture One never comes back: because the official
+SDK is not publicly downloadable, `coplugin-macos/Headers/CaptureOnePlugins.h`
+was rebuilt from Objective-C runtime metadata in two binaries already on the
+machine — the shipped `CaptureOnePlugins.framework`, and an installed
+third-party plugin. The second one matters: ObjC protocols are emitted into
+whichever binary *uses* them, so a real plugin's binary still carries the full
+text of `COOpenWithPlugin`, `COEditingPlugin`, `COSettings`, `COFileHandling`,
+`COVariantProcessing` and `COActionSettings`, including method type encodings.
+Selector names and encodings are therefore exact; enum names and values are not
+recoverable from a binary and are marked `SDK-UNVERIFIED`.
+
+The framework binary itself is Phase One's property and is **gitignored** — it is
+staged into `build/` from the locally installed app at build time only.
+
+Backend work it would have required (none of it done):
+
+1. **Host-neutral photo identity.** Today's `meta1:` id is an MD5 over eleven
+   values, four of which are *formatted Lightroom display strings*
+   (`"1/125 s"`, `"f/2.8"`, `"70 mm"`, `"ISO 400"`). No other host reproduces
+   those byte-for-byte. The `md5p:` fallback is genuinely file-based but includes
+   `mtime`, so it does not survive a backup/restore. Proposed replacement:
+   `file1:` = MD5 over `<size>:<first 4 MiB>:<last 4 MiB>`, no mtime.
+2. **Separate the training corpus per host.** `POST /v1/edit/training` expects
+   Lightroom SDK keys and crosswalks them through `LR_TO_CANONICAL` in
+   `lrg-analysis/src/training.rs`. Capture One's controls are named differently
+   *and scale differently* — mixing them would corrupt the existing style profile.
+3. **Edit-recipe scale and prompt profile.** `temperature` is Kelvin for RAW and
+   −100..100 otherwise (a Lightroom convention); `prompts.rs` says "senior
+   Lightroom Classic retoucher" verbatim and the schema is `lightroom_edit_recipe`.
+4. **Generalise `/update/apply`**, which today patches `.lua` files into the
+   `.lrdevplugin` folder via the `plugin_files` manifest key.
+5. **`GET /v1/host/capabilities`**, so the UI can explain what a host cannot do
+   instead of showing dead buttons.
+6. **Decouple the lifecycle** — PID/OK files currently land next to `db_path` in
+   the Lightroom catalog folder.
+7. **`client_id` for job and action polling.** Both `GET /v1/jobs/{id}` and
+   `GET /v1/ui/actions` are *destructive* reads: a finished job is handed out
+   exactly once, and the actions queue is drained. Two clients polling in
+   parallel would steal each other's results. Invisible today because there is
+   only one client.
+
+Untouched: search, similarity, culling, faces, keyword clustering, jobs, model
+assets, LLM providers, species links, DB bind/stats/backup, health/logs — all
+already host-agnostic. `POST /v1/index/photos/by-path` would in fact have become
+the *preferred* path, since the backend decodes originals itself and needs no
+export renderer in the host at all.
+
+## Decisions recorded
+
+Taken 2026-09-10, in case this is revisited:
+
+- **Windows scope:** reduced and honestly described. No writing into the Capture
+  One SQLite database — schema migrates per point release, no undo, real
+  corruption risk, permanent maintenance.
+- **Index:** separate from Lightroom for now. Capture One would get its own store
+  with a host-neutral `file1:` id. No rebuild of the working Lightroom path, no
+  alias migration. Cost: a user switching from Lightroom re-indexes once.
+- **Workflow priority:** catalogs before sessions.
+
+## What would never have worked
+
+On both platforms: own dialogs inside Capture One; the ~40 custom per-photo
+metadata fields; alt text (Capture One has no such field); clickable
+iNaturalist/Wikipedia links on the photo; undo for our changes; a hook that runs
+on import; persisting plugin settings in Capture One (the vendor explicitly does
+not store them); Lightroom-style `A|B|C` hierarchical keywords.
+
+Additionally on Windows: albums as a result (Search Results, Picks, People,
+Duplicates); setting the selection; applying develop settings automatically;
+masks; virtual copies; "analyse the whole catalog"; metadata appearing without a
+manual sync step.
+
+Additionally on macOS: everything is Pro-gated (`current document` and `process`
+are PRO only, so Essentials is largely out); Capture One must be running with a
+document open; the user must grant Apple Events permission once, and refusing it
+falls the write-back path back to XMP.
+
+## Open verifications, if this is revisited
+
+Points 1–4 cost under two hours on a Mac with a populated catalog.
+
+| # | Question | How | What depends on it |
+|---|---|---|---|
+| 1 | Can AppleScript create **hierarchical** keywords? | `keyword` has a `parent` property in the sdef — read an existing hierarchy back, then try to create one. `,` and `\|` are forbidden in names. | Whether the core keyword path works natively on macOS or has to go through XMP there too |
+| 2 | Does `make new layer … {kind:subject mask}` work? | Run it on an open image, check the Layers panel | Whether AI Edit gets masks on macOS |
+| 3 | How fast is a JXA batch over 1000 variants? | Script that sets 1000 ratings, measure | Batch size, or whether write-back needs chunking |
+| 4 | Does the developer portal still deliver a working SDK 1.0.1 for **both** platforms? | Sign up at captureone.com developer portal | **The single hard blocker for Windows.** Vendoring `PhaseOne.Plugin.dll` from third-party repos is not licensable |
+| 5 | Does XMP sidecar sync work equivalently in **sessions**? | Test session, hand-write a sidecar, "Load Metadata" | Whether the Windows path holds for session users |
+| 6 | How does a lower edition behave? | Call `current document` and `process` on Essentials | How much product survives on Essentials |
+| 7 | Is Apple Events access granted cleanly to a LaunchAgent-started `.app`? | Prototype, start via LaunchAgent, run `osascript` | Whether the companion must stay an `.app` |
+| 8 | The whole Windows path | Reproduce on a real Windows install | **Every Windows statement on this page is derived, not reproduced** |
+
+## Verification status of this page
+
+Everything under "Verified first-hand" was checked against the running
+application on 2026-09-10. The AppleScript capability list is read from the
+shipped `.sdef` — write operations were **not** executed, because the open
+catalog was empty (0 images, 0 variants, 5 collections). All Windows statements
+come from documentation, the two public Windows plugin repositories
+(PanoCapture, PostCapture) and the `PhaseOne.Plugin.xml` shipped with them; they
+are internally consistent but were not reproduced on a Windows machine.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -46,6 +46,7 @@ Welcome to the project wiki.
 - [Server Guide](Dev-Server-Guide) — backend architecture, database backup, lifecycle
 - [Dev: Feature Priority Decision](Dev-Feature-Priority-Decision)
 - [Dev: Image Culling Implementation Plan](Dev-Image-Culling-Implementation-Plan)
+- [Dev: Capture One Port — Findings and Plan](Dev-Capture-One-Port-Plan) — what Capture One can and cannot do; investigated 2026-09-10, not pursued
 
 ### Auto-generated from README files
 


### PR DESCRIPTION
## What this is

An investigation into porting the plugin to Capture One (Windows + macOS), plus the partial code it produced. **Capture One is not being pursued** — this lands as a record so the research does not have to be redone.

## The finding

Capture One has no equivalent of a Lightroom plugin. Its SDK is a file-in/file-out interface: a plugin receives file paths and returns a status. There is **no catalog, metadata, keyword, selection or window API** — so writing an AI-generated keyword back onto a photo, the core of `Analyze & Index`, is outside its contract entirely. The SDK is also effectively frozen: last release 1.0.1 in March 2022, no public repository, download behind a developer-portal signup.

macOS and Windows would have been two different products sharing a backend:

| | macOS | Windows |
|---|---|---|
| Automation | AppleScript/JXA — 2212-line dictionary, 90 develop parameters, keywords, rating, IPTC, albums, selection | none |
| Write-back | native | XMP sidecar + a user-triggered sync step |
| Develop settings | native | `.costyle` the user applies by hand |
| Albums, selection | native | not reachable |

## Two things worth remembering regardless of Capture One

Both surfaced while checking whether a second client was possible, and both are latent in the current code:

- **`photo_id` is not host-portable.** `Util.computeStableMetadataPhotoId` hashes eleven values, four of which are *formatted Lightroom display strings* (`"1/125 s"`, `"f/2.8"`, `"70 mm"`, `"ISO 400"`). No other host reproduces those byte-for-byte. The `md5p:` fallback is genuinely file-based but includes `mtime`, so it does not survive a backup/restore.
- **`GET /v1/jobs/{id}` and `GET /v1/ui/actions` are destructive reads** — a finished job is handed out exactly once, the actions queue is drained. Invisible today because there is exactly one client; two clients polling in parallel would steal each other's results.

## What is in the code

Partial — the run was stopped part-way. The JXA bridge and the companion CLI that would have done the actual work were never written; the Windows side has only support classes.

The one artefact worth keeping is **`capture-one/coplugin-macos/Headers/CaptureOnePlugins.h`**: a reconstructed SDK interface, since the official one is not publicly available. It was recovered from Objective-C runtime metadata in the shipped `CaptureOnePlugins.framework` *and* in an installed third-party plugin — ObjC protocols are emitted into whichever binary uses them, so a real plugin still carries the full text of `COOpenWithPlugin`, `COEditingPlugin`, `COSettings`, `COFileHandling`, `COVariantProcessing` and `COActionSettings`, with method type encodings. Selectors and encodings are exact; enum names and values leave no trace in a binary and are marked `SDK-UNVERIFIED`.

## Verification status

Capture One 16.8.5.30 was installed and running; everything under "Verified first-hand" in the wiki page was checked against it. **No write path was ever executed** — the open catalog was empty. All Windows statements are derived from documentation and two public plugin repositories, never reproduced on Windows.

## Note on `build/` and `dist/`

Gitignored, partly for legal reasons: `build.sh` stages Phase One's own `CaptureOnePlugins.framework` out of the locally installed app so the compiler has something to link against. That binary must not be committed or redistributed. The reconstructed header is our own work; the framework binary is not. Verified that nothing binary is in this diff.

## Docs

- `docs/wiki/Dev-Capture-One-Port-Plan.md` — findings, feasibility matrix, mechanism ranking, the architecture this was heading towards, the seven backend changes it would have needed, and the open verifications
- `capture-one/README.md` — what exists on disk and what does not
- Linked from `Home.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KSd9PoqtZzTu5FkMDEKrn